### PR TITLE
fix(chat): replay persisted assistant on disconnect retry (#263)

### DIFF
--- a/docs/issue-263-message-persist-analysis.md
+++ b/docs/issue-263-message-persist-analysis.md
@@ -1,0 +1,166 @@
+# Issue #263 — "The message could not be saved." (message-persist-failed)
+
+## TL;DR
+
+A re-sent message after a dropped stream collided with a `UNIQUE`
+constraint. The first turn fully succeeded **server-side** (both the user
+message and the AI reply were written to the DB), but the customer's iPhone
+Safari never received the finished stream. When the client retried, it
+re-sent the **same** user message id. The server's duplicate-detection guard
+only looked at the *last* persisted message and required it to be a `user`
+row — but after a completed turn the last row is the **assistant**, so the
+guard was blind, the handler re-inserted the user message with an
+already-used `public_id`, and `messages.public_id UNIQUE` threw
+`message-persist-failed`.
+
+This never reproduces on a stable desktop connection because the finished
+stream arrives before any disconnect, so the client never retries and the
+duplicate-insert path is never reached.
+
+---
+
+## Confirmed root cause
+
+`server/api/v1/chats/[slug]/index.post.ts`
+
+- Each turn writes **two** rows that share one `UNIQUE` column,
+  `messages.public_id` (`server/db/schemas/chats.ts:58`):
+  - the **user** row uses `publicId = newMessage.id` (the client-generated
+    ULID, stable across retries),
+  - the **assistant** row uses `publicId = ulid()` (a fresh server ULID).
+- The guard `isDuplicateUserMessage` was anchored on
+  `lastPersistedMessage?.role === 'user'`. After a completed turn the last
+  persisted message is the assistant, so the guard short-circuits to `false`
+  regardless of a matching id.
+- With the guard `false`, the handler calls `insertMessageWithPublicId(...)`
+  with the **existing** client `public_id` → SQLite `UNIQUE constraint
+  failed: messages.public_id` → caught and re-thrown as
+  `message-persist-failed`, `stage = persist-user-message`.
+
+### Production timeline (from the issue logs, 2026-06-22)
+
+| Time (UTC) | Event |
+|---|---|
+| 14:14:31 | `POST /chats/<slug>` → 200. **User row persisted** (`public_id = 01KVQT…3V`). |
+| 14:14:43 | `AI stream completed`, `finishReason=stop`. **Assistant row persisted** server-side. |
+| 14:15:00 | Client beacon → `client-transport`: *"The connection was interrupted before the response finished streaming."* The phone never got the reply. |
+| 14:15:02 | Retry `POST` → **500 `message-persist-failed`** (`persist-user-message`), same `public_id`. |
+| 14:15:06 | Retry again → **500**, same `public_id`. |
+| 14:15:26 | User opens the chat → **sees the real AI reply** (proving both rows were persisted in the first turn). |
+
+The two failed POSTs carry the **identical** `public_id`
+(`01KVQTXGM8WP6ZHD443JT1973V`), proving the client re-sent a stable id rather
+than generating a new one.
+
+---
+
+## Why previous fixes did not catch it
+
+The duplicate-detection logic has been touched four times, and each fix
+addressed an adjacent problem while leaving the guard's *single-last-row,
+role==='user'* shape intact:
+
+| PR | Commit | What it did | Why it missed #263 |
+|---|---|---|---|
+| #139 | `a3ab74a` | Introduced `isDuplicateUserMessage` to stop re-inserting the user message every turn. | Born as a single-last-row + `role==='user'` check; no id check at all yet. |
+| #187 | `94da333` | Aligned SDK and DB message ids — the client ULID now lands in `public_id`. | This is what makes a re-sent id actually **collide**. Added id-equality to the guard, but kept it gated on the last row being a `user`. |
+| #205 | `0a4bf26` | Added structured errors + the `persist-user-message` try/catch that emits the exact `message-persist-failed` signature. Its own review flagged a "publicId duplicate-submission race." | Made the failure **observable**, not **prevented**. |
+| #207 | `36d26b1` | Reverted `insertMessageWithPublicId` to a single atomic insert (fixing an orphan-row risk from #205). | Hardened insert *atomicity*; the broken component was duplicate *detection*. |
+
+**Structural defect, unchanged across all four:** the guard inspected only
+the last persisted message and required it to be a `user` row. Once an
+assistant row exists, it sits last and the guard can never fire for a re-sent
+user id. Every existing duplicate test seeded only a trailing **user**
+message, so CI stayed green through every fix.
+
+---
+
+## Why it happens for the customer but never on your machine
+
+This is a **state-assumption bug exposed by a network race**, not a network
+bug. There is a vulnerability window:
+
+> **Window opens** the instant the assistant row is committed (~14:14:43)
+> **and stays open** until the client either fully receives the stream or
+> gives up. Any *disconnect → retry* inside that window triggers the
+> duplicate-insert.
+
+**The customer's setup lands inside the window; yours never does.**
+
+- **Mobile Safari amplifiers** (all present in this report):
+  1. **Long stream** — `msToFirstChunk` 6.7s, total ~11s. The connection has
+     to stay open far longer than a quick reply.
+  2. **"Make a new photo" flow** — taking a photo foregrounds the camera and
+     backgrounds Safari; iOS aggressively suspends/throttles network for
+     backgrounded tabs.
+  3. **Cellular ⇄ Wi-Fi handoff** and a flaky last mile tear down the
+     in-flight Cloudflare Workers stream.
+  4. **Safari's aggressive idle-connection teardown** kills long-lived
+     streaming responses.
+  In every case the server has *already committed both rows* — the teardown
+  only loses **delivery**, not **persistence**.
+- **Desktop immunity:** a fast, stable wired/Wi-Fi connection receives the
+  finished stream before any disconnect. `onFinish` has the assistant
+  content, the client never retries, and the duplicate-insert branch is never
+  reached. That is precisely the "works on my machine" asymmetry.
+
+The retry itself is a **user-initiated Regenerate** (the AI SDK does **not**
+auto-retry in this configuration). After a transport "Load failed" the
+Regenerate button appears; `regenerate()` drops the trailing assistant error
+stub and re-sends the surviving user message **with its original id**, so the
+`public_id` collides.
+
+---
+
+## The fix
+
+Server-only change in `server/api/v1/chats/[slug]/index.post.ts`. Three
+parts, all preserving the intentional `message-persist-failed` behavior for
+**genuine** DB failures and the #205/#207 atomic-insert fix:
+
+1. **Deterministic order.** Add `orderBy(asc(messages.id))` to the messages
+   relation so persistence order (the model context **and** the
+   user/assistant adjacency) is explicit, not an implicit D1 rowid contract.
+
+2. **Replay the stored reply (the core fix).** Before any model work, scan
+   the persisted history for a user message whose `publicId === newMessage.id`
+   and check whether the **next** persisted message is an assistant. If so,
+   the turn already completed: **replay** the stored assistant back to the
+   client as a UI-message stream (`buildPersistedAssistantReplayChunks`) and
+   return. No model call, **no token recharge, no duplicate assistant row, no
+   re-insert** — exactly the issue's acceptance criterion ("if the AI response
+   was stored, display it without error"). This is unambiguous because the UI
+   only re-sends a completed turn's user id on a disconnect retry; there is no
+   per-message Regenerate that would legitimately want a fresh reply.
+
+3. **Idempotent insert (belt-and-suspenders).** The user-message insert now
+   uses `ON CONFLICT(public_id) DO NOTHING` (still a single atomic statement),
+   so even a concurrent double-retry that slips past the in-memory scan turns
+   a duplicate into a no-op instead of a 500. The assistant insert keeps
+   strict behavior so real DB failures still surface loudly.
+
+### Why it won't happen again
+
+- The reported flow (disconnect after a fully-persisted turn → retry) now
+  hits the **replay** path: no insert at all, so the `UNIQUE` collision is
+  structurally impossible.
+- Any *other* path that re-sends an existing `public_id` (degenerate
+  histories, or a sub-second concurrent double-retry that slips past the
+  in-memory scan) is absorbed by `ON CONFLICT DO NOTHING`.
+- Together: a duplicate `public_id` can **no longer** produce
+  `message-persist-failed`. (One honest residual: in the rare sub-second
+  concurrent-retry window the losing request still streams its own reply, so
+  it can leave a second assistant row — no error, no data loss. Fully
+  serializing that would need a lock/transaction, not worth it for D1 at this
+  probability.)
+
+### Tests added (`tests/integration/api/chats-duplicate-message.spec.ts`)
+
+- Disconnect retry after a fully-persisted turn → **no insert, no model call,
+  replays the stored assistant** (start/text-delta/finish with the stored
+  text and the assistant's `public_id`).
+- Multi-turn chat → replays the assistant **adjacent** to the matched user
+  message, not a later turn.
+- Reasoning gating → reasoning parts are not replayed when `reasoning='off'`.
+- The three pre-existing duplicate tests remain green (the trailing-user
+  re-stamp path is untouched).

--- a/server/api/v1/chats/[slug]/index.post.ts
+++ b/server/api/v1/chats/[slug]/index.post.ts
@@ -1,4 +1,4 @@
-import type { LanguageModel, UIMessage } from 'ai'
+import type { LanguageModel, UIMessage, InferUIMessageChunk } from 'ai'
 import type { SharedV2ProviderOptions } from '@ai-sdk/provider'
 import type { H3Event } from 'h3'
 import type { ChatErrorPayload } from '#shared/types/chat-errors.d'
@@ -113,6 +113,15 @@ export default defineEventHandler(async (event) => {
           reasoning: true,
           createdAt: true,
         },
+        // Persistence order is load-bearing: previousMessages is the model
+        // context AND the basis for detecting whether a re-sent user message
+        // already has a persisted assistant reply (issue #263). id is the
+        // autoincrement integer primary key, so ascending id is insertion
+        // order — making the user/assistant adjacency deterministic instead of
+        // relying on the implicit D1 rowid ordering.
+        orderBy(messages, { asc }) {
+          return asc(messages.id)
+        },
       },
     },
   })
