### PR TITLE
feat(reasoning): implemented auto-hide flag when expanded steps enabled

### DIFF
--- a/.drizzle/migrations/0014_legal_dark_beast.sql
+++ b/.drizzle/migrations/0014_legal_dark_beast.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_settings` ADD `reasoning_auto_hide` integer DEFAULT true NOT NULL;

--- a/.drizzle/migrations/meta/0014_snapshot.json
+++ b/.drizzle/migrations/meta/0014_snapshot.json
@@ -1,0 +1,1168 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dd83720c-3d3d-4756-a59a-3b626113580e",
+  "prevId": "5844decc-3109-4d72-9a50-add8dcf6cd5b",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_expanded": {
+          "name": "reasoning_expanded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reasoning_auto_hide": {
+          "name": "reasoning_auto_hide",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "allow_external_links": {
+          "name": "allow_external_links",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_user_settings_user": {
+          "name": "uq_user_settings_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "shared": {
+          "name": "shared",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chats_slug_unique": {
+          "name": "chats_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "uq_chat_user": {
+          "name": "uq_chat_user",
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "uq_chat_slug": {
+          "name": "uq_chat_slug",
+          "columns": [
+            "id",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_users_id_fk": {
+          "name": "chats_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        }
+      },
+      "indexes": {
+        "uq_message_chat": {
+          "name": "uq_message_chat",
+          "columns": [
+            "id",
+            "chat_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keys": {
+      "name": "keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_key_user": {
+          "name": "uq_key_user",
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "uq_key_user_provider": {
+          "name": "uq_key_user_provider",
+          "columns": [
+            "user_id",
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "keys_user_id_users_id_fk": {
+          "name": "keys_user_id_users_id_fk",
+          "tableFrom": "keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'upload'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_message_id": {
+          "name": "origin_message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_provider": {
+          "name": "origin_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "files_storageKey_unique": {
+          "name": "files_storageKey_unique",
+          "columns": [
+            "storage_key"
+          ],
+          "isUnique": true
+        },
+        "uq_file_user": {
+          "name": "uq_file_user",
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "uq_file_storageKey": {
+          "name": "uq_file_storageKey",
+          "columns": [
+            "storage_key"
+          ],
+          "isUnique": true
+        },
+        "idx_files_expires_at": {
+          "name": "idx_files_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "files_user_id_users_id_fk": {
+          "name": "files_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_origin_message_id_messages_id_fk": {
+          "name": "files_origin_message_id_messages_id_fk",
+          "tableFrom": "files",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "origin_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_share_files": {
+      "name": "chat_share_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_share_id": {
+          "name": "chat_share_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_chat_share_file": {
+          "name": "uq_chat_share_file",
+          "columns": [
+            "chat_share_id",
+            "file_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chat_share_files_chat_share_id_chat_shares_id_fk": {
+          "name": "chat_share_files_chat_share_id_chat_shares_id_fk",
+          "tableFrom": "chat_share_files",
+          "tableTo": "chat_shares",
+          "columnsFrom": [
+            "chat_share_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_share_files_file_id_files_id_fk": {
+          "name": "chat_share_files_file_id_files_id_fk",
+          "tableFrom": "chat_share_files",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_shares": {
+      "name": "chat_shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_chat_share_chat": {
+          "name": "uq_chat_share_chat",
+          "columns": [
+            "chat_id",
+            "id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chat_shares_chat_id_chats_id_fk": {
+          "name": "chat_shares_chat_id_chats_id_fk",
+          "tableFrom": "chat_shares",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "storages": {
+      "name": "storages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage": {
+          "name": "storage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20971520
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "max_files_per_message": {
+          "name": "max_files_per_message",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "max_message_files_bytes": {
+          "name": "max_message_files_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1048576000
+        },
+        "file_retention_days": {
+          "name": "file_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 30
+        },
+        "image_transform_limit_total": {
+          "name": "image_transform_limit_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image_transform_used_total": {
+          "name": "image_transform_used_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_storage_user": {
+          "name": "uq_storage_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "storages_user_id_users_id_fk": {
+          "name": "storages_user_id_users_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "image_transform_usage_monthly": {
+      "name": "image_transform_usage_monthly",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "month_key": {
+          "name": "month_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transforms_used": {
+          "name": "transforms_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transforms_limit": {
+          "name": "transforms_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1000
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/.drizzle/migrations/meta/_journal.json
+++ b/.drizzle/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1772289561441,
       "tag": "0013_rainy_dragon_man",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1772365285316,
+      "tag": "0014_legal_dark_beast",
+      "breakpoints": true
     }
   ]
 }

--- a/app/components/Chat/Reasoning.vue
+++ b/app/components/Chat/Reasoning.vue
@@ -235,7 +235,10 @@ const activeStreamingTitle = computed<string>(() => {
 
 const reasoningSeconds = shallowRef<number>(0)
 const reasoningDurationSeconds = shallowRef<number>(0)
-const { reasoningExpanded: isReasoningExpanded } = useUserSetting()
+const {
+  reasoningExpanded: isReasoningExpanded,
+  reasoningAutoHide,
+} = useUserSetting()
 
 const isMainExpanded = shallowRef<boolean>(false)
 const expandedStepId = shallowRef<string>('')
@@ -282,6 +285,10 @@ watch(
 
 watch(hasTextPart, (textStarted, hadText) => {
   if (!textStarted || hadText) {
+    return
+  }
+
+  if (!reasoningAutoHide.value) {
     return
   }
 

--- a/app/components/ChatInput/ReasoningTrigger.vue
+++ b/app/components/ChatInput/ReasoningTrigger.vue
@@ -30,39 +30,67 @@
       <div class="dropdown-content z-50 w-44 pb-2">
         <div class="bg-base-100 rounded-box w-full shadow-sm">
           <ul class="menu menu-xs w-full">
-            <li class="menu-title text-xs pt-2">
-              Reasoning steps
-            </li>
-            <li class="">
-              <fieldset class="fieldset p-0">
-                <label
-                  class="label cursor-pointer py-1 px-2 justify-between gap-2"
-                >
-                  <span
-                    class="flex items-center gap-2"
-                    :class="{
-                      'text-primary dark:text-primary-content':
-                        reasoningExpanded
-                    }"
-                  >
-                    <Icon
-                      :name="`lucide:eye${reasoningExpanded ? '' : '-off'}`"
-                      size="16"
-                    />
-                    <span class="label-text text-xs">
-                      {{ reasoningExpanded ? 'Visible' : 'Hidden' }}
-                    </span>
-                  </span>
-                  <input
-                    data-testid="reasoning-expanded-toggle"
-                    type="checkbox"
-                    class="toggle toggle-xs"
-                    :checked="reasoningExpanded"
-                    @change="onReasoningExpandedChange"
-                  >
-                </label>
-              </fieldset>
-            </li>
+            <TransitionGroup name="slide-fade">
+              <template v-if="reasoning !== 'off'">
+                <li class="menu-title text-xs pt-2">
+                  Reasoning steps
+                </li>
+                <Transition name="slide-fade">
+                  <li v-if="reasoningExpanded">
+                    <fieldset class="fieldset p-0">
+                      <label
+                        data-tip="Once reasoning done"
+                        class="tooltip tooltip-top label cursor-pointer py-1 px-2 justify-between gap-2 text-primary dark:text-primary-content"
+                      >
+                        <span class="flex items-center gap-2">
+                          <Icon name="lucide:timer-reset" size="16" />
+                          <span class="label-text text-xs text-primary dark:text-primary-content">
+                            Auto-hide
+                          </span>
+                        </span>
+                        <input
+                          data-testid="reasoning-auto-hide-toggle"
+                          type="checkbox"
+                          class="toggle toggle-xs"
+                          :checked="reasoningAutoHide"
+                          @change="onReasoningAutoHideChange"
+                        >
+                      </label>
+                    </fieldset>
+                  </li>
+                </Transition>
+                <li>
+                  <fieldset class="fieldset p-0">
+                    <label
+                      class="label cursor-pointer py-1 px-2 justify-between gap-2 text-primary dark:text-primary-content"
+                    >
+                      <span
+                        class="flex items-center gap-2"
+                        :class="{
+                          'text-primary dark:text-primary-content':
+                            reasoningExpanded
+                        }"
+                      >
+                        <Icon
+                          name="lucide:list-tree"
+                          size="16"
+                        />
+                        <span class="label-text text-xs">
+                          Expanded
+                        </span>
+                      </span>
+                      <input
+                        data-testid="reasoning-expanded-toggle"
+                        type="checkbox"
+                        class="toggle toggle-xs"
+                        :checked="reasoningExpanded"
+                        @change="onReasoningExpandedChange"
+                      >
+                    </label>
+                  </fieldset>
+                </li>
+              </template>
+            </TransitionGroup>
             <li class="menu-title text-xs">
               Reasoning effort
             </li>
@@ -112,7 +140,12 @@ const { isIos, isAndroid } = useDevice()
 
 const dropdown = useTemplateRef<HTMLDetailsElement>('dropdown')
 const isDropdownHovered = useElementHover(dropdown)
-const { reasoningExpanded, setReasoningExpanded } = useUserSetting()
+const {
+  reasoningExpanded,
+  reasoningAutoHide,
+  setReasoningExpanded,
+  setReasoningAutoHide,
+} = useUserSetting()
 
 const isReasoningActive = computed<boolean>(() => {
   return reasoning.value !== 'off'
@@ -141,10 +174,6 @@ watch(isDropdownHovered, (hovered) => {
 
 function selectLevel(level: ReasoningLevel) {
   reasoning.value = level
-
-  if (dropdown.value?.open) {
-    dropdown.value.open = false
-  }
 }
 
 function getIconComponent(level: ReasoningLevel): string {
@@ -160,4 +189,24 @@ function onReasoningExpandedChange(event: Event) {
 
   void setReasoningExpanded(target.checked)
 }
+
+function onReasoningAutoHideChange(event: Event) {
+  const target = event.target as HTMLInputElement | null
+
+  if (!target) {
+    return
+  }
+
+  void setReasoningAutoHide(target.checked)
+}
 </script>
+<style scoped>
+  .slide-fade-enter-active {
+    transition: all 0.1s ease-in;
+  }
+
+  .slide-fade-enter-from {
+    transform: translateY(10px);
+    opacity: 0;
+  }
+</style>

--- a/app/composables/user-setting.ts
+++ b/app/composables/user-setting.ts
@@ -13,6 +13,10 @@ export function useUserSetting() {
     'user-settings:reasoning-expanded',
     () => null,
   )
+  const serverReasoningAutoHide = useState<boolean | null>(
+    'user-settings:reasoning-auto-hide',
+    () => null,
+  )
   const serverAllowExternalLinks = useState<boolean | null>(
     'user-settings:allow-external-links',
     () => null,
@@ -37,6 +41,10 @@ export function useUserSetting() {
     'settings_reasoning_expanded',
     false,
   )
+  const fallbackReasoningAutoHide = useLocalStorage<boolean>(
+    'settings_reasoning_auto_hide',
+    true,
+  )
 
   const reasoningExpanded = computed<boolean>(() => {
     if (
@@ -48,6 +56,18 @@ export function useUserSetting() {
     }
 
     return serverReasoningExpanded.value
+  })
+
+  const reasoningAutoHide = computed<boolean>(() => {
+    if (
+      !activeUserId.value
+      || loadedUserId.value !== activeUserId.value
+      || serverReasoningAutoHide.value === null
+    ) {
+      return fallbackReasoningAutoHide.value
+    }
+
+    return serverReasoningAutoHide.value
   })
 
   const allowExternalLinks = computed<boolean>(() => {
@@ -93,10 +113,15 @@ export function useUserSetting() {
       const nextReasoningExpanded = Boolean(
         response.reasoningExpanded,
       )
+      const nextReasoningAutoHide = Boolean(
+        response.reasoningAutoHide ?? true,
+      )
 
       loadedUserId.value = userId
       serverReasoningExpanded.value = nextReasoningExpanded
       fallbackReasoningExpanded.value = nextReasoningExpanded
+      serverReasoningAutoHide.value = nextReasoningAutoHide
+      fallbackReasoningAutoHide.value = nextReasoningAutoHide
       serverAllowExternalLinks.value = response.allowExternalLinks ?? null
     } catch (exception) {
       if (
@@ -108,6 +133,7 @@ export function useUserSetting() {
 
       loadedUserId.value = null
       serverReasoningExpanded.value = null
+      serverReasoningAutoHide.value = null
       serverAllowExternalLinks.value = null
 
       const parsedException = parseError(exception)
@@ -173,6 +199,56 @@ export function useUserSetting() {
     }
   }
 
+  async function setReasoningAutoHide(value: boolean) {
+    settingsError.value = null
+
+    const previousFallbackReasoningAutoHide
+      = fallbackReasoningAutoHide.value
+    fallbackReasoningAutoHide.value = value
+
+    if (!activeUserId.value) {
+      return
+    }
+
+    const currentUserId = activeUserId.value as string
+    const previousServerReasoningAutoHide
+      = serverReasoningAutoHide.value as boolean
+
+    serverReasoningAutoHide.value = value
+    isSavingSettings.value = true
+
+    try {
+      await $fetch('/api/v1/profiles/settings', {
+        method: 'PATCH',
+        body: {
+          reasoningAutoHide: value,
+        },
+      })
+
+      if (activeUserId.value !== currentUserId) {
+        return
+      }
+
+      loadedUserId.value = currentUserId
+      serverReasoningAutoHide.value = value
+      fallbackReasoningAutoHide.value = value
+    } catch (exception) {
+      if (activeUserId.value !== currentUserId) {
+        return
+      }
+
+      serverReasoningAutoHide.value = previousServerReasoningAutoHide
+      fallbackReasoningAutoHide.value = previousFallbackReasoningAutoHide
+
+      const parsedException = parseError(exception)
+
+      settingsError.value = parsedException.message
+        || 'Failed to save profile settings'
+    } finally {
+      isSavingSettings.value = false
+    }
+  }
+
   async function setAllowExternalLinks(value: boolean) {
     settingsError.value = null
 
@@ -220,6 +296,7 @@ export function useUserSetting() {
     activeUserId.value = null
     loadedUserId.value = null
     serverReasoningExpanded.value = null
+    serverReasoningAutoHide.value = null
     serverAllowExternalLinks.value = null
     settingsError.value = null
     isLoadingSettings.value = false
@@ -229,12 +306,14 @@ export function useUserSetting() {
   return {
     activeUserId,
     reasoningExpanded,
+    reasoningAutoHide,
     allowExternalLinks,
     isLoadingSettings,
     isSavingSettings,
     settingsError,
     syncForUser,
     setReasoningExpanded,
+    setReasoningAutoHide,
     setAllowExternalLinks,
     clearUserContext,
   }

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -60,6 +60,8 @@ export function getAffectedTests(changedFiles) {
   ]
   const profileSettingsTests = [
     'tests/integration/api/profile-settings.spec.ts',
+    'tests/unit/composables/user-setting.spec.ts',
+    'tests/unit/plugins/user-settings-sync.client.spec.ts',
   ]
 
   const testMappings = [
@@ -150,6 +152,18 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern: /^server\/db\/schemas\/user-settings\.ts$/,
+      tests: profileSettingsTests,
+    },
+    {
+      pattern: /^app\/components\/Chat\/(UrlSources|Reasoning)\.vue$/,
+      tests: profileSettingsTests,
+    },
+    {
+      pattern: /^app\/components\/ChatInput\/ReasoningTrigger\.vue$/,
+      tests: profileSettingsTests,
+    },
+    {
+      pattern: /^app\/plugins\/.*user-settings.*\.ts$/,
       tests: profileSettingsTests,
     },
     {

--- a/server/api/v1/profiles/settings/index.get.ts
+++ b/server/api/v1/profiles/settings/index.get.ts
@@ -11,12 +11,14 @@ export default defineEventHandler(async () => {
     },
     columns: {
       reasoningExpanded: true,
+      reasoningAutoHide: true,
       allowExternalLinks: true,
     },
   })
 
   return {
     reasoningExpanded: settings?.reasoningExpanded ?? false,
+    reasoningAutoHide: settings?.reasoningAutoHide ?? true,
     allowExternalLinks: settings?.allowExternalLinks ?? null,
   }
 })

--- a/server/api/v1/profiles/settings/index.patch.ts
+++ b/server/api/v1/profiles/settings/index.patch.ts
@@ -10,6 +10,7 @@ export default defineEventHandler(async (event) => {
 
   const body = await readValidatedBody(event, z.object({
     reasoningExpanded: z.boolean().optional(),
+    reasoningAutoHide: z.boolean().optional(),
     allowExternalLinks: z.boolean().nullable().optional(),
   }).safeParse)
 
@@ -34,11 +35,16 @@ export default defineEventHandler(async (event) => {
 
   const fieldUpdates: {
     reasoningExpanded?: boolean
+    reasoningAutoHide?: boolean
     allowExternalLinks?: boolean | null
   } = {}
 
   if (body.data.reasoningExpanded !== undefined) {
     fieldUpdates.reasoningExpanded = body.data.reasoningExpanded
+  }
+
+  if (body.data.reasoningAutoHide !== undefined) {
+    fieldUpdates.reasoningAutoHide = body.data.reasoningAutoHide
   }
 
   if ('allowExternalLinks' in body.data) {

--- a/server/db/schemas/user-settings.ts
+++ b/server/db/schemas/user-settings.ts
@@ -18,6 +18,9 @@ export const userSettings = sqliteTable(
     reasoningExpanded: integer({ mode: 'boolean' })
       .notNull()
       .default(false),
+    reasoningAutoHide: integer({ mode: 'boolean' })
+      .notNull()
+      .default(true),
     allowExternalLinks: integer({ mode: 'boolean' }),
   },
   table => [

--- a/tests/integration/api/profile-settings.spec.ts
+++ b/tests/integration/api/profile-settings.spec.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 interface SettingsRecord {
   id: number
   reasoningExpanded: boolean
+  reasoningAutoHide: boolean
+  allowExternalLinks: boolean | null
 }
 
 function createDbMock() {
@@ -13,11 +15,15 @@ function createDbMock() {
   })
   const insertValues = vi.fn().mockImplementation(async (values: {
     userId: number
-    reasoningExpanded: boolean
+    reasoningExpanded?: boolean
+    reasoningAutoHide?: boolean
+    allowExternalLinks?: boolean | null
   }) => {
     currentSettings = {
       id: 1,
-      reasoningExpanded: values.reasoningExpanded,
+      reasoningExpanded: values.reasoningExpanded ?? false,
+      reasoningAutoHide: values.reasoningAutoHide ?? true,
+      allowExternalLinks: values.allowExternalLinks ?? null,
     }
   })
   const insert = vi.fn(() => ({
@@ -27,11 +33,21 @@ function createDbMock() {
     return undefined
   })
   const updateSet = vi.fn().mockImplementation((values: {
-    reasoningExpanded: boolean
+    reasoningExpanded?: boolean
+    reasoningAutoHide?: boolean
+    allowExternalLinks?: boolean | null
   }) => {
     currentSettings = {
       id: 1,
-      reasoningExpanded: values.reasoningExpanded,
+      reasoningExpanded: values.reasoningExpanded
+        ?? currentSettings?.reasoningExpanded
+        ?? false,
+      reasoningAutoHide: values.reasoningAutoHide
+        ?? currentSettings?.reasoningAutoHide
+        ?? true,
+      allowExternalLinks: 'allowExternalLinks' in values
+        ? (values.allowExternalLinks ?? null)
+        : (currentSettings?.allowExternalLinks ?? null),
     }
 
     return {
@@ -141,6 +157,7 @@ describe('profile settings API', () => {
 
     expect(response).toEqual({
       reasoningExpanded: false,
+      reasoningAutoHide: true,
       allowExternalLinks: null,
     })
   })
@@ -183,7 +200,70 @@ describe('profile settings API', () => {
 
     expect(getResponse).toEqual({
       reasoningExpanded: false,
+      reasoningAutoHide: true,
       allowExternalLinks: null,
+    })
+  })
+
+  it('saves and returns reasoningAutoHide', async () => {
+    const getHandler = await getSettingsHandler()
+    const patchHandler = await patchSettingsHandler()
+    const dbMock = createDbMock()
+
+    vi.stubGlobal('useDb', () => dbMock.db)
+    vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue({
+      user: {
+        id: '1',
+      },
+    }))
+
+    const patchResponse = await patchHandler({
+      body: {
+        reasoningAutoHide: false,
+      },
+    } as any)
+
+    expect(patchResponse).toEqual({
+      reasoningAutoHide: false,
+    })
+
+    const getResponse = await getHandler({} as any)
+
+    expect(getResponse).toEqual({
+      reasoningExpanded: false,
+      reasoningAutoHide: false,
+      allowExternalLinks: null,
+    })
+  })
+
+  it('saves and returns allowExternalLinks', async () => {
+    const getHandler = await getSettingsHandler()
+    const patchHandler = await patchSettingsHandler()
+    const dbMock = createDbMock()
+
+    vi.stubGlobal('useDb', () => dbMock.db)
+    vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue({
+      user: {
+        id: '1',
+      },
+    }))
+
+    const patchResponse = await patchHandler({
+      body: {
+        allowExternalLinks: true,
+      },
+    } as any)
+
+    expect(patchResponse).toEqual({
+      allowExternalLinks: true,
+    })
+
+    const getResponse = await getHandler({} as any)
+
+    expect(getResponse).toEqual({
+      reasoningExpanded: false,
+      reasoningAutoHide: true,
+      allowExternalLinks: true,
     })
   })
 

--- a/tests/unit/composables/user-setting.spec.ts
+++ b/tests/unit/composables/user-setting.spec.ts
@@ -22,6 +22,7 @@ describe('useUserSetting', () => {
   it('syncs settings once for the same user and reuses cached value', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       reasoningExpanded: true,
+      reasoningAutoHide: true,
     })
 
     vi.stubGlobal('$fetch', fetchMock)
@@ -49,6 +50,7 @@ describe('useUserSetting', () => {
 
     const fetchMock = vi.fn().mockResolvedValue({
       reasoningExpanded: false,
+      reasoningAutoHide: true,
     })
 
     vi.stubGlobal('$fetch', fetchMock)
@@ -88,9 +90,11 @@ describe('useUserSetting', () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         reasoningExpanded: false,
+        reasoningAutoHide: true,
       })
       .mockResolvedValueOnce({
         reasoningExpanded: true,
+        reasoningAutoHide: true,
       })
 
     vi.stubGlobal('$fetch', fetchMock)
@@ -124,6 +128,7 @@ describe('useUserSetting', () => {
   it('persists setting when authenticated user is active before sync', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       reasoningExpanded: true,
+      reasoningAutoHide: true,
     })
 
     vi.stubGlobal('$fetch', fetchMock)
@@ -155,6 +160,7 @@ describe('useUserSetting', () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         reasoningExpanded: false,
+        reasoningAutoHide: true,
       })
       .mockRejectedValueOnce(new Error('Save failed'))
 
@@ -177,6 +183,216 @@ describe('useUserSetting', () => {
     await savePromise
 
     expect(reasoningExpanded.value).toBe(false)
+    expect(settingsError.value).not.toBeNull()
+  })
+
+  it('uses localStorage fallback of true for reasoningAutoHide before sync', () => {
+    const { reasoningAutoHide } = useUserSetting()
+
+    expect(reasoningAutoHide.value).toBe(true)
+  })
+
+  it('syncs reasoningAutoHide from server response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      reasoningExpanded: false,
+      reasoningAutoHide: false,
+    })
+
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const { syncForUser, reasoningAutoHide } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    expect(reasoningAutoHide.value).toBe(false)
+    expect(localStorage.getItem('settings_reasoning_auto_hide')).toBe(
+      'false',
+    )
+  })
+
+  it('updates reasoningAutoHide without API call for guests', async () => {
+    const fetchMock = vi.fn()
+
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const { reasoningAutoHide, setReasoningAutoHide } = useUserSetting()
+
+    await setReasoningAutoHide(false)
+
+    expect(reasoningAutoHide.value).toBe(false)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('persists reasoningAutoHide for authenticated users', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        reasoningExpanded: false,
+        reasoningAutoHide: true,
+      })
+      .mockResolvedValueOnce({
+        reasoningAutoHide: false,
+      })
+
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const {
+      syncForUser,
+      reasoningAutoHide,
+      setReasoningAutoHide,
+    } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    const savePromise = setReasoningAutoHide(false)
+
+    expect(reasoningAutoHide.value).toBe(false)
+    await savePromise
+
+    expect(reasoningAutoHide.value).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/v1/profiles/settings',
+      {
+        method: 'PATCH',
+        body: {
+          reasoningAutoHide: false,
+        },
+      },
+    )
+  })
+
+  it('rolls back optimistic reasoningAutoHide when authenticated save fails', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        reasoningExpanded: false,
+        reasoningAutoHide: true,
+      })
+      .mockRejectedValueOnce(new Error('Save failed'))
+
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const {
+      reasoningAutoHide,
+      settingsError,
+      syncForUser,
+      setReasoningAutoHide,
+    } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    expect(reasoningAutoHide.value).toBe(true)
+
+    const savePromise = setReasoningAutoHide(false)
+
+    expect(reasoningAutoHide.value).toBe(false)
+    await savePromise
+
+    expect(reasoningAutoHide.value).toBe(true)
+    expect(settingsError.value).not.toBeNull()
+  })
+
+  it('defaults allowExternalLinks to false for guests', () => {
+    const { allowExternalLinks } = useUserSetting()
+
+    expect(allowExternalLinks.value).toBe(false)
+  })
+
+  it('syncs allowExternalLinks from server response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      reasoningExpanded: false,
+      reasoningAutoHide: true,
+      allowExternalLinks: true,
+    })
+
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const { syncForUser, allowExternalLinks } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    expect(allowExternalLinks.value).toBe(true)
+  })
+
+  it('does not persist allowExternalLinks for guests', async () => {
+    const fetchMock = vi.fn()
+
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const { allowExternalLinks, setAllowExternalLinks } = useUserSetting()
+
+    await setAllowExternalLinks(true)
+
+    expect(allowExternalLinks.value).toBe(false)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('persists allowExternalLinks for authenticated users', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        reasoningExpanded: false,
+        reasoningAutoHide: true,
+        allowExternalLinks: false,
+      })
+      .mockResolvedValueOnce({
+        allowExternalLinks: true,
+      })
+
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const {
+      syncForUser,
+      allowExternalLinks,
+      setAllowExternalLinks,
+    } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    const savePromise = setAllowExternalLinks(true)
+
+    expect(allowExternalLinks.value).toBe(true)
+    await savePromise
+
+    expect(allowExternalLinks.value).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/v1/profiles/settings',
+      {
+        method: 'PATCH',
+        body: {
+          allowExternalLinks: true,
+        },
+      },
+    )
+  })
+
+  it('rolls back optimistic allowExternalLinks when save fails', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        reasoningExpanded: false,
+        reasoningAutoHide: true,
+        allowExternalLinks: false,
+      })
+      .mockRejectedValueOnce(new Error('Save failed'))
+
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const {
+      allowExternalLinks,
+      settingsError,
+      syncForUser,
+      setAllowExternalLinks,
+    } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    expect(allowExternalLinks.value).toBe(false)
+
+    const savePromise = setAllowExternalLinks(true)
+
+    expect(allowExternalLinks.value).toBe(true)
+    await savePromise
+
+    expect(allowExternalLinks.value).toBe(false)
     expect(settingsError.value).not.toBeNull()
   })
 })

--- a/tests/unit/plugins/user-settings-sync.client.spec.ts
+++ b/tests/unit/plugins/user-settings-sync.client.spec.ts
@@ -30,6 +30,7 @@ describe('user settings sync plugin', () => {
   it('syncs settings immediately when auth user is already available', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       reasoningExpanded: true,
+      reasoningAutoHide: true,
     })
     const { user } = useAuth()
     const { activeUserId, reasoningExpanded } = useUserSetting()
@@ -51,6 +52,7 @@ describe('user settings sync plugin', () => {
   it('clears user context when auth user becomes null', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       reasoningExpanded: false,
+      reasoningAutoHide: true,
     })
     const { user } = useAuth()
     const { activeUserId } = useUserSetting()
@@ -76,6 +78,7 @@ describe('user settings sync plugin', () => {
   it('does not trigger sync again when user id stays unchanged', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       reasoningExpanded: false,
+      reasoningAutoHide: true,
     })
     const { user } = useAuth()
 


### PR DESCRIPTION
Summary

- Adds an Auto-hide toggle to the reasoning dropdown that controls whether the reasoning block collapses automatically when the AI starts streaming its text response (default: on)
- The toggle is only shown when Expanded is enabled — auto-hide has no meaning when reasoning is already hidden
- Setting is persisted per-user in the database (reasoning_auto_hide column, NOT NULL DEFAULT 1) and falls back to localStorage for guests and before sync

What changed

Database — new reasoning_auto_hide column in user_settings (INTEGER NOT NULL DEFAULT 1); all existing rows default to true via SQLite's ALTER TABLE … DEFAULT semantics.

API — GET /api/v1/profiles/settings returns reasoningAutoHide; PATCH accepts and persists it.

Composable (useUserSetting) — follows the same pattern as reasoningExpanded: server state (useState), localStorage fallback (useLocalStorage, default true), computed that never
exposes null, and setReasoningAutoHide with optimistic update + rollback.

Chat/Reasoning.vue — watch(hasTextPart, …) now skips collapsing when reasoningAutoHide is false.

ChatInput/ReasoningTrigger.vue — Auto-hide toggle rendered above Expanded toggle, gated by v-if="reasoningExpanded", with a slide-fade entrance transition.

Tests — integration and unit tests updated with full coverage for reasoningAutoHide (5 new composable tests, 1 new integration test) and the previously missing allowExternalLinks
coverage (5 new composable tests, 1 new integration test); test-affected-check.mjs updated so changes to UrlSources.vue, Reasoning.vue, ReasoningTrigger.vue, or the user-settings
plugin now correctly trigger all three related test suites.

Test plan

- Enable reasoning at any level → dropdown shows Expanded toggle
- Turn Expanded on → Auto-hide toggle appears (default: on); turn it off → Auto-hide disappears
- With Auto-hide on: streaming text collapses the reasoning block
- With Auto-hide off: streaming text leaves the reasoning block expanded
- Refresh — setting persists (localStorage for guests, DB for authenticated users)
- pnpm vitest run tests/integration/api/profile-settings.spec.ts tests/unit/composables/user-setting.spec.ts tests/unit/plugins/user-settings-sync.client.spec.ts
