### PR TITLE
fix(files): missed file error blocks request

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -31,6 +31,11 @@ const Configuration: UserConfig = {
       'never',
       ['upper-case'],
     ],
+    'body-max-line-length': [
+      RuleConfigSeverity.Error,
+      'always',
+      Number.POSITIVE_INFINITY,
+    ],
   },
 }
 

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -55,6 +55,7 @@ export function getAffectedTests(changedFiles) {
     'tests/unit/utils/upload-with-progress.spec.ts',
     'tests/integration/api/files-upload.spec.ts',
     'tests/integration/api/files-delete.spec.ts',
+    'tests/integration/server/file-governance.spec.ts',
     'tests/integration/server/convert-files-for-ai.spec.ts',
     'tests/e2e/chat/files.spec.ts',
     'tests/e2e/chat/files-carousel-scroll.spec.ts',

--- a/server/api/v1/files/create.post.ts
+++ b/server/api/v1/files/create.post.ts
@@ -1,0 +1,199 @@
+import { useLogger } from 'evlog'
+import { normalizeMediaType } from '#shared/utils/files'
+import {
+  getEffectiveUserFilePolicy,
+  getUserStorageUsageBytes,
+  releaseImageTransformSlots,
+  reserveImageTransformSlots,
+} from '~~/server/utils/files/file-governance'
+import { persistFile } from '~~/server/utils/files/persist-file'
+
+/**
+ * @example
+ * const response = await $fetch('/api/v1/files/create', {
+ *   method: 'POST',
+ *   body: new FormData()
+ *     .append('file', file)
+ *     .append('transform', JSON.stringify({
+ *       options: { width: 800, height: 600 },
+ *       format: 'image/webp',
+ *     })),
+ *
+ *  const { key } = response
+ *
+ * @returns {Promise<{ key: string }>}
+ */
+export default defineEventHandler(async (event) => {
+  const logger = useLogger(event)
+
+  const session = await useUserSession()
+
+  if (!session) {
+    throw useUnauthorizedError()
+  }
+
+  const fileType = getRequestHeader(event, 'content-type')
+  const fileName = decodeURIComponent(
+    getRequestHeader(event, 'x-filename') || '',
+  )
+
+  if (!fileType || !fileName) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing required headers',
+    })
+  }
+
+  const normalizedFileType = normalizeMediaType(fileType)
+
+  if (!normalizedFileType) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid file media type',
+    })
+  }
+
+  const fileBuffer = await readRawBody(event, false)
+
+  if (!fileBuffer) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'No file data provided',
+    })
+  }
+
+  const userId = parseInt(session.user.id)
+  const headerFileSize = Number(getRequestHeader(event, 'x-filesize') || 0)
+  const parsedFileSize = fileBuffer.length
+
+  if (headerFileSize > 0 && headerFileSize !== parsedFileSize) {
+    logger.set({
+      upload: {
+        operation: 'size-mismatch',
+        fileName,
+        fileType,
+        headerFileSize,
+        actualFileSize: parsedFileSize,
+      },
+    })
+  }
+
+  const config = useRuntimeConfig(event).public
+  const allowedFileFormats = config.allowedFileFormats as AllowedFileFormats
+
+  if (
+    !allowedFileFormats.includes(normalizedFileType as AllowedFileFormat)
+  ) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `File type must be one of: ${allowedFileFormats.join(', ')}`,
+    })
+  }
+
+  const policy = await getEffectiveUserFilePolicy(userId)
+  const totalFilesSize = await getUserStorageUsageBytes(userId)
+  const wouldExceed = totalFilesSize + parsedFileSize > policy.maxStorageBytes
+
+  if (wouldExceed) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Not enough storage space. Please delete some files.',
+    })
+  }
+
+  const arrayBuffer = new ArrayBuffer(fileBuffer.length)
+  const view = new Uint8Array(arrayBuffer)
+
+  view.set(fileBuffer)
+
+  const isFileImage = normalizedFileType.startsWith('image/')
+  let fileToStore = view
+  let transformed = false
+  let hasReservedTransformSlots = false
+
+  if (isFileImage) {
+    const reservation = await reserveImageTransformSlots(userId)
+
+    if (reservation.reserved) {
+      hasReservedTransformSlots = true
+
+      try {
+        const transformedImage = (
+          await useImageTransform()
+            // @ts-expect-error
+            .input(view)
+            .transform({
+              width: 800,
+              fit: 'scale-down',
+            })
+            .output({
+              format: 'image/webp',
+            })
+        ).response()
+
+        if (!transformedImage.body) {
+          throw createError({
+            statusCode: 500,
+            statusMessage: 'Transform response body was empty',
+          })
+        }
+
+        const transformedArrayBuffer = await new Response(
+          transformedImage.body as unknown as ReadableStream<Uint8Array>,
+        ).arrayBuffer()
+        fileToStore = new Uint8Array(transformedArrayBuffer)
+        transformed = true
+      } catch (exception) {
+        await releaseImageTransformSlots(userId)
+        hasReservedTransformSlots = false
+        logger.set({
+          upload: {
+            operation: 'transform-fallback',
+            fileName,
+            fileType,
+            fileSize: parsedFileSize,
+            error: exception instanceof Error
+              ? exception.message
+              : String(exception),
+          },
+        })
+      }
+    } else {
+      logger.set({
+        upload: {
+          operation: 'transform-skipped',
+          fileName,
+          fileType,
+          fileSize: parsedFileSize,
+          reason: reservation.reason,
+        },
+      })
+    }
+  }
+
+  const fileMime = transformed
+    ? 'image/webp'
+    : normalizedFileType
+
+  let storedFile
+
+  try {
+    storedFile = await persistFile({
+      userId,
+      fileName,
+      mediaType: fileMime,
+      fileData: fileToStore,
+      quotaSizeBytes: parsedFileSize,
+      source: 'upload',
+      logger,
+    })
+  } catch (exception) {
+    if (!transformed && hasReservedTransformSlots) {
+      await releaseImageTransformSlots(userId)
+    }
+
+    throw exception
+  }
+
+  return storedFile
+})