@@ -154,6 +163,62 @@ export default defineEventHandler(async (event) => {
       tools: message.tools,
       reasoning: message.reasoning,
     }))
+
+  // Idempotent-retry guard for issue #263. When the client never receives a
+  // finished stream (a mobile-Safari connection drop, a backgrounded tab, a
+  // flaky last mile) it re-sends the same user message id. If that turn already
+  // fully persisted server-side (user message + assistant reply), re-running
+  // the model would recharge tokens and write a duplicate assistant row, and
+  // re-inserting the user message would collide on messages.public_id (UNIQUE)
+  // — the message-persist-failed reported in #263. Detect the assistant reply
+  // already stored for this exact user message and replay it, so the user sees
+  // the real response with no error and no extra cost.
+  //
+  // This is unambiguous in the current UI: a completed turn's user id is only
+  // ever re-sent by a disconnect retry. The Regenerate button is gated on a
+  // stopped/errored stream (canShowRegenerate -> displayRegenerate), and there
+  // is no per-message regenerate that would legitimately expect a fresh
+  // response for an already-answered message. Revisit this short-circuit if
+  // such a feature is added.
+  const persistedUserIndex = previousMessages.findIndex((message) => {
+    return message.role === 'user' && message.id === newMessage.id
+  })
+  const followingPersistedMessage = persistedUserIndex >= 0
+    ? previousMessages[persistedUserIndex + 1]
+    : undefined
+  const persistedAssistantMessage
+    = followingPersistedMessage?.role === 'assistant'
+      ? followingPersistedMessage
+      : undefined
+
+  if (newMessage.role === 'user' && persistedAssistantMessage) {
+    logger.set({
+      stage: 'replay-persisted-assistant',
+      replayedAssistantPublicId: persistedAssistantMessage.id,
+    })
+
+    return createUIMessageStreamResponse({
+      stream: createUIMessageStream({
+        onError(error) {
+          return JSON.stringify(normalizeChatError({
+            error,
+            event,
+          }))
+        },
+        execute({ writer }) {
+          const replayChunks = buildPersistedAssistantReplayChunks({
+            publicId: persistedAssistantMessage.id,
+            parts: persistedAssistantMessage.parts as UIMessage['parts'],
+            sendReasoning: persistedAssistantMessage.reasoning !== 'off',
+          })
+
+          for (const chunk of replayChunks) {
+            writer.write(chunk)
+          }
+        },
+      }),
+    })
+  }
 
   const allMessages = [...previousMessages, newMessage]
   const modelContextMessages = sanitizeMessagesForModelContext(allMessages)
