### PR TITLE
feat(chat): url sources replaced with better UX that takes less space

### DIFF
--- a/.drizzle/migrations/0013_rainy_dragon_man.sql
+++ b/.drizzle/migrations/0013_rainy_dragon_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_settings` ADD `allow_external_links` integer;

--- a/.drizzle/migrations/meta/0013_snapshot.json
+++ b/.drizzle/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1160 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5844decc-3109-4d72-9a50-add8dcf6cd5b",
+  "prevId": "c14b84f4-5467-4327-9a5d-be84fac92bdc",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_expanded": {
+          "name": "reasoning_expanded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allow_external_links": {
+          "name": "allow_external_links",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_user_settings_user": {
+          "name": "uq_user_settings_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "shared": {
+          "name": "shared",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chats_slug_unique": {
+          "name": "chats_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "uq_chat_user": {
+          "name": "uq_chat_user",
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "uq_chat_slug": {
+          "name": "uq_chat_slug",
+          "columns": [
+            "id",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_users_id_fk": {
+          "name": "chats_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        }
+      },
+      "indexes": {
+        "uq_message_chat": {
+          "name": "uq_message_chat",
+          "columns": [
+            "id",
+            "chat_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keys": {
+      "name": "keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_key_user": {
+          "name": "uq_key_user",
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "uq_key_user_provider": {
+          "name": "uq_key_user_provider",
+          "columns": [
+            "user_id",
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "keys_user_id_users_id_fk": {
+          "name": "keys_user_id_users_id_fk",
+          "tableFrom": "keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'upload'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_message_id": {
+          "name": "origin_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_provider": {
+          "name": "origin_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "files_storageKey_unique": {
+          "name": "files_storageKey_unique",
+          "columns": [
+            "storage_key"
+          ],
+          "isUnique": true
+        },
+        "uq_file_user": {
+          "name": "uq_file_user",
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "uq_file_storageKey": {
+          "name": "uq_file_storageKey",
+          "columns": [
+            "storage_key"
+          ],
+          "isUnique": true
+        },
+        "idx_files_expires_at": {
+          "name": "idx_files_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_origin_message_id_messages_id_fk": {
+          "name": "files_origin_message_id_messages_id_fk",
+          "tableFrom": "files",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "origin_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_share_files": {
+      "name": "chat_share_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_share_id": {
+          "name": "chat_share_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_chat_share_file": {
+          "name": "uq_chat_share_file",
+          "columns": [
+            "chat_share_id",
+            "file_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chat_share_files_chat_share_id_chat_shares_id_fk": {
+          "name": "chat_share_files_chat_share_id_chat_shares_id_fk",
+          "tableFrom": "chat_share_files",
+          "tableTo": "chat_shares",
+          "columnsFrom": [
+            "chat_share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_share_files_file_id_files_id_fk": {
+          "name": "chat_share_files_file_id_files_id_fk",
+          "tableFrom": "chat_share_files",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_shares": {
+      "name": "chat_shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_chat_share_chat": {
+          "name": "uq_chat_share_chat",
+          "columns": [
+            "chat_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chat_shares_chat_id_chats_id_fk": {
+          "name": "chat_shares_chat_id_chats_id_fk",
+          "tableFrom": "chat_shares",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "storages": {
+      "name": "storages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage": {
+          "name": "storage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20971520
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "max_files_per_message": {
+          "name": "max_files_per_message",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "max_message_files_bytes": {
+          "name": "max_message_files_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1048576000
+        },
+        "file_retention_days": {
+          "name": "file_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 30
+        },
+        "image_transform_limit_total": {
+          "name": "image_transform_limit_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image_transform_used_total": {
+          "name": "image_transform_used_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_storage_user": {
+          "name": "uq_storage_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "storages_user_id_users_id_fk": {
+          "name": "storages_user_id_users_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_transform_usage_monthly": {
+      "name": "image_transform_usage_monthly",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "month_key": {
+          "name": "month_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transforms_used": {
+          "name": "transforms_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transforms_limit": {
+          "name": "transforms_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/.drizzle/migrations/meta/_journal.json
+++ b/.drizzle/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1772122520334,
       "tag": "0012_silky_scourge",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1772289561441,
+      "tag": "0013_rainy_dragon_man",
+      "breakpoints": true
     }
   ]
 }

--- a/app/components/Chat/UrlSources.vue
+++ b/app/components/Chat/UrlSources.vue
@@ -1,51 +1,99 @@
 <template>
-  <div
-    v-if="parts.length > 0"
-    class="collapse collapse-arrow my-2 border border-base-300 bg-base-100"
+  <details
+    v-if="sources.length > 0"
+    class="group collapse mt-2"
   >
-    <input
-      :id="`url-sources-${message.id}-checkbox`"
-      :aria-labelledby="`url-sources-${message.id}-label`"
-      type="checkbox"
+    <summary
+      :id="`sources-url-${message.id}-label`"
+      :aria-controls="`sources-url-${message.id}-content`"
+      class="collapse-title flex items-center gap-1 p-0 text-xs"
     >
-    <strong
-      :id="`url-sources-${message.id}-label`"
-      class="collapse-title flex items-center gap-2 py-3 font-semibold text-sm"
+      <Icon name="lucide:link" size="12" />
+      <span>Sources</span>
+      <span class="ml-1 badge badge-soft badge-xs gap-1">
+        {{ sources.length }}
+      </span>
+      <Icon
+        name="lucide:chevron-right"
+        class="text-base-content/60 transition-transform group-open:rotate-90"
+      />
+    </summary>
+    <div
+      :id="`sources-url-${message.id}-content`"
     >
-      <Icon name="lucide:link" />
-      Links
-    </strong>
-    <div class="collapse-content ml-6 text-sm">
-      <ul class="list list-disc list-inside gap-1">
-        <li
-          v-for="source in parts"
+      <div class="flex flex-wrap gap-2 pt-4 px-3">
+        <button
+          v-for="source in sources"
           :key="source.sourceId"
+          type="button"
+          class="link badge badge-soft badge-sm gap-1 no-underline"
+          @click="openLink(source)"
         >
-          <NuxtLink
-            :href="source.url"
-            target="_blank"
-            rel="noopener noreferrer"
-            external
-            class="link"
-          >
-            {{ source.title || source.url }}
-          </NuxtLink>
-        </li>
-      </ul>
+          <span class="max-w-32 truncate text-xs">{{ getLabel(source) }}</span>
+        </button>
+      </div>
     </div>
-  </div>
+  </details>
 </template>
 
 <script setup lang="ts">
 import type { UIMessage, SourceUrlUIPart } from 'ai'
 
+const MAX_TITLE_LENGTH = 30
+
 const props = defineProps<{
   message: UIMessage
 }>()
 
-const parts = computed<SourceUrlUIPart[]>(() => {
+const { allowExternalLinks, setAllowExternalLinks } = useUserSetting()
+
+const sources = computed<SourceUrlUIPart[]>(() => {
   return props.message.parts.filter((part) => {
     return part.type === 'source-url'
   })
 })
+
+async function openLink(source: SourceUrlUIPart) {
+  if (allowExternalLinks.value) {
+    window.open(source.url, '_blank', 'noopener,noreferrer')
+
+    return
+  }
+
+  const result = await useConfirm({
+    text: `Open ${getLabel(source)}?`,
+    subtitle: 'You are about to leave and open an external website. Make sure you trust this source before continuing.',
+    actions: ['Open', 'Open always'],
+    labelDecline: 'Close',
+  })
+
+  if (!result) return
+
+  if (result.index === 1) {
+    const alsoConfirmed = await useConfirm({
+      text: 'Always open external links?',
+      subtitle: 'All future links will open without asking. You can reset this in Settings.',
+      actions: ['Yes, always'],
+      labelDecline: 'No, just this once',
+    })
+
+    if (alsoConfirmed) {
+      void setAllowExternalLinks(true)
+    }
+  }
+
+  window.open(source.url, '_blank', 'noopener,noreferrer')
+}
+
+function getLabel(source: SourceUrlUIPart): string {
+  if (source.title && source.title.length <= MAX_TITLE_LENGTH) {
+    return source.title
+  }
+
+  try {
+    return new URL(source.url).hostname.replace(/^www\./, '')
+  } catch {
+    return source.url
+  }
+}
 </script>

--- a/app/components/ChatInput/Files/Attached/Preview.client.vue
+++ b/app/components/ChatInput/Files/Attached/Preview.client.vue
@@ -324,20 +324,26 @@ async function scrollToEnd() {
   })
 }
 
-function removeAttachedFile(storageKey: FileMetadata['storageKey']) {
-  useConfirmationModal(
-    emit,
-    ['remove', storageKey],
-    'Are you sure you want to detach this file?',
-  )
+async function removeAttachedFile(storageKey: FileMetadata['storageKey']) {
+  const result = await useConfirm({
+    text: 'Are you sure you want to detach this file?',
+    actions: ['Confirm'],
+  })
+
+  if (!result) return
+
+  emit('remove', storageKey)
 }
 
-function removeAllFiles() {
-  useConfirmationModal(
-    emit,
-    ['removeAll'],
-    `Detach all ${totalFilesCount.value} files?`,
-  )
+async function removeAllFiles() {
+  const result = await useConfirm({
+    text: `Detach all ${totalFilesCount.value} files?`,
+    actions: ['Confirm'],
+  })
+
+  if (!result) return
+
+  emit('removeAll')
 }
 
 watch(() => uploadingFilesArray.value.length, (newCount, oldCount) => {

--- a/app/components/ChatInput/Files/Modal/Select.client.vue
+++ b/app/components/ChatInput/Files/Modal/Select.client.vue
@@ -383,22 +383,28 @@ async function handleDeleteSelected() {
   }
 }
 
-function confirmDelete(file: FileManagerFile) {
-  useConfirmationModal(
-    () => handleDelete(file.id),
-    [],
-    `Are you sure you want to delete "${truncateFilename(file.name, 30)}"?`,
-    true,
-  )
+async function confirmDelete(file: FileManagerFile) {
+  const result = await useConfirm({
+    text: `Are you sure you want to delete "${truncateFilename(file.name, 30)}"?`,
+    alert: true,
+    actions: ['Confirm'],
+  })
+
+  if (!result) return
+
+  await handleDelete(file.id)
 }
 
-function confirmDeleteSelected() {
-  useConfirmationModal(
-    handleDeleteSelected,
-    [],
-    `Are you sure you want to delete ${selectedCount.value} file${selectedCount.value === 1 ? '' : 's'}?`,
-    true,
-  )
+async function confirmDeleteSelected() {
+  const result = await useConfirm({
+    text: `Are you sure you want to delete ${selectedCount.value} file${selectedCount.value === 1 ? '' : 's'}?`,
+    alert: true,
+    actions: ['Confirm'],
+  })
+
+  if (!result) return
+
+  await handleDeleteSelected()
 }
 
 function attachSelected() {

--- a/app/components/ChatInput/Files/Trigger.vue
+++ b/app/components/ChatInput/Files/Trigger.vue
@@ -141,12 +141,15 @@ function detachAllFiles() {
   closeDropdown()
 }
 
-function onDetachAllFiles() {
-  useConfirmationModal(
-    detachAllFiles,
-    [],
-    'Are you sure you want to detach all files?',
-  )
+async function onDetachAllFiles() {
+  const result = await useConfirm({
+    text: 'Are you sure you want to detach all files?',
+    actions: ['Confirm'],
+  })
+
+  if (!result) return
+
+  detachAllFiles()
 }
 
 function onFilesAttached(

--- a/app/components/Profile/Keys/Google.vue
+++ b/app/components/Profile/Keys/Google.vue
@@ -153,11 +153,14 @@ async function deleteKey() {
   }
 }
 
-function onDeleteKey() {
-  useConfirmationModal(
-    deleteKey,
-    [],
-    'Are you sure you want to delete your Google AI Studio key?',
-  )
+async function onDeleteKey() {
+  const result = await useConfirm({
+    text: 'Are you sure you want to delete your Google AI Studio key?',
+    actions: ['Confirm'],
+  })
+
+  if (!result) return
+
+  await deleteKey()
 }
 </script>

--- a/app/components/Profile/Keys/OpenAi.vue
+++ b/app/components/Profile/Keys/OpenAi.vue
@@ -158,11 +158,14 @@ async function deleteKeys() {
   }
 }
 
-function onDeleteKeys() {
-  useConfirmationModal(
-    deleteKeys,
-    [],
-    'Are you sure you want to delete your OpenAI API key?',
-  )
+async function onDeleteKeys() {
+  const result = await useConfirm({
+    text: 'Are you sure you want to delete your OpenAI API key?',
+    actions: ['Confirm'],
+  })
+
+  if (!result) return
+
+  await deleteKeys()
 }
 </script>

--- a/app/pages/chats/[slug].vue
+++ b/app/pages/chats/[slug].vue
@@ -131,7 +131,7 @@ const query = computed(() => {
     scenario = 'short'
   }
 
-  if (!['off', 'low', 'medium', 'high'].includes(effort)) {
+  if (!['low', 'medium', 'high', 'off'].includes(effort)) {
     effort = 'medium'
   }
 

--- a/app/types/confirmation.d.ts
+++ b/app/types/confirmation.d.ts
@@ -1,8 +1,12 @@
-export type ConfirmationCallback = (...args: any[]) => void | Promise<any>
+export interface ConfirmOptions {
+  text?: string
+  subtitle?: string
+  alert?: boolean
+  actions: string[]
+  labelDecline?: string
+}
 
-export interface Confirmation {
-  callback: ConfirmationCallback
-  text: string
-  args: any[]
-  alert: boolean
+export interface ConfirmResult {
+  label: string
+  index: number
 }

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -58,6 +58,9 @@ export function getAffectedTests(changedFiles) {
     'tests/integration/server/convert-files-for-ai.spec.ts',
     'tests/e2e/chat/files.spec.ts',
   ]
+  const profileSettingsTests = [
+    'tests/integration/api/profile-settings.spec.ts',
+  ]
 
   const testMappings = [
     {
@@ -85,7 +88,15 @@ export function getAffectedTests(changedFiles) {
       tests: filesModuleTests,
     },
     {
+      pattern: /^app\/components\/ui\/Confirmation\.vue$/,
+      tests: filesModuleTests,
+    },
+    {
       pattern: /^app\/composables\/(chat-files|file-manager)\.ts$/,
+      tests: filesModuleTests,
+    },
+    {
+      pattern: /^app\/composables\/confirmation\.ts$/,
       tests: filesModuleTests,
     },
     {
@@ -118,7 +129,10 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern: /^server\/db\/schema\.ts$/,
-      tests: filesModuleTests,
+      tests: [
+        ...filesModuleTests,
+        ...profileSettingsTests,
+      ],
     },
     {
       pattern: /^app\/composables\/.*\.ts$/,
@@ -129,6 +143,14 @@ export function getAffectedTests(changedFiles) {
 
         return existsSync(testFile) ? [testFile] : []
       },
+    },
+    {
+      pattern: /^server\/api\/v1\/profiles\/settings\/index\.(get|patch)\.ts$/,
+      tests: profileSettingsTests,
+    },
+    {
+      pattern: /^server\/db\/schemas\/user-settings\.ts$/,
+      tests: profileSettingsTests,
     },
     {
       pattern: /^app\/utils\/.*\.ts$/,

--- a/server/api/v1/profiles/settings/index.get.ts
+++ b/server/api/v1/profiles/settings/index.get.ts
@@ -11,10 +11,12 @@ export default defineEventHandler(async () => {
     },
     columns: {
       reasoningExpanded: true,
+      allowExternalLinks: true,
     },
   })
 
   return {
     reasoningExpanded: settings?.reasoningExpanded ?? false,
+    allowExternalLinks: settings?.allowExternalLinks ?? null,
   }
 })

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,4 +1,5 @@
 export * from './schemas/auth'
+export * from './schemas/user-settings'
 export * from './schemas/chats'
 export * from './schemas/keys'
 export * from './schemas/files'

--- a/server/db/schemas/auth.ts
+++ b/server/db/schemas/auth.ts
@@ -2,7 +2,6 @@ import {
   sqliteTable,
   text,
   integer,
-  uniqueIndex,
 } from 'drizzle-orm/sqlite-core'
 import { relations } from 'drizzle-orm'
 import { defaultSchemaTimestamps } from '../../utils/schema'
@@ -10,6 +9,7 @@ import { chats } from './chats'
 import { keys } from './keys'
 import { files } from './files'
 import { storages } from './storages'
+import { userSettings } from './user-settings'
 
 export const users = sqliteTable('users', {
   ...defaultSchemaTimestamps,
@@ -57,23 +57,6 @@ export const verifications = sqliteTable('verifications', {
   expiresAt: integer({ mode: 'timestamp' }).notNull(),
 })
 
-export const userSettings = sqliteTable(
-  'user_settings',
-  {
-    ...defaultSchemaTimestamps,
-    id: integer({ mode: 'number' }).primaryKey({ autoIncrement: true }),
-    userId: integer({ mode: 'number' })
-      .notNull()
-      .references(() => users.id, { onDelete: 'cascade' }),
-    reasoningExpanded: integer({ mode: 'boolean' })
-      .notNull()
-      .default(false),
-  },
-  table => [
-    uniqueIndex('uq_user_settings_user').on(table.userId),
-  ],
-)
-
 export const usersRelations = relations(users, ({ many, one }) => ({
   accounts: many(accounts),
   sessions: many(sessions),
@@ -112,13 +95,6 @@ export const accountsRelations = relations(accounts, ({ one }) => ({
 export const sessionsRelations = relations(sessions, ({ one }) => ({
   user: one(users, {
     fields: [sessions.userId],
-    references: [users.id],
-  }),
-}))
-
-export const userSettingsRelations = relations(userSettings, ({ one }) => ({
-  user: one(users, {
-    fields: [userSettings.userId],
     references: [users.id],
   }),
 }))

--- a/server/db/schemas/user-settings.ts
+++ b/server/db/schemas/user-settings.ts
@@ -1,0 +1,33 @@
+import {
+  sqliteTable,
+  integer,
+  uniqueIndex,
+} from 'drizzle-orm/sqlite-core'
+import { relations } from 'drizzle-orm'
+import { defaultSchemaTimestamps } from '../../utils/schema'
+import { users } from './auth'
+
+export const userSettings = sqliteTable(
+  'user_settings',
+  {
+    ...defaultSchemaTimestamps,
+    id: integer({ mode: 'number' }).primaryKey({ autoIncrement: true }),
+    userId: integer({ mode: 'number' })
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    reasoningExpanded: integer({ mode: 'boolean' })
+      .notNull()
+      .default(false),
+    allowExternalLinks: integer({ mode: 'boolean' }),
+  },
+  table => [
+    uniqueIndex('uq_user_settings_user').on(table.userId),
+  ],
+)
+
+export const userSettingsRelations = relations(userSettings, ({ one }) => ({
+  user: one(users, {
+    fields: [userSettings.userId],
+    references: [users.id],
+  }),
+}))

--- a/tests/e2e/chat/files.spec.ts
+++ b/tests/e2e/chat/files.spec.ts
@@ -199,6 +199,7 @@ async function openFilesModal(
   const actionButton = page.getByTestId(actionTestId)
 
   await expect(actionButton).toBeVisible()
+  await expect(page.getByTestId('files-modal')).toBeAttached({ timeout: 10000 })
   await actionButton.evaluate((element) => {
     ;(element as HTMLButtonElement).click()
   })

--- a/tests/integration/api/profile-settings.spec.ts
+++ b/tests/integration/api/profile-settings.spec.ts
@@ -141,6 +141,7 @@ describe('profile settings API', () => {
 
     expect(response).toEqual({
       reasoningExpanded: false,
+      allowExternalLinks: null,
     })
   })
 
@@ -182,6 +183,7 @@ describe('profile settings API', () => {
 
     expect(getResponse).toEqual({
       reasoningExpanded: false,
+      allowExternalLinks: null,
     })
   })
 

--- a/tests/unit/components/Confirmation.spec.ts
+++ b/tests/unit/components/Confirmation.spec.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import type { ConfirmOptions } from '../../../app/types/confirmation.d'
+import ConfirmationComponent from '../../../app/components/ui/Confirmation.vue'
+import {
+  useConfirmation,
+  useConfirm,
+  resetConfirmationState,
+} from '../../../app/composables/confirmation'
+
+function makeOptions(overrides?: Partial<ConfirmOptions>): ConfirmOptions {
+  return {
+    text: 'Confirm',
+    alert: false,
+    actions: ['Confirm'],
+    ...overrides,
+  }
+}
+
+describe('Confirmation.vue', () => {
+  beforeEach(() => {
+    resetConfirmationState()
+    vi.spyOn(HTMLDialogElement.prototype, 'showModal').mockImplementation(() => {})
+    vi.spyOn(HTMLDialogElement.prototype, 'close').mockImplementation(() => {})
+  })
+
+  it('renders no title, no action button, and Close label when no confirmation is pending', async () => {
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('h3').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="confirmation-decline"]').text()).toBe('Close')
+    expect(wrapper.find('[data-testid="confirmation-action-0"]').exists()).toBe(false)
+  })
+
+  it('renders title text from confirmation state', async () => {
+    useConfirmation().value = makeOptions({ text: 'Are you sure?' })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('h3').text()).toBe('Are you sure?')
+  })
+
+  it('renders subtitle when provided, hides generic alert text', async () => {
+    useConfirmation().value = makeOptions({
+      subtitle: 'This will permanently remove the item.',
+    })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('p').text()).toBe('This will permanently remove the item.')
+    expect(wrapper.html()).not.toContain('Be careful')
+  })
+
+  it('renders generic alert text when alert is true and no subtitle', async () => {
+    useConfirmation().value = makeOptions({ alert: true })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('p').text()).toContain('Be careful')
+  })
+
+  it('renders subtitle instead of alert text when both are set', async () => {
+    useConfirmation().value = makeOptions({
+      alert: true,
+      subtitle: 'Custom warning.',
+    })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('p').text()).toBe('Custom warning.')
+    expect(wrapper.html()).not.toContain('Be careful')
+  })
+
+  it('adds text-center to title when alert is false', async () => {
+    useConfirmation().value = makeOptions({ alert: false })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('h3').classes()).toContain('text-center')
+  })
+
+  it('removes text-center from title when alert is true', async () => {
+    useConfirmation().value = makeOptions({ alert: true })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('h3').classes()).not.toContain('text-center')
+  })
+
+  it('renders single action as a plain button, no split container', async () => {
+    useConfirmation().value = makeOptions({ actions: ['Delete'] })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('[data-testid="confirmation-action-0"]').text()).toBe('Delete')
+    expect(wrapper.find('[data-testid="confirmation-actions-split"]').exists()).toBe(false)
+  })
+
+  it('shows default Decline label from prop when state has no labelDecline', async () => {
+    useConfirmation().value = makeOptions()
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('[data-testid="confirmation-decline"]').text()).toBe('Decline')
+  })
+
+  it('shows labelDecline from state, overriding prop default', async () => {
+    useConfirmation().value = makeOptions({ labelDecline: 'Close' })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('[data-testid="confirmation-decline"]').text()).toBe('Close')
+  })
+
+  it('uses prop labelDecline as fallback when state has no labelDecline', async () => {
+    useConfirmation().value = makeOptions()
+
+    const wrapper = await mountSuspended(ConfirmationComponent, {
+      props: { labelDecline: 'No' },
+    })
+
+    expect(wrapper.find('[data-testid="confirmation-decline"]').text()).toBe('No')
+  })
+
+  it('resolves with result when action button is clicked', async () => {
+    const promise = useConfirm({ text: 'Confirm', actions: ['OK'] })
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    await wrapper.find('[data-testid="confirmation-action-0"]').trigger('click')
+
+    expect(await promise).toEqual({ label: 'OK', index: 0 })
+  })
+
+  it('resolves with null when decline button is clicked', async () => {
+    const promise = useConfirm({ text: 'Confirm', actions: ['OK'] })
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    await wrapper.find('[data-testid="confirmation-decline"]').trigger('click')
+
+    expect(await promise).toBeNull()
+  })
+
+  it('clears state after action is confirmed', async () => {
+    const state = useConfirmation()
+    const promise = useConfirm({ text: 'Confirm', actions: ['OK'] })
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    await wrapper.find('[data-testid="confirmation-action-0"]').trigger('click')
+    await promise
+
+    expect(state.value).toBeNull()
+  })
+
+  it('renders two actions with split container and primary + dropdown', async () => {
+    useConfirmation().value = makeOptions({
+      actions: ['Open', 'Open always'],
+    })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('[data-testid="confirmation-actions-split"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="confirmation-action-0"]').text()).toBe('Open')
+    expect(wrapper.find('[data-testid="confirmation-action-1"]').text()).toBe('Open always')
+  })
+
+  it('resolves with index 1 when dropdown action is clicked', async () => {
+    const promise = useConfirm({
+      text: 'Open link?',
+      actions: ['Open', 'Open always'],
+    })
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    await wrapper.find('[data-testid="confirmation-action-1"]').trigger('click')
+
+    expect(await promise).toEqual({ label: 'Open always', index: 1 })
+  })
+
+  it('shows next queued confirmation after first is resolved via click', async () => {
+    const promise1 = useConfirm({ text: 'First', actions: ['OK'] })
+    useConfirm({ text: 'Second', actions: ['OK'] })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    await wrapper.find('[data-testid="confirmation-action-0"]').trigger('click')
+    await promise1
+    await nextTick()
+
+    expect(useConfirmation().value?.text).toBe('Second')
+  })
+
+  it('renders all custom options correctly', async () => {
+    const promise = useConfirm({
+      text: 'Open external site?',
+      alert: false,
+      subtitle: 'You are about to leave the application.',
+      actions: ['Open', 'Open always'],
+      labelDecline: 'Close',
+    })
+
+    const wrapper = await mountSuspended(ConfirmationComponent)
+
+    expect(wrapper.find('h3').text()).toBe('Open external site?')
+    expect(wrapper.find('h3').classes()).toContain('text-center')
+    expect(wrapper.find('p').text()).toBe('You are about to leave the application.')
+    expect(wrapper.html()).not.toContain('Be careful')
+    expect(wrapper.find('[data-testid="confirmation-decline"]').text()).toBe('Close')
+    expect(wrapper.find('[data-testid="confirmation-actions-split"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="confirmation-action-0"]').trigger('click')
+
+    expect(await promise).toEqual({ label: 'Open', index: 0 })
+  })
+})

--- a/tests/unit/composables/confirmation.spec.ts
+++ b/tests/unit/composables/confirmation.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+import {
+  useConfirmation,
+  useConfirm,
+  resolveConfirmation,
+  resetConfirmationState,
+} from '../../../app/composables/confirmation'
+
+describe('useConfirm / resolveConfirmation', () => {
+  beforeEach(() => {
+    resetConfirmationState()
+  })
+
+  it('sets confirmation state with provided options', () => {
+    useConfirm({ text: 'Delete this item?', actions: ['Confirm'] })
+
+    expect(useConfirmation().value?.text).toBe('Delete this item?')
+    expect(useConfirmation().value?.actions).toEqual(['Confirm'])
+  })
+
+  it('applies alert and subtitle options', () => {
+    useConfirm({
+      text: 'Confirm',
+      alert: true,
+      subtitle: 'This cannot be undone.',
+      actions: ['Confirm'],
+    })
+
+    expect(useConfirmation().value?.alert).toBe(true)
+    expect(useConfirmation().value?.subtitle).toBe('This cannot be undone.')
+  })
+
+  it('stores labelDecline option', () => {
+    useConfirm({ text: 'Confirm', actions: ['OK'], labelDecline: 'Cancel' })
+
+    expect(useConfirmation().value?.labelDecline).toBe('Cancel')
+  })
+
+  it('resolves with result when resolveConfirmation is called', async () => {
+    const promise = useConfirm({ text: 'Confirm', actions: ['OK'] })
+
+    resolveConfirmation({ label: 'OK', index: 0 })
+
+    expect(await promise).toEqual({ label: 'OK', index: 0 })
+  })
+
+  it('resolves with null when resolveConfirmation(null) is called', async () => {
+    const promise = useConfirm({ text: 'Confirm', actions: ['OK'] })
+
+    resolveConfirmation(null)
+
+    expect(await promise).toBeNull()
+  })
+
+  it('clears confirmation state after resolveConfirmation', async () => {
+    const promise = useConfirm({ text: 'Confirm', actions: ['OK'] })
+
+    resolveConfirmation({ label: 'OK', index: 0 })
+    await promise
+
+    expect(useConfirmation().value).toBeNull()
+  })
+
+  it('resolves with the correct action index for multi-action confirmations', async () => {
+    const promise = useConfirm({
+      text: 'Open link?',
+      actions: ['Open', 'Open always'],
+    })
+
+    resolveConfirmation({ label: 'Open always', index: 1 })
+
+    expect(await promise).toEqual({ label: 'Open always', index: 1 })
+  })
+
+  it('queues a second call while first is pending', () => {
+    useConfirm({ text: 'First', actions: ['OK'] })
+    useConfirm({ text: 'Second', actions: ['OK'] })
+
+    expect(useConfirmation().value?.text).toBe('First')
+  })
+
+  it('shows next queued confirmation after first resolves', async () => {
+    const promise1 = useConfirm({ text: 'First', actions: ['OK'] })
+    useConfirm({ text: 'Second', actions: ['OK'] })
+
+    resolveConfirmation({ label: 'OK', index: 0 })
+    await promise1
+    await nextTick()
+
+    expect(useConfirmation().value?.text).toBe('Second')
+  })
+
+  it('resolves queued confirmations in order', async () => {
+    const promise1 = useConfirm({ text: 'First', actions: ['A'] })
+    const promise2 = useConfirm({ text: 'Second', actions: ['B'] })
+
+    resolveConfirmation({ label: 'A', index: 0 })
+    const result1 = await promise1
+    await nextTick()
+
+    resolveConfirmation({ label: 'B', index: 0 })
+    const result2 = await promise2
+
+    expect(result1).toEqual({ label: 'A', index: 0 })
+    expect(result2).toEqual({ label: 'B', index: 0 })
+  })
+
+  it('is a no-op when resolveConfirmation is called with empty queue', () => {
+    expect(() => resolveConfirmation(null)).not.toThrow()
+    expect(useConfirmation().value).toBeNull()
+  })
+
+  it('resetConfirmationState resolves all pending promises with null', async () => {
+    const promise1 = useConfirm({ text: 'First', actions: ['OK'] })
+    const promise2 = useConfirm({ text: 'Second', actions: ['OK'] })
+
+    resetConfirmationState()
+
+    expect(await promise1).toBeNull()
+    expect(await promise2).toBeNull()
+    expect(useConfirmation().value).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Add persistent "allow external links" user setting stored in DB
- Rewrite confirmation system with a Promise-based useConfirm() API that supports chaining, queuing, and eliminates the close-event race condition
- Introduce split-button confirmation UI (primary action + chevron dropdown for additional actions)
- Two-step "Open always" flow: opening a source link shows a first modal; choosing "Open always" chains a second modal before saving the setting

## What changed

### External links trust setting

- user_settings.allow_external_links — new nullable boolean column (migration 0013); NULL means "ask each time", true means skip future prompts
- GET /api/v1/profiles/settings — exposes allowExternalLinks in the response
- PATCH /api/v1/profiles/settings — accepts optional allowExternalLinks; both fields now optional so each composable can patch only what it owns; added 400 guard for empty-body
requests (previously hit Drizzle's "No values to set" error as a 500)
- useUserSetting — new allowExternalLinks computed + setAllowExternalLinks() setter with optimistic update; synced from server on login, reset on logout; no localStorage
fallback since null is the intentional "unset" state

### Confirmation system rewrite

The previous design stored callbacks inside shared state, which created an unfixable race condition: when an action was confirmed, the dialog's async close DOM event fired after
the next confirmation was already set, silently wiping it.

New design:
- useConfirm(options) returns Promise<ConfirmResult | null> — null means declined, { label, index } means which action was chosen
- Module-level queue — concurrent callers are shown in order instead of silently dropped
- resolveConfirmation(result) — shifts the queue, clears state, resolves the promise, advances to the next queued entry via nextTick
- resetConfirmationState() — resolves all pending promises with null for clean test teardown
- Component wired to explicit user gestures only: decline button (@click), backdrop (@click), Escape (@cancel.prevent); the close DOM event listener is removed entirely, which
was the root cause of the race
- Split-button UI: single action renders a plain button; 2+ actions render a join container with the primary action and a chevron dropdown for extras
- data-testid attributes on all interactive elements (confirmation-decline, confirmation-action-{n}, confirmation-actions-split)

UrlSources two-step flow

click source → Modal 1: "Open example.com?"
               ├─ [Close]          → nothing
               ├─ [Open]           → link opens
               └─ [Open always ▾]  → Modal 2: "Always open external links?"
                                          ├─ [No, just this once] → link opens
                                          └─ [Yes, always]        → setting saved + link opens

All confirmation call sites

Eight call sites migrated from the old fire-and-forget callback pattern to async/await:

// before
function onDeleteKey() {
useConfirmationModal({ callback: deleteKey, text: '...' })
}

// after
async function onDeleteKey() {
const result = await useConfirm({ text: '...', actions: ['Confirm'] })
if (!result) return
await deleteKey()
}

### Bug fixes

- Removed console.log(chat) from useChat that was leaking full conversation content to browser logs
- effort=off now accepted by the test-chat query sanitizer (was being coerced to medium, breaking the no-reasoning test path)

## Test plan

- Click a source link → confirmation modal appears with "Open" as primary and chevron revealing "Open always"
- Click "Open always" → second modal appears; confirming saves the setting and opens the link
- Decline the second modal → link still opens, setting not saved
- Subsequent clicks on any source link → link opens directly without confirmation
- Log out and back in → allowExternalLinks setting persists from DB
- All existing confirmation flows (delete file, detach files, delete API key) still work via async/await
- pnpm vitest run tests/unit/composables/confirmation.spec.ts tests/unit/components/Confirmation.spec.ts — 30 tests pass
- pnpm run db:migrate required after deploy to apply the allow_external_links column

## Preview

### Before

<img width="1982" height="1192" alt="image" src="https://github.com/user-attachments/assets/7dea9f10-d8be-4237-b9cd-c0c2aeb8ce16" />

<img width="1878" height="1486" alt="image" src="https://github.com/user-attachments/assets/a122ef9b-a0e8-4c80-8cdb-c72fa31086db" />

### After

<img width="1656" height="758" alt="image" src="https://github.com/user-attachments/assets/156685c4-b8f7-41a7-b30c-fae8707cd381" />
<img width="1664" height="874" alt="image" src="https://github.com/user-attachments/assets/cd0d4a4e-0cbd-4b2b-804a-75da84366b83" />
<img width="3142" height="1938" alt="image" src="https://github.com/user-attachments/assets/303c1bd8-a143-4547-a6ac-1636885917ec" />
<img width="1498" height="670" alt="image" src="https://github.com/user-attachments/assets/944fd70a-3ab4-474c-8405-2f8abf8e402b" />