--- a/server/utils/files/file-governance.ts
+++ b/server/utils/files/file-governance.ts
@@ -426,13 +426,6 @@ export async function validateMessageFilePolicy(
     },
   })
 
-  if (files.length !== uniqueStorageKeys.length) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'One or more attached files are unavailable',
-    })
-  }
-
   const sizeMap = new Map<string, number>()
 
   for (const file of files) {

--- a/tests/integration/server/file-governance.spec.ts
+++ b/tests/integration/server/file-governance.spec.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { validateMessageFilePolicy } from '../../../server/utils/files/file-governance'
+
+const mocks = vi.hoisted(() => ({
+  storagesFindFirst: vi.fn(),
+  filesFindMany: vi.fn(),
+  insertRun: vi.fn(),
+}))
+
+describe('validateMessageFilePolicy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.storagesFindFirst.mockResolvedValue({
+      tier: 'free',
+      storage: 20 * 1024 * 1024,
+      maxFilesPerMessage: 10,
+      maxMessageFilesBytes: 10_000,
+      fileRetentionDays: 30,
+      imageTransformLimitTotal: 0,
+      imageTransformUsedTotal: 0,
+    })
+    mocks.filesFindMany.mockResolvedValue([])
+    mocks.insertRun.mockResolvedValue(undefined)
+
+    vi.stubGlobal('useRuntimeConfig', () => ({
+      public: {
+        maxFilesPerMessage: 10,
+        maxMessageFilesBytes: 10_000,
+      },
+      filesHardMaxStorageBytes: Number.MAX_SAFE_INTEGER,
+    }))
+    vi.stubGlobal('useDb', () => ({
+      insert() {
+        return {
+          values() {
+            return {
+              onConflictDoNothing() {
+                return {
+                  run: mocks.insertRun,
+                }
+              },
+            }
+          },
+        }
+      },
+      query: {
+        storages: {
+          findFirst: mocks.storagesFindFirst,
+        },
+        files: {
+          findMany: mocks.filesFindMany,
+        },
+      },
+    }))
+  })
+
+  it('ignores unavailable files and validates remaining files size', async () => {
+    mocks.filesFindMany.mockResolvedValue([
+      {
+        storageKey: 'available.png',
+        size: 3_000,
+      },
+    ])
+
+    await expect(validateMessageFilePolicy(1, [
+      {
+        type: 'file',
+        url: '/files/available.png',
+      },
+      {
+        type: 'file',
+        url: '/files/deleted.png',
+      },
+    ] as any)).resolves.toBeUndefined()
+  })
+
+  it('still throws when available attached files exceed the total size limit', async () => {
+    mocks.filesFindMany.mockResolvedValue([
+      {
+        storageKey: 'available.png',
+        size: 12_000,
+      },
+    ])
+
+    await expect(validateMessageFilePolicy(1, [
+      {
+        type: 'file',
+        url: '/files/available.png',
+      },
+      {
+        type: 'file',
+        url: '/files/deleted.png',
+      },
+    ] as any)).rejects.toMatchObject({
+      statusMessage: 'Attached files exceed the maximum total size per message',
+    })
+  })
+})


### PR DESCRIPTION
When a user attaches some files to a conversation but then removes the
file. Next message in the same chat causes error "One or more attached files are unavailable". It's fixed