@@ -224,6 +289,7 @@ export default defineEventHandler(async (event) => {
             reasoning: body.data.reasoning,
           },
           publicId: newMessage.id,
+          ignoreConflict: true,
         })
 
         await db.update(schema.chats)
@@ -600,22 +666,131 @@ export default defineEventHandler(async (event) => {
   })
 })
 
+// Returns the inserted { id, publicId } row, OR `undefined` when
+// `ignoreConflict` is set and the public_id already existed (ON CONFLICT DO
+// NOTHING inserts no row, so `.get()` yields undefined). Callers that pass
+// `ignoreConflict: true` must not assume a row came back.
 async function insertMessageWithPublicId(input: {
   db: ReturnType<typeof useDb>
   values: typeof schema.messages.$inferInsert
   publicId: string
+  ignoreConflict?: boolean
 }) {
-  return await input.db
+  const insert = input.db
     .insert(schema.messages)
     .values({
       ...input.values,
       publicId: input.publicId,
     })
+
+  // Belt-and-suspenders idempotency for issue #263. The in-memory duplicate
+  // scan reads a single chat snapshot, so two near-simultaneous retries of the
+  // same user message (before either commits, and before any assistant reply
+  // exists to replay) could both pass it. ON CONFLICT DO NOTHING keeps this a
+  // single atomic statement (preserving the #205/#207 fix — no insert-then-
+  // update) and guarantees a duplicate public_id can never again surface as a
+  // message-persist-failed 500. It does NOT serialize the racing requests: the
+  // losing one no-ops here and still streams its own assistant, so that rare
+  // window can leave a second assistant row (no error, no data loss) rather
+  // than a 500. Closing that fully would need a lock/transaction, which is not
+  // worth it for D1 at this probability. Scoped to the public_id target so an
+  // unrelated constraint still throws. Only the user-message insert opts in;
+  // the assistant insert keeps strict behavior so a genuine DB failure still
+  // surfaces loudly.
+  const statement = input.ignoreConflict
+    ? insert.onConflictDoNothing({ target: schema.messages.publicId })
+    : insert
+
+  return await statement
     .returning({
       id: schema.messages.id,
       publicId: schema.messages.publicId,
     })
     .get()
+}
+
+// Rebuild a UI message stream from an already-persisted assistant message so a
+// disconnect retry (issue #263) replays the stored reply instead of erroring or
+// re-calling the model. Emits the same chunk vocabulary that
+// result.toUIMessageStream produces, so the client transport reconstructs a
+// normal assistant message with no client changes. The persisted parts already
+// passed through normalizeAssistantParts, so the part vocabulary is bounded; an
+// unmapped part degrades to "reload to see it", never to data loss (the row is
+// intact in D1).
+function buildPersistedAssistantReplayChunks(input: {
+  publicId: string
+  parts: UIMessage['parts']
+  sendReasoning: boolean
+}): InferUIMessageChunk<UIMessage>[] {
+  const chunks: InferUIMessageChunk<UIMessage>[] = [{
+    type: 'start',
+    messageId: input.publicId,
+  }]
+
+  for (const [index, part] of input.parts.entries()) {
+    if (part.type === 'text') {
+      const id = `replay-text-${index}`
+
+      chunks.push(
+        { type: 'text-start', id },
+        { type: 'text-delta', id, delta: part.text },
+        { type: 'text-end', id },
+      )
+
+      continue
+    }
+
+    if (part.type === 'reasoning') {
+      if (!input.sendReasoning || !part.text) {
+        continue
+      }
+
+      const id = `replay-reasoning-${index}`
+
+      chunks.push(
+        { type: 'reasoning-start', id },
+        { type: 'reasoning-delta', id, delta: part.text },
+        { type: 'reasoning-end', id },
+      )
+
+      continue
+    }
+
+    if (part.type === 'source-url') {
+      chunks.push({
+        type: 'source-url',
+        sourceId: part.sourceId,
+        url: part.url,
+        title: part.title,
+      })
+
+      continue
+    }
+
+    if (part.type === 'source-document') {
+      chunks.push({
+        type: 'source-document',
+        sourceId: part.sourceId,
+        mediaType: part.mediaType,
+        title: part.title,
+        filename: part.filename,
+      })
+
+      continue
+    }
+
+    if (part.type === 'file') {
+      chunks.push({
+        type: 'file',
+        url: part.url,
+        mediaType: part.mediaType,
+      })
+    }
+  }
+
+  chunks.push({ type: 'finish' })
+
+  return chunks
 }
 
 async function persistAssistantMessageFromStream(input: {

--- a/tests/integration/api/chats-duplicate-message.spec.ts
+++ b/tests/integration/api/chats-duplicate-message.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { streamText } from 'ai'
 
 function createMockUIMessageStream(messageId: string) {
   return new ReadableStream({
@@ -182,6 +183,11 @@ function createDb(overrides: {
   insertValues.mockImplementation(() => ({
     returning: () => ({
       get: insertGet,
+    }),
+    onConflictDoNothing: () => ({
+      returning: () => ({
+        get: insertGet,
+      }),
     }),
   }))
 
@@ -403,4 +409,208 @@ describe('chat duplicate message detection', () => {
       publicId: 'new-message-id',
     })
   })
+
+  it('replays the stored assistant when the turn already fully persisted (issue #263 disconnect retry)', async () => {
+    const handler = await getHandler()
+    const userMessage = {
+      id: 'db-user-1',
+      publicId: 'user-public-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Question' }],
+      tools: [] as string[],
+      reasoning: 'off',
+      createdAt: new Date('2026-06-22T14:14:31Z'),
+    }
+    const assistantMessage = {
+      id: 'db-assistant-1',
+      publicId: 'assistant-public-1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Stored answer' }],
+      tools: [] as string[],
+      reasoning: 'off',
+      createdAt: new Date('2026-06-22T14:14:43Z'),
+    }
+    const { db, insertValues, updateSet } = createDb({
+      messages: [userMessage, assistantMessage],
+    })
+
+    vi.stubGlobal('useDb', () => db)
+
+    const stream = await handler({
+      params: { slug: '01ARZ3NDEKTSV4RRFFQ69G5FAV' },
+      body: {
+        model: 'gpt-5-mini',
+        tools: [],
+        reasoning: 'off',
+        messages: [{
+          id: 'user-public-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Question' }],
+        }],
+      },
+    } as any)
+
+    const chunks = await collectStreamChunks(stream)
+
+    expect(insertValues).not.toHaveBeenCalled()
+    expect(updateSet).not.toHaveBeenCalled()
+    expect(streamText).not.toHaveBeenCalled()
+    expect(chunks[0]).toEqual({
+      type: 'start',
+      messageId: 'assistant-public-1',
+    })
+    expect(chunks).toContainEqual(expect.objectContaining({
+      type: 'text-delta',
+      delta: 'Stored answer',
+    }))
+    expect(chunks.at(-1)).toEqual({ type: 'finish' })
+  })
+
+  it('replays the assistant adjacent to the matched user message, not a later turn', async () => {
+    const handler = await getHandler()
+    const messages = [
+      {
+        id: 'db-user-1',
+        publicId: 'user-public-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'First question' }],
+        tools: [] as string[],
+        reasoning: 'off',
+        createdAt: new Date('2026-06-22T14:00:00Z'),
+      },
+      {
+        id: 'db-assistant-1',
+        publicId: 'assistant-public-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'First answer' }],
+        tools: [] as string[],
+        reasoning: 'off',
+        createdAt: new Date('2026-06-22T14:00:05Z'),
+      },
+      {
+        id: 'db-user-2',
+        publicId: 'user-public-2',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Second question' }],
+        tools: [] as string[],
+        reasoning: 'off',
+        createdAt: new Date('2026-06-22T14:01:00Z'),
+      },
+      {
+        id: 'db-assistant-2',
+        publicId: 'assistant-public-2',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Second answer' }],
+        tools: [] as string[],
+        reasoning: 'off',
+        createdAt: new Date('2026-06-22T14:01:05Z'),
+      },
+    ]
+    const { db, insertValues } = createDb({ messages })
+
+    vi.stubGlobal('useDb', () => db)
+
+    const stream = await handler({
+      params: { slug: '01ARZ3NDEKTSV4RRFFQ69G5FAV' },
+      body: {
+        model: 'gpt-5-mini',
+        tools: [],
+        reasoning: 'off',
+        messages: [{
+          id: 'user-public-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'First question' }],
+        }],
+      },
+    } as any)
+
+    const chunks = await collectStreamChunks(stream)
+
+    expect(insertValues).not.toHaveBeenCalled()
+    expect(chunks[0]).toEqual({
+      type: 'start',
+      messageId: 'assistant-public-1',
+    })
+    expect(chunks).toContainEqual(expect.objectContaining({
+      type: 'text-delta',
+      delta: 'First answer',
+    }))
+    expect(chunks).not.toContainEqual(expect.objectContaining({
+      type: 'text-delta',
+      delta: 'Second answer',
+    }))
+  })
+
+  it('does not replay reasoning parts when reasoning is off', async () => {
+    const handler = await getHandler()
+    const userMessage = {
+      id: 'db-user-1',
+      publicId: 'user-public-1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'Question' }],
+      tools: [] as string[],
+      reasoning: 'off',
+      createdAt: new Date('2026-06-22T14:14:31Z'),
+    }
+    const assistantMessage = {
+      id: 'db-assistant-1',
+      publicId: 'assistant-public-1',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', text: 'Hidden reasoning' },
+        { type: 'text', text: 'Visible answer' },
+      ],
+      tools: [] as string[],
+      reasoning: 'off',
+      createdAt: new Date('2026-06-22T14:14:43Z'),
+    }
+    const { db } = createDb({
+      messages: [userMessage, assistantMessage],
+    })
+
+    vi.stubGlobal('useDb', () => db)
+
+    const stream = await handler({
+      params: { slug: '01ARZ3NDEKTSV4RRFFQ69G5FAV' },
+      body: {
+        model: 'gpt-5-mini',
+        tools: [],
+        reasoning: 'off',
+        messages: [{
+          id: 'user-public-1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Question' }],
+        }],
+      },
+    } as any)
+
+    const chunks = await collectStreamChunks(stream)
+    const reasoningChunks = chunks.filter((chunk) => {
+      return typeof chunk?.type === 'string'
+        && chunk.type.startsWith('reasoning')
+    })
+
+    expect(reasoningChunks).toHaveLength(0)
+    expect(chunks).toContainEqual(expect.objectContaining({
+      type: 'text-delta',
+      delta: 'Visible answer',
+    }))
+  })
 })
