### PR TITLE
fix(projects): context fixed for new chats

### DIFF
--- a/app/pages/chats/[slug].vue
+++ b/app/pages/chats/[slug].vue
@@ -20,7 +20,13 @@
       />
       <ClientOnly>
         <template #fallback>
-          <ChatSkeleton :messages-length="chatSdk.messages.length" />
+          <div
+            :class="{
+              'mt-3': projectInstructionsText || projectMemoryText,
+            }"
+          >
+            <ChatSkeleton :messages-length="chatSdk.messages.length" />
+          </div>
         </template>
       </ClientOnly>
       <div

--- a/app/pages/chats/new.vue
+++ b/app/pages/chats/new.vue
@@ -1,5 +1,12 @@
 <template>
   <ChatContainer>
+    <ChatProjectInstructions
+      v-if="projectInstructionsText || projectMemoryText"
+      :project-id="projectContext?.id || null"
+      :project-name="projectContext?.name || 'Project'"
+      :instructions="projectInstructionsText"
+      :memory="projectMemoryText"
+    />
     <ChatMessage
       role="assistant"
       :hide-assistant-avatar-on-mobile="false"
@@ -67,19 +74,68 @@ const routeProjectId = computed<string | null>(() => {
   return parseRouteProjectId(route.query.projectId)
 })
 
+interface ProjectDetails {
+  id: string
+  name: string
+  instructions: string | null
+  memory: string | null
+  memoryStatus:
+    | 'idle'
+    | 'stale'
+    | 'refreshing'
+    | 'ready'
+    | 'failed'
+    | 'unavailable'
+    | 'disabled'
+}
+
 const projectId = shallowRef<string | null>(routeProjectId.value)
 const projectContext = useState<{ id: string, name: string } | null>(
   'chats-new:project-context',
   () => null,
 )
+const projectInstructions = useState<string | null | undefined>(
+  'chats-new:project-instructions',
+  () => undefined,
+)
+const projectMemory = useState<string | null>(
+  'chats-new:project-memory',
+  () => null,
+)
+const projectMemoryStatus = useState<ProjectDetails['memoryStatus']>(
+  'chats-new:project-memory-status',
+  () => 'idle',
+)
+
+const projectInstructionsText = computed(() => {
+  const instructions = projectInstructions.value?.trim()
+
+  return instructions || null
+})
+
+const projectMemoryText = computed(() => {
+  if (projectMemoryStatus.value !== 'ready') {
+    return null
+  }
+
+  const memory = projectMemory.value?.trim()
+
+  return memory || null
+})
 
 if (!projectId.value) {
   projectContext.value = null
+  projectInstructions.value = null
+  projectMemory.value = null
+  projectMemoryStatus.value = 'idle'
 } else if (projectContext.value?.id !== projectId.value) {
   projectContext.value = {
     id: projectId.value,
     name: 'Project',
   }
+  projectInstructions.value = undefined
+  projectMemory.value = null
+  projectMemoryStatus.value = 'stale'
 }
 
 reasoning.value = normalizeReasoningLevel(reasoning.value)
