### PR TITLE
fix(chat input): regenerate replaced with submit button when new text typed

### DIFF
--- a/app/components/ChatInput.client.vue
+++ b/app/components/ChatInput.client.vue
@@ -146,7 +146,7 @@
                 @click="stop"
               />
               <UiButton
-                v-show="displayRegenerate"
+                v-show="canShowRegenerate"
                 mode="accent"
                 soft
                 circle
@@ -157,7 +157,7 @@
                 @click="regenerate"
               />
               <UiButton
-                v-show="!displayStop && !displayRegenerate"
+                v-show="!displayStop && !canShowRegenerate"
                 mode="accent"
                 circle
                 :disabled="!hasMessage"
@@ -292,6 +292,10 @@ const { textarea, input } = useTextareaAutosize({
 
 const hasMessage = computed<boolean>(() => {
   return !!input.value?.trim().length
+})
+
+const canShowRegenerate = computed<boolean>(() => {
+  return !!props.displayRegenerate && !hasMessage.value
 })
 
 const isWebSearchEnabled = computed<boolean>(() => {

--- a/app/composables/chat.ts
+++ b/app/composables/chat.ts
@@ -138,6 +138,8 @@ export function useChat(chat: MaybeRefOrGetter<Chat>) {
   const nuxtApp = useNuxtApp()
 
   async function submit() {
+    isStopped.value = false
+
     const parts: any[] = []
 
     if (input.value.trim()) {


### PR DESCRIPTION
## Summary

Fixes chat input action state so Regenerate does not remain visible when the user starts a new message after stopping a response.

## Problem

Repro:

1. Submit a query.
2. Click Stop while generation is in progress.
3. Start typing a new message.
4. Regenerate is still shown, but expected action is Send.

## Root Cause

- isStopped was not reset when starting a fresh submit flow.
- Regenerate visibility did not account for active draft text.

## Changes

- app/composables/chat.ts
  - Reset isStopped at the start of submit() so a new request is treated as a fresh generation cycle.
- app/components/ChatInput.client.vue
  - Added canShowRegenerate computed:
      - show regenerate only when displayRegenerate is true and input is empty.
  - Updated button visibility logic:
      - Regenerate: v-show="canShowRegenerate"
      - Send: v-show="!displayStop && !canShowRegenerate"

## Expected Behavior After Fix

1. After Stop with empty input: Regenerate is shown.
2. After Stop and user types new text: Send is shown.
3. On submitting that new text: stopped state is cleared and Stop appears during the new generation.