+
+async function collectStreamChunks(stream: any): Promise<any[]> {
+  const reader = stream.getReader()
+  const chunks: any[] = []
+
+  while (true) {
+    const { done, value } = await reader.read()
+
+    if (done) {
+      break
+    }
+
+    chunks.push(value)
+  }
+
+  return chunks
+}

--- a/tests/integration/api/chats-message-id-stream.spec.ts
+++ b/tests/integration/api/chats-message-id-stream.spec.ts
@@ -168,6 +168,11 @@ function createDb() {
     returning: () => ({
       get: insertGet,
     }),
+    onConflictDoNothing: () => ({
+      returning: () => ({
+        get: insertGet,
+      }),
+    }),
   }))
 
   return {

--- a/tests/integration/api/chats-project-instructions.spec.ts
+++ b/tests/integration/api/chats-project-instructions.spec.ts
@@ -203,6 +203,11 @@ function createDb(chat: {
     returning: () => ({
       get: insertGet,
     }),
+    onConflictDoNothing: () => ({
+      returning: () => ({
+        get: insertGet,
+      }),
+    }),
   }))
 
   return {


### PR DESCRIPTION
Body:

Fixes #263 — users on mobile (iPhone Safari) intermittently saw "The message
could not be saved." (`message-persist-failed`) in an existing chat, without
reloading.

Each turn writes two rows sharing the `UNIQUE` `messages.public_id` column: the
user row uses the client message id, the assistant row uses a server ULID. When
the first turn fully persists server-side but the client never receives the
finished stream (connection drop), the client re-sends the same user message
id. The `isDuplicateUserMessage` guard only inspected the *last* persisted
message and required role `user` — but after a completed turn the assistant is
last, so the guard returned false, the user message was re-inserted with an
existing `public_id`, and the `UNIQUE` constraint threw `message-persist-failed`
at `stage=persist-user-message`.

Prior fixes (#139, #187, #205, #207) each addressed an adjacent problem but
never changed the guard's single-last-row / `role==='user'` shape, and every
duplicate test seeded only a trailing user message — so the
assistant-already-persisted case was never covered.

A state-assumption bug exposed by a network race: the window opens when the
assistant row commits and closes when the client receives the stream or gives
up. A stable desktop receives the finished stream first, so no retry fires.
Mobile Safari (backgrounding on the camera flow, flaky last mile, long streams)
lands inside the window.

- **Deterministic order** — `orderBy(asc(messages.id))` on the messages
  relation so persistence order (model context + user/assistant adjacency) is
  explicit, not implicit D1 rowid order.
- **Replay** — when a re-sent user id already has a persisted assistant reply,
  replay it as a UI message stream and return early: no model call, no token
  recharge, no duplicate row, no error.
- **Idempotent insert** — `ON CONFLICT (public_id) DO NOTHING` on the user
  insert (single atomic statement; preserves #205/#207), so a duplicate
  `public_id` can never again produce a 500.

The intentional `message-persist-failed` behaviour for genuine DB failures and
the existing trailing-user duplicate detection are preserved.

- Disconnect retry after a fully-persisted turn → no insert, no model call,
  replays the stored assistant.
- Multi-turn chat → replays the assistant adjacent to the matched user message,
  not a later turn.
- Reasoning parts are not replayed when reasoning is off.
- The three pre-existing duplicate tests stay green.

106/106 affected tests pass; `pnpm run format` and `pnpm run typecheck` clean.

A sub-second *concurrent* double-retry (both passing the in-memory scan before
either commits) can leave a second assistant row — no error, no data loss.
Fully serializing it would need a lock/transaction, not worth it for D1 at that
probability. The reported 500 is structurally eliminated.

See `docs/issue-263-message-persist-analysis.md` for the full analysis.