@@ -109,6 +165,9 @@ function updateProjectQuery(
 function clearProject() {
   projectId.value = null
   projectContext.value = null
+  projectInstructions.value = null
+  projectMemory.value = null
+  projectMemoryStatus.value = 'idle'
 
   updateProjectQuery(null)
 }
@@ -126,6 +185,9 @@ async function syncProjectContext(
   if (!nextProjectId) {
     if (canApply()) {
       projectContext.value = null
+      projectInstructions.value = null
+      projectMemory.value = null
+      projectMemoryStatus.value = 'idle'
     }
 
     return
@@ -134,6 +196,7 @@ async function syncProjectContext(
   if (
     projectContext.value?.id === nextProjectId
     && projectContext.value.name !== 'Project'
+    && projectInstructions.value !== undefined
   ) {
     return
   }
@@ -141,8 +204,13 @@ async function syncProjectContext(
   if (canApply()) {
     projectContext.value = {
       id: nextProjectId,
-      name: 'Project',
+      name: projectContext.value?.id === nextProjectId
+        ? projectContext.value.name
+        : 'Project',
     }
+    projectInstructions.value = undefined
+    projectMemory.value = null
+    projectMemoryStatus.value = 'stale'
   }
 
   try {
@@ -156,6 +224,11 @@ async function syncProjectContext(
       id: project.id,
       name: project.name,
     }
+    projectInstructions.value = (project as ProjectDetails).instructions ?? null
+    projectMemory.value = (project as ProjectDetails).memory ?? null
+    projectMemoryStatus.value = (
+      project as ProjectDetails
+    ).memoryStatus ?? 'idle'
   } catch (exception) {
     if (!canApply()) {
       return
@@ -210,6 +283,11 @@ function onProjectPickerSubmit(payload: {
       name: payload.projectName || 'Project',
     }
     : null
+  projectInstructions.value = payload.projectId
+    ? undefined
+    : null
+  projectMemory.value = null
+  projectMemoryStatus.value = payload.projectId ? 'stale' : 'idle'
 
   updateProjectQuery(payload.projectId)
 }

--- a/server/api/v1/chats/[slug]/index.get.ts
+++ b/server/api/v1/chats/[slug]/index.get.ts
@@ -1,3 +1,5 @@
+import { isPersistedMessageRole } from '#shared/utils/chat-message-role'
+
 export default defineEventHandler(async (event) => {
   const params = await getValidatedRouterParams(event, z.object({
     slug: z.ulid(),
@@ -53,9 +55,13 @@ export default defineEventHandler(async (event) => {
 
   return {
     ...chat,
-    messages: chat.messages.map(message => ({
-      ...message,
-      id: message.publicId ?? message.id,
-    })),
+    messages: chat.messages
+      .filter((message) => {
+        return isPersistedMessageRole(message.role)
+      })
+      .map(message => ({
+        ...message,
+        id: message.publicId ?? message.id,
+      })),
   }
 })

--- a/server/api/v1/chats/[slug]/index.post.ts
+++ b/server/api/v1/chats/[slug]/index.post.ts
@@ -2,6 +2,7 @@ import type { LanguageModel, UIMessage } from 'ai'
 import type { SharedV2ProviderOptions } from '@ai-sdk/provider'
 import type { H3Event } from 'h3'
 import type { ChatErrorPayload } from '#shared/types/chat-errors.d'
+import { isPersistedMessageRole } from '#shared/utils/chat-message-role'
 import type { FormattedTools } from '~~/server/types/tools.d'
 import { useLogger, createError, log } from 'evlog'
 import { createAILogger } from 'evlog/ai'
@@ -24,7 +25,7 @@ import {
   sanitizeMessagesForModelContext,
 } from '~~/server/utils/files/assistant-files'
 import { resolveDataUrlsInModelMessages } from '~~/server/utils/files/resolve-data-urls'
-import { buildProjectInstructionsMessage } from '~~/server/utils/projects/instructions'
+import { buildProjectSystemPrompt } from '~~/server/utils/projects/instructions'
 import { markProjectsMemoryStale } from '~~/server/utils/projects/memory'
 
 export default defineEventHandler(async (event) => {
@@ -48,7 +49,7 @@ export default defineEventHandler(async (event) => {
     messages: z.array(
       z.object({
         id: z.string().nonempty(),
-        role: z.enum(['system', 'user', 'assistant']),
+        role: z.enum(['user', 'assistant']),
         createdAt: z.coerce.date().optional(),
         annotations: z.array(z.string()).optional(),
         parts: z.array(z.any()),
@@ -141,30 +142,29 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const previousMessages = chat.messages.map(message => ({
-    id: message.publicId ?? message.id,
-    role: message.role,
-    parts: message.parts,
-    createdAt: message.createdAt,
-    tools: message.tools,
-    reasoning: message.reasoning,
-  }))
+  const previousMessages = chat.messages
+    .filter((message) => {
+      return isPersistedMessageRole(message.role)
+    })
+    .map(message => ({
+      id: message.publicId ?? message.id,
+      role: message.role,
+      parts: message.parts,
+      createdAt: message.createdAt,
+      tools: message.tools,
+      reasoning: message.reasoning,
+    }))
 
   const allMessages = [...previousMessages, newMessage]
   const modelContextMessages = sanitizeMessagesForModelContext(allMessages)
-  const projectInstructionsMessage = buildProjectInstructionsMessage(
-    chat.project
-      ? {
-        name: chat.project.name,
-        instructions: chat.project.instructions,
-        memory: chat.project.memory,
-        memoryStatus: chat.project.memoryStatus,
-      }
-      : null,
-  )
-  const contextMessages = projectInstructionsMessage
-    ? [projectInstructionsMessage, ...modelContextMessages]
-    : modelContextMessages
+  const projectSystemPrompt = buildProjectSystemPrompt(chat.project
+    ? {
+      name: chat.project.name,
+      instructions: chat.project.instructions,
+      memory: chat.project.memory,
+      memoryStatus: chat.project.memoryStatus,
+    }
+    : null)
 
   if (!newMessage.parts || newMessage.parts.length === 0) {
     throw createError({
@@ -181,7 +181,7 @@ export default defineEventHandler(async (event) => {
   const {
     messages: messagesForAI,
     missingFiles,
-  } = await convertFilesForAI(contextMessages)
+  } = await convertFilesForAI(modelContextMessages)
 
   logger.set({
     filesCount: newMessage.parts.filter(part => part.type === 'file').length,
@@ -393,6 +393,8 @@ export default defineEventHandler(async (event) => {
       try {
         result = streamText({
           model: ai.wrap(instance),
+          system: projectSystemPrompt || undefined,
+          allowSystemInMessages: false,
           messages: resolveDataUrlsInModelMessages(
             await convertToModelMessages(messagesForAI),
           ),

--- a/server/api/v1/chats/[slug]/title.patch.ts
+++ b/server/api/v1/chats/[slug]/title.patch.ts
@@ -1,4 +1,3 @@
-import { isPersistedMessageRole } from '#shared/utils/chat-message-role'
 import { eq } from 'drizzle-orm'
 import * as schema from '~~/server/db/schema'
 
@@ -49,11 +48,14 @@ export default defineEventHandler(async (event) => {
     },
     with: {
       messages: {
+        limit: 1,
+        where(messages, { eq }) {
+          return eq(messages.role, 'user')
+        },
         orderBy(messages, { asc }) {
           return asc(messages.createdAt)
         },
         columns: {
-          role: true,
           parts: true,
         },
       },
@@ -73,10 +75,7 @@ export default defineEventHandler(async (event) => {
 
   const { provider, model } = useChatProvider(body.data.model)
 
-  const initialMessage = chat.messages.find((message) => {
-    return isPersistedMessageRole(message.role)
-      && message.role === 'user'
-  })
+  const initialMessage = chat.messages[0]
 
   if (!initialMessage) {
     return null

--- a/server/api/v1/chats/[slug]/title.patch.ts
+++ b/server/api/v1/chats/[slug]/title.patch.ts
@@ -1,3 +1,4 @@
+import { isPersistedMessageRole } from '#shared/utils/chat-message-role'
 import { eq } from 'drizzle-orm'
 import * as schema from '~~/server/db/schema'
 
@@ -48,11 +49,11 @@ export default defineEventHandler(async (event) => {
     },
     with: {
       messages: {
-        limit: 1,
         orderBy(messages, { asc }) {
           return asc(messages.createdAt)
         },
         columns: {
+          role: true,
           parts: true,
         },
       },
@@ -72,12 +73,17 @@ export default defineEventHandler(async (event) => {
 
   const { provider, model } = useChatProvider(body.data.model)
 
-  if (!chat.messages.length) {
+  const initialMessage = chat.messages.find((message) => {
+    return isPersistedMessageRole(message.role)
+      && message.role === 'user'
+  })
+
+  if (!initialMessage) {
     return null
   }
 
   // @ts-expect-error
-  const initialMessages = chat.messages[0]!.parts?.[0]?.text as string
+  const initialMessages = initialMessage.parts?.[0]?.text as string
   let title = ''
 
   switch (provider.id) {

--- a/server/api/v1/chats/branch/index.post.ts
+++ b/server/api/v1/chats/branch/index.post.ts
@@ -1,3 +1,4 @@
+import { isPersistedMessageRole } from '#shared/utils/chat-message-role'
 import type { BatchItem } from 'drizzle-orm/batch'
 import * as schema from '~~/server/db/schema'
 import { refreshProjectActivityAt } from '~~/server/utils/projects/activity'
@@ -61,7 +62,10 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const branchIndex = chat.messages.findIndex((message) => {
+  const persistedMessages = chat.messages.filter((message) => {
+    return isPersistedMessageRole(message.role)
+  })
+  const branchIndex = persistedMessages.findIndex((message) => {
     return message.publicId === body.data.messageId
       || message.id === body.data.messageId
   })
@@ -73,7 +77,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const messagesToCopy = chat.messages.slice(0, branchIndex + 1)
+  const messagesToCopy = persistedMessages.slice(0, branchIndex + 1)
 
   const title = chat.title
     ? `Branch: ${chat.title.replace(/Branch: /g, '')}`

--- a/server/db/schemas/chats.ts
+++ b/server/db/schemas/chats.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from 'ai'
+import { persistedMessageRoles } from '#shared/utils/chat-message-role'
 import { relations, sql } from 'drizzle-orm'
 import {
   sqliteTable, text, integer, uniqueIndex, index,
@@ -42,7 +43,7 @@ export const messages = sqliteTable(
     chatId: publicId()
       .notNull()
       .references(() => chats.id, { onDelete: 'cascade' }),
-    role: text({ enum: ['system', 'user', 'assistant'] }).notNull(),
+    role: text({ enum: persistedMessageRoles }).notNull(),
     parts: text({ mode: 'json' })
       .notNull()
       .$type<UIMessage['parts']>()

--- a/server/utils/chats/title.ts
+++ b/server/utils/chats/title.ts
@@ -14,11 +14,9 @@ export async function useChatTitle(
 
   const { text } = await generateText({
     model,
+    system: instructions.join('.\n -'),
+    allowSystemInMessages: false,
     messages: [
-      {
-        role: 'system',
-        content: instructions.join('.\n -'),
-      },
       {
         role: 'user',
         content: message,

--- a/server/utils/projects/instructions.ts
+++ b/server/utils/projects/instructions.ts
@@ -1,4 +1,3 @@
-import type { UIMessage } from 'ai'
 import type { ProjectMemoryStatus } from '#shared/types/projects.d'
 
 interface ProjectInstructionsContext {
@@ -8,9 +7,9 @@ interface ProjectInstructionsContext {
   memoryStatus?: ProjectMemoryStatus | null
 }
 
-export function buildProjectInstructionsMessage(
+export function buildProjectSystemPrompt(
   project: ProjectInstructionsContext | null,
-): UIMessage | null {
+): string | null {
   const instructions = project?.instructions?.trim()
   const memory = project?.memory?.trim()
 
@@ -38,14 +37,5 @@ export function buildProjectInstructionsMessage(
     'If earlier messages imply different project-specific context, ignore them and follow the current project.',
   )
 
-  return {
-    id: crypto.randomUUID(),
-    role: 'system',
-    parts: [
-      {
-        type: 'text',
-        text: sections.join('\n\n'),
-      },
-    ],
-  }
+  return sections.join('\n\n')
 }

--- a/server/utils/projects/memory.ts
+++ b/server/utils/projects/memory.ts
@@ -1,5 +1,6 @@
 import type { LanguageModel, UIMessage } from 'ai'
 import type { ProjectMemoryStatus } from '#shared/types/projects.d'
+import { isPersistedMessageRole } from '#shared/utils/chat-message-role'
 import { and, eq, ne } from 'drizzle-orm'
 import { generateText } from 'ai'
 import { createError } from 'evlog'
@@ -306,20 +307,18 @@ async function refreshChatProjectMemorySummary(
 
   const { text } = await generateText({
     model,
+    system: [
+      'Summarize only durable project memory from this chat.',
+      'Use a concise structured memo with these sections when relevant:',
+      'Purpose & context, Actual state, Key learnings and principles, Approach & patterns, Tools and resources used.',
+      'Include stable goals, preferences, constraints, decisions, conventions, and durable workflow context.',
+      'Treat tools and resources as high-level references only, not exhaustive logs.',
+      'If nothing durable exists, respond with NONE.',
+      'Exclude temporary task status, one-off troubleshooting, short-lived details, and raw link dumps.',
+      'Return plain text only and keep it concise.',
+    ].join(' '),
+    allowSystemInMessages: false,
     messages: [
-      {
-        role: 'system',
-        content: [
-          'Summarize only durable project memory from this chat.',
-          'Use a concise structured memo with these sections when relevant:',
-          'Purpose & context, Actual state, Key learnings and principles, Approach & patterns, Tools and resources used.',
-          'Include stable goals, preferences, constraints, decisions, conventions, and durable workflow context.',
-          'Treat tools and resources as high-level references only, not exhaustive logs.',
-          'If nothing durable exists, respond with NONE.',
-          'Exclude temporary task status, one-off troubleshooting, short-lived details, and raw link dumps.',
-          'Return plain text only and keep it concise.',
-        ].join(' '),
-      },
       {
         role: 'user',
         content: transcript,
@@ -346,20 +345,18 @@ async function synthesizeProjectMemory(
 ) {
   const { text } = await generateText({
     model,
+    system: [
+      `You are maintaining durable memory for the project "${projectName}".`,
+      'Merge the provided chat summaries into one concise structured memo.',
+      'Use these sections when they have durable content: Purpose & context, Actual state, Key learnings and principles, Approach & patterns, Tools and resources used.',
+      'Keep only stable goals, preferences, constraints, decisions, conventions, and durable workflow context.',
+      'Tools and resources used must be high-level references only, not exhaustive logs or raw URL dumps.',
+      'Deduplicate aggressively and remove stale or temporary details.',
+      'If there is no durable memory, respond with NONE.',
+      'Return plain text only.',
+    ].join(' '),
+    allowSystemInMessages: false,
     messages: [
-      {
-        role: 'system',
-        content: [
-          `You are maintaining durable memory for the project "${projectName}".`,
-          'Merge the provided chat summaries into one concise structured memo.',
-          'Use these sections when they have durable content: Purpose & context, Actual state, Key learnings and principles, Approach & patterns, Tools and resources used.',
-          'Keep only stable goals, preferences, constraints, decisions, conventions, and durable workflow context.',
-          'Tools and resources used must be high-level references only, not exhaustive logs or raw URL dumps.',
-          'Deduplicate aggressively and remove stale or temporary details.',
-          'If there is no durable memory, respond with NONE.',
-          'Return plain text only.',
-        ].join(' '),
-      },
       {
         role: 'user',
         content: summaries
@@ -482,6 +479,10 @@ function toChatTranscript(
   const lines: string[] = []
 
   for (const message of messages) {
+    if (!isPersistedMessageRole(message.role)) {
+      continue
+    }
+
     const text = toMessageText(message.parts)
 
     if (!text) {
@@ -500,6 +501,10 @@ function getLatestMessageCreatedAt(
   let latestMessageCreatedAt: Date | null = null
 
   for (const message of messages) {
+    if (!isPersistedMessageRole(message.role)) {
+      continue
+    }
+
     if (!message.createdAt) {
       continue
     }

--- a/shared/utils/chat-message-role.ts
+++ b/shared/utils/chat-message-role.ts
@@ -1,0 +1,11 @@
+export const persistedMessageRoles = ['user', 'assistant'] as const
+
+export type PersistedMessageRole = typeof persistedMessageRoles[number]
+
+export function isPersistedMessageRole(
+  role: string,
+): role is PersistedMessageRole {
+  return persistedMessageRoles.includes(
+    role as PersistedMessageRole,
+  )
+}

--- a/tests/integration/api/chats-project-instructions.spec.ts
+++ b/tests/integration/api/chats-project-instructions.spec.ts
@@ -273,7 +273,7 @@ describe('chat project instructions', () => {
     })))
   })
 
-  it('prepends project instructions to model context without persisting them', async () => {
+  it('passes project instructions via system prompt without persisting them', async () => {
     const handler = await getHandler()
     const { db, insertValues } = createDb({
       id: 'chat-1',
@@ -303,16 +303,13 @@ describe('chat project instructions', () => {
     const convertMessages = mocks.convertFilesForAICalls[0] as Array<any>
 
     expect(convertMessages[0]).toMatchObject({
-      role: 'system',
-      parts: [
-        {
-          type: 'text',
-        },
-      ],
+      role: 'user',
     })
-    expect(convertMessages[0]?.parts[0]?.text).toContain(
-      'Stay focused on milestone decisions',
-    )
+    expect(mocks.streamTextCalls[0]).toMatchObject({
+      system: expect.stringContaining(
+        'Stay focused on milestone decisions',
+      ),
+    })
     expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({
       role: 'user',
     }))
@@ -326,7 +323,7 @@ describe('chat project instructions', () => {
     )
   })
 
-  it('does not prepend a system message when the project has no instructions', async () => {
+  it('does not set a system prompt when the project has no instructions', async () => {
     const handler = await getHandler()
     const { db } = createDb({
       id: 'chat-1',
@@ -361,7 +358,7 @@ describe('chat project instructions', () => {
     })
   })
 
-  it('prepends ready project memory to model context', async () => {
+  it('passes ready project memory via system prompt', async () => {
     const handler = await getHandler()
     const { db } = createDb({
       id: 'chat-1',
@@ -390,9 +387,14 @@ describe('chat project instructions', () => {
 
     const convertMessages = mocks.convertFilesForAICalls[0] as Array<any>
 
-    expect(convertMessages[0]?.parts[0]?.text).toContain('Project memory:')
-    expect(convertMessages[0]?.parts[0]?.text).toContain(
-      'milestone-based updates',
-    )
+    expect(convertMessages[0]).toMatchObject({
+      role: 'user',
+    })
+    expect(mocks.streamTextCalls[0]).toMatchObject({
+      system: expect.stringContaining('Project memory:'),
+    })
+    expect(mocks.streamTextCalls[0]).toMatchObject({
+      system: expect.stringContaining('milestone-based updates'),
+    })
   })
 })

--- a/tests/setup/fixtures/messages.ts
+++ b/tests/setup/fixtures/messages.ts
@@ -4,7 +4,7 @@
 
 export interface TestMessage {
   id: string
-  role: 'user' | 'assistant' | 'system'
+  role: 'user' | 'assistant'
   content: string
   createdAt: Date
 }
@@ -31,11 +31,6 @@ export const testMessages = {
     id: 'msg-assistant-1',
     role: 'assistant',
     content: 'I can help you with various tasks. What do you need?',
-  }),
-  systemMessage: createMockMessage({
-    id: 'msg-system-1',
-    role: 'system',
-    content: 'You are a helpful assistant.',
   }),
 }
 

--- a/tests/unit/pages/chats-new.spec.ts
+++ b/tests/unit/pages/chats-new.spec.ts
@@ -98,6 +98,14 @@ describe('chats new page', () => {
           ChatContainer: {
             template: '<div><slot /></div>',
           },
+          ChatProjectInstructions: {
+            props: ['instructions', 'memory'],
+            template: `
+              <div data-testid="project-instructions">
+                {{ instructions || '' }}|{{ memory || '' }}
+              </div>
+            `,
+          },
           ChatMessage: {
             template: '<div><slot /></div>',
           },
@@ -164,6 +172,80 @@ describe('chats new page', () => {
 
     expect(wrapper.get('[data-testid="project-context"]').text()).toBe(
       'project-b|Project B',
+    )
+  })
+
+  it('shows project instructions and memory after selecting a project', async () => {
+    const projectPickerStub = defineComponent({
+      name: 'ChatInputProjectPicker',
+      emits: ['submit'],
+      methods: {
+        open() {},
+        close() {},
+      },
+      template: '<div />',
+    })
+
+    vi.stubGlobal('$fetch', vi.fn(async () => ({
+      id: 'project-a',
+      name: 'Project A',
+      instructions: 'Stay focused on milestones',
+      memory: 'User prefers concise updates.',
+      memoryStatus: 'ready',
+    })))
+
+    wrapper = await mountSuspended(ChatsNewPage, {
+      global: {
+        stubs: {
+          ChatContainer: {
+            template: '<div><slot /></div>',
+          },
+          ChatProjectInstructions: {
+            props: ['instructions', 'memory'],
+            template: `
+              <div data-testid="project-instructions">
+                {{ instructions || '' }}|{{ memory || '' }}
+              </div>
+            `,
+          },
+          ChatMessage: {
+            template: '<div><slot /></div>',
+          },
+          LazyBackgroundLogo: true,
+          ChatInput: {
+            props: ['projectContext'],
+            template: `
+              <div data-testid="project-context">
+                {{ projectContext?.id }}|{{ projectContext?.name }}
+              </div>
+            `,
+          },
+          ChatInputProjectPicker: projectPickerStub,
+          LazyChatInputProjectPicker: projectPickerStub,
+        },
+      },
+    })
+
+    expect(
+      wrapper.find('[data-testid="project-instructions"]').exists(),
+    ).toBe(false)
+
+    wrapper.findComponent({ name: 'ChatInputProjectPicker' }).vm.$emit(
+      'submit',
+      {
+        projectId: 'project-a',
+        projectName: 'Project A',
+      },
+    )
+    await nextTick()
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.get('[data-testid="project-context"]').text()).toBe(
+      'project-a|Project A',
+    )
+    expect(wrapper.get('[data-testid="project-instructions"]').text()).toBe(
+      'Stay focused on milestones|User prefers concise updates.',
     )
   })
 })

--- a/tests/unit/utils/project-instructions.spec.ts
+++ b/tests/unit/utils/project-instructions.spec.ts
@@ -1,52 +1,34 @@
 import { describe, expect, it } from 'vitest'
-import { buildProjectInstructionsMessage } from '../../../server/utils/projects/instructions'
+import { buildProjectSystemPrompt } from '../../../server/utils/projects/instructions'
 
 describe('project instructions', () => {
-  it('builds a system message when instructions exist', () => {
-    const message = buildProjectInstructionsMessage({
+  it('builds a system prompt when instructions exist', () => {
+    const prompt = buildProjectSystemPrompt({
       name: 'Roadmap',
       instructions: 'Stay focused on milestones',
     })
 
-    expect(message).toMatchObject({
-      role: 'system',
-      parts: [
-        {
-          type: 'text',
-        },
-      ],
-    })
-    expect(message?.parts[0]).toMatchObject({
-      text: expect.stringContaining('Current project: Roadmap'),
-    })
-    expect(message?.parts[0]).toMatchObject({
-      text: expect.stringContaining('Stay focused on milestones'),
-    })
+    expect(prompt).toContain('Current project: Roadmap')
+    expect(prompt).toContain('Stay focused on milestones')
   })
 
-  it('includes ready project memory in the system message', () => {
-    const message = buildProjectInstructionsMessage({
+  it('includes ready project memory in the system prompt', () => {
+    const prompt = buildProjectSystemPrompt({
       name: 'Roadmap',
       instructions: null,
       memory: 'User prefers milestone-based plans and concise tradeoff notes.',
       memoryStatus: 'ready',
     })
 
-    expect(message?.parts[0]).toMatchObject({
-      text: expect.stringContaining('Project memory:'),
-    })
-    expect(message?.parts[0]).toMatchObject({
-      text: expect.stringContaining('milestone-based plans'),
-    })
-    expect(message?.parts[0]).toMatchObject({
-      text: expect.stringContaining(
-        'Project memory is secondary background context only.',
-      ),
-    })
+    expect(prompt).toContain('Project memory:')
+    expect(prompt).toContain('milestone-based plans')
+    expect(prompt).toContain(
+      'Project memory is secondary background context only.',
+    )
   })
 
   it('returns null when instructions are empty', () => {
-    expect(buildProjectInstructionsMessage({
+    expect(buildProjectSystemPrompt({
       name: 'Roadmap',
       instructions: '   ',
     })).toBeNull()


### PR DESCRIPTION
- move project context from synthetic chat messages to top-level
AI SDK system prompts

- disallow `system` chat messages in request payloads and enforce
`allowSystemInMessages: false`

- restrict persisted message roles to `user` and `assistant`, and
ignore non-persisted roles in read/branch/title/memory paths

- show project instructions and ready memory on `/chats/new`
after project preselection or picker changes

- fix loading-only spacing below the project context banner on
`/chats/[slug]`

- update tests for the new system-prompt flow and `/chats/new`
project context UI
