### PR TITLE
fix(auth): preserve chat draft and recover cleanly from dead-session 401s

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -64,7 +64,9 @@ async function onException(exception: unknown) {
   if (parsedException.status === 401) {
     const { fetchSession, session } = useAuth()
 
-    await fetchSession()
+    // Bypass the cookie cache so a dead server session is detected here
+    // instead of being masked by a still-cached get-session.
+    await fetchSession({ disableCookieCache: true })
 
     if (!session.value) {
       await navigateTo('/signin')

--- a/app/composables/auth.ts
+++ b/app/composables/auth.ts
@@ -43,8 +43,8 @@ export function useAuth() {
   const session = useState<InferSessionFromClient<BetterAuthClientOptions> | null>('auth:session', () => null)
   const user = useState<User | null>('auth:user', () => null)
   const sessionFetching = import.meta.server
-    ? shallowRef(false)
-    : useState('auth:sessionFetching', () => false)
+    ? shallowRef(0)
+    : useState('auth:sessionFetching', () => 0)
 
   const lastLoginMethod = useState<string | null>('auth:lastLoginMethod', () => null)
 
@@ -68,14 +68,16 @@ export function useAuth() {
   }
 
   async function fetchSession(options?: { disableCookieCache?: boolean }) {
-    // A cache-bypassing refresh is the 401 recovery path: it must always run,
+    // A cache-bypassing refresh is the 401 recovery path and must always run,
     // never no-op behind an in-flight cached fetch, or a stale truthy session
-    // would survive and skip the redirect to /signin.
-    if (sessionFetching.value && !options?.disableCookieCache) {
+    // would survive and skip the redirect to /signin. sessionFetching is an
+    // in-flight counter (not a boolean) so the guard holds until every pending
+    // fetch settles, even when a bypass call overlaps a normal one.
+    if (sessionFetching.value > 0 && !options?.disableCookieCache) {
       return
     }
 
-    sessionFetching.value = true
+    sessionFetching.value++
 
     const fetchId = import.meta.client ? ++latestSessionFetchId : 0
     const query = options?.disableCookieCache
@@ -98,6 +100,14 @@ export function useAuth() {
           query,
         })
 
+        // A transport/server error (offline, flaky cell, captive portal, 5xx)
+        // is NOT an authoritative "no session" — get-session returns 200/null
+        // for an absent session. Preserve the last-known state so a network
+        // blip (e.g. on PWA resume) cannot trigger a false logout.
+        if (result.error) {
+          return
+        }
+
         data = result.data
       }
 
@@ -119,14 +129,11 @@ export function useAuth() {
 
       return data
     } catch {
-      if (import.meta.client && fetchId !== latestSessionFetchId) {
-        return
-      }
-
-      session.value = null
-      user.value = null
+      // Network/transport failure (thrown): transient, not a dead session —
+      // leave the last-known session intact rather than forcing a logout.
+      return
     } finally {
-      sessionFetching.value = false
+      sessionFetching.value--
     }
   }
 
@@ -152,11 +159,21 @@ export function useAuth() {
     }: {
       redirectTo?: RouteLocationRaw
     } = {}) {
+      const draftBackup = useChatDraftBackup()
+      const preferenceStorage = usePreferenceStorage()
+
       await client.signOut({
         fetchOptions: {
           async onSuccess() {
             session.value = null
             user.value = null
+
+            // Discard the unsent /chats/new draft on sign-out so it cannot
+            // leak to the next user on a shared device — the backup lives
+            // under the 'necessary' category (never auto-cleaned) and
+            // chat_input persists whenever 'preferences' consent is granted.
+            draftBackup.clear()
+            preferenceStorage.removeItem('chat_input')
 
             if (!redirectTo) {
               return

--- a/app/composables/auth.ts
+++ b/app/composables/auth.ts
@@ -15,6 +15,12 @@ interface RuntimeAuthConfig {
   redirectGuestTo: RouteLocationRaw | string
 }
 
+// Client-only fetch sequencing: when a cache-bypassing recovery fetch overlaps
+// a normal (possibly cookie-cached) fetch already in flight, only the most
+// recently started fetch may write session state — so a stale truthy result
+// cannot resurrect a session the bypass call just found dead.
+let latestSessionFetchId = 0
+
 export function useAuth() {
   const headers = import.meta.server ? useRequestHeaders() : undefined
 
@@ -61,12 +67,20 @@ export function useAuth() {
     }
   }
 
-  async function fetchSession() {
-    if (sessionFetching.value) {
+  async function fetchSession(options?: { disableCookieCache?: boolean }) {
+    // A cache-bypassing refresh is the 401 recovery path: it must always run,
+    // never no-op behind an in-flight cached fetch, or a stale truthy session
+    // would survive and skip the redirect to /signin.
+    if (sessionFetching.value && !options?.disableCookieCache) {
       return
     }
 
     sessionFetching.value = true
+
+    const fetchId = import.meta.client ? ++latestSessionFetchId : 0
+    const query = options?.disableCookieCache
+      ? { disableCookieCache: true }
+      : undefined
 
     try {
       let data: Awaited<ReturnType<typeof client.getSession>>['data']
@@ -74,15 +88,22 @@ export function useAuth() {
       if (import.meta.server) {
         data = await $fetch('/api/auth/get-session', {
           headers,
+          query,
         })
       } else {
         const result = await client.getSession({
           fetchOptions: {
             headers,
           },
+          query,
         })
 
         data = result.data
+      }
+
+      // A newer fetch started after this one — let it be the source of truth.
+      if (import.meta.client && fetchId !== latestSessionFetchId) {
+        return data
       }
 
       session.value = data?.session || null
@@ -98,6 +119,10 @@ export function useAuth() {
 
       return data
     } catch {
+      if (import.meta.client && fetchId !== latestSessionFetchId) {
+        return
+      }
+
       session.value = null
       user.value = null
     } finally {

--- a/app/composables/chat-draft.ts
+++ b/app/composables/chat-draft.ts
@@ -1,5 +1,15 @@
 const DRAFT_BACKUP_KEY = 'chat_input_backup'
 
+// Bound how long an unsent draft can resurrect: long enough to recover after a
+// failed send plus a /signin re-login or a PWA relaunch, short enough that a
+// draft the user abandoned does not silently reappear on a much later visit.
+const DRAFT_TTL_MS = 24 * 60 * 60 * 1000
+
+interface DraftBackup {
+  text: string
+  savedAt: number
+}
+
 // A user's own unsent message is functional/necessary data, so the backup is
 // written straight to localStorage — deliberately NOT gated behind the
 // 'preferences' consent category like `chat_input` is. It survives an
@@ -26,7 +36,12 @@ export function useChatDraftBackup() {
       return
     }
 
-    getStorage()?.setItem(DRAFT_BACKUP_KEY, text)
+    const payload: DraftBackup = {
+      text,
+      savedAt: Date.now(),
+    }
+
+    getStorage()?.setItem(DRAFT_BACKUP_KEY, JSON.stringify(payload))
   }
 
   function peek(): string | null {
@@ -34,7 +49,33 @@ export function useChatDraftBackup() {
       return null
     }
 
-    return getStorage()?.getItem(DRAFT_BACKUP_KEY) ?? null
+    const storage = getStorage()
+    const raw = storage?.getItem(DRAFT_BACKUP_KEY)
+
+    if (!raw) {
+      return null
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as Partial<DraftBackup>
+      const text = typeof parsed.text === 'string' ? parsed.text : null
+      const savedAt = typeof parsed.savedAt === 'number' ? parsed.savedAt : 0
+
+      // Discard a draft with no text, a missing/zero timestamp, or one past
+      // the TTL, so an abandoned message cannot resurrect on a later visit.
+      if (!text || Date.now() - savedAt > DRAFT_TTL_MS) {
+        storage?.removeItem(DRAFT_BACKUP_KEY)
+
+        return null
+      }
+
+      return text
+    } catch {
+      // Corrupt or legacy plain-string value — drop it.
+      storage?.removeItem(DRAFT_BACKUP_KEY)
+
+      return null
+    }
   }
 
   function clear(): void {

--- a/app/composables/chat-draft.ts
+++ b/app/composables/chat-draft.ts
@@ -1,0 +1,53 @@
+const DRAFT_BACKUP_KEY = 'chat_input_backup'
+
+// A user's own unsent message is functional/necessary data, so the backup is
+// written straight to localStorage — deliberately NOT gated behind the
+// 'preferences' consent category like `chat_input` is. It survives an
+// optimistic clear, a failed send, a /signin redirect, and a PWA relaunch so
+// the draft can be restored when the user returns to /chats/new.
+export function useChatDraftBackup() {
+  function getStorage(): Storage | null {
+    try {
+      return window.localStorage ?? null
+    } catch {
+      return null
+    }
+  }
+
+  function save(text: string): void {
+    if (!import.meta.client) {
+      return
+    }
+
+    // Reject blank-only drafts, but persist the original text verbatim so the
+    // user's exact input (including intentional leading/trailing newlines) is
+    // restored unchanged.
+    if (!text.trim()) {
+      return
+    }
+
+    getStorage()?.setItem(DRAFT_BACKUP_KEY, text)
+  }
+
+  function peek(): string | null {
+    if (!import.meta.client) {
+      return null
+    }
+
+    return getStorage()?.getItem(DRAFT_BACKUP_KEY) ?? null
+  }
+
+  function clear(): void {
+    if (!import.meta.client) {
+      return
+    }
+
+    getStorage()?.removeItem(DRAFT_BACKUP_KEY)
+  }
+
+  return {
+    save,
+    peek,
+    clear,
+  }
+}

--- a/app/pages/chats/new.vue
+++ b/app/pages/chats/new.vue
@@ -55,6 +55,7 @@ useSeoMeta({
 
 const route = useRoute()
 const router = useRouter()
+const auth = useAuth()
 const prefStorage = usePreferenceStorage()
 const message = customRef<string>((track, trigger) => ({
   get() {
@@ -327,14 +328,18 @@ function onProjectPickerSubmit(payload: {
 }
 
 async function onSubmit() {
-  // ChatInput clears the textarea optimistically on submit, so snapshot the
-  // text first and back it up durably — a failed send (e.g. a 401 from a dead
-  // session) must never lose what the user typed.
+  if (pending.value) {
+    return
+  }
+
+  // ChatInput clears the textarea and attached files optimistically on submit,
+  // so snapshot both first — a failed send (e.g. a 401 from a dead session)
+  // must never lose what the user typed or attached.
   const draft = message.value
+  const draftFiles = [...files.value]
   const draftBackup = useChatDraftBackup()
 
   pending.value = true
-  draftBackup.save(draft)
 
   try {
     const response = await $fetch('/api/v1/chats/new', {
@@ -345,8 +350,8 @@ async function onSubmit() {
             type: 'text',
             text: draft,
           } as TextUIPart,
-          ...(files.value.length
-            ? files.value.map((file): FileUIPart => ({
+          ...(draftFiles.length
+            ? draftFiles.map((file): FileUIPart => ({
               type: 'file',
               mediaType: file.type,
               filename: file.name,
@@ -370,22 +375,22 @@ async function onSubmit() {
     }
 
     draftBackup.clear()
-    navigateTo(`/chats/${response.slug}`)
+    await navigateTo(`/chats/${response.slug}`)
   } catch (exception) {
-    // Restore the optimistically-cleared input; the backup stays until a send
-    // actually succeeds so the draft also survives a redirect or relaunch.
+    // Back up the draft only on a real failure (a successful send never leaves
+    // one behind) and restore the optimistically-cleared input and files.
+    draftBackup.save(draft)
     message.value = draft
+    files.value = draftFiles
 
     const parsedException = parseError(exception)
 
     if (parsedException.status === 401) {
-      const { fetchSession, session } = useAuth()
-
       // Bypass the 5-minute cookie cache: a 401 means the server session is
       // gone, and a cached get-session would mask that and skip the redirect.
-      await fetchSession({ disableCookieCache: true })
+      await auth.fetchSession({ disableCookieCache: true })
 
-      if (!session.value) {
+      if (!auth.session.value) {
         await navigateTo('/signin')
 
         return

--- a/app/pages/chats/new.vue
+++ b/app/pages/chats/new.vue
@@ -288,6 +288,20 @@ if (import.meta.client) {
   }, { immediate: true })
 }
 
+onMounted(() => {
+  // Restore a draft backed up by a previously failed send (e.g. after a
+  // /signin redirect or a PWA relaunch), unless the input already has text.
+  if (message.value?.trim()) {
+    return
+  }
+
+  const backup = useChatDraftBackup().peek()
+
+  if (backup) {
+    message.value = backup
+  }
+})
+
 function openProjectPicker() {
   projectPickerRef.value?.open(projectId.value)
 }
@@ -313,7 +327,14 @@ function onProjectPickerSubmit(payload: {
 }
 
 async function onSubmit() {
+  // ChatInput clears the textarea optimistically on submit, so snapshot the
+  // text first and back it up durably — a failed send (e.g. a 401 from a dead
+  // session) must never lose what the user typed.
+  const draft = message.value
+  const draftBackup = useChatDraftBackup()
+
   pending.value = true
+  draftBackup.save(draft)
 
   try {
     const response = await $fetch('/api/v1/chats/new', {
@@ -322,7 +343,7 @@ async function onSubmit() {
         parts: [
           {
             type: 'text',
-            text: message.value,
+            text: draft,
           } as TextUIPart,
           ...(files.value.length
             ? files.value.map((file): FileUIPart => ({
@@ -348,14 +369,21 @@ async function onSubmit() {
       })
     }
 
+    draftBackup.clear()
     navigateTo(`/chats/${response.slug}`)
   } catch (exception) {
+    // Restore the optimistically-cleared input; the backup stays until a send
+    // actually succeeds so the draft also survives a redirect or relaunch.
+    message.value = draft
+
     const parsedException = parseError(exception)
 
     if (parsedException.status === 401) {
       const { fetchSession, session } = useAuth()
 
-      await fetchSession()
+      // Bypass the 5-minute cookie cache: a 401 means the server session is
+      // gone, and a cached get-session would mask that and skip the redirect.
+      await fetchSession({ disableCookieCache: true })
 
       if (!session.value) {
         await navigateTo('/signin')

--- a/app/plugins/session-revalidate.client.ts
+++ b/app/plugins/session-revalidate.client.ts
@@ -1,0 +1,48 @@
+// Issue #235: an installed PWA can resume from suspension showing a stale
+// "logged-in" UI while the server session has already expired or been evicted.
+// Re-validate (bypassing the cookie cache) when the app regains focus so a dead
+// session surfaces as a clean /signin redirect instead of a failed send.
+const MIN_REVALIDATE_INTERVAL = 30_000
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const { fetchSession, session, loggedIn } = useAuth()
+  const route = useRoute()
+
+  let lastRevalidatedAt = 0
+
+  async function revalidate() {
+    if (!loggedIn.value) {
+      return
+    }
+
+    const now = Date.now()
+
+    if (now - lastRevalidatedAt < MIN_REVALIDATE_INTERVAL) {
+      return
+    }
+
+    lastRevalidatedAt = now
+
+    await fetchSession({ disableCookieCache: true })
+
+    if (session.value) {
+      return
+    }
+
+    const auth = route.meta.auth
+
+    if (auth && typeof auth === 'object' && auth.only === 'user') {
+      await nuxtApp.runWithContext(() => navigateTo('/signin'))
+    }
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      revalidate()
+    }
+  })
+
+  window.addEventListener('focus', () => {
+    revalidate()
+  })
+})

--- a/app/plugins/session-revalidate.client.ts
+++ b/app/plugins/session-revalidate.client.ts
@@ -5,7 +5,7 @@
 const MIN_REVALIDATE_INTERVAL = 30_000
 
 export default defineNuxtPlugin((nuxtApp) => {
-  const { fetchSession, session, loggedIn } = useAuth()
+  const { fetchSession, session, loggedIn, options } = useAuth()
   const route = useRoute()
 
   let lastRevalidatedAt = 0
@@ -23,6 +23,9 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     lastRevalidatedAt = now
 
+    // A transient/transport failure leaves session.value untouched (see
+    // fetchSession), so only an authoritative empty session falls through to
+    // the redirect — a network blip on resume cannot force a logout.
     await fetchSession({ disableCookieCache: true })
 
     if (session.value) {
@@ -32,17 +35,23 @@ export default defineNuxtPlugin((nuxtApp) => {
     const auth = route.meta.auth
 
     if (auth && typeof auth === 'object' && auth.only === 'user') {
-      await nuxtApp.runWithContext(() => navigateTo('/signin'))
+      await nuxtApp.runWithContext(() => navigateTo(options.redirectGuestTo))
     }
+  }
+
+  // Swallow async rejections so the sync event listeners never surface an
+  // unhandled promise rejection (e.g. from a navigation abort).
+  function scheduleRevalidate() {
+    revalidate().catch(() => {})
   }
 
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'visible') {
-      revalidate()
+      scheduleRevalidate()
     }
   })
 
   window.addEventListener('focus', () => {
-    revalidate()
+    scheduleRevalidate()
   })
 })

--- a/docs/session-401-recovery.md
+++ b/docs/session-401-recovery.md
@@ -105,19 +105,29 @@ kept to avoid regressing the auth-middleware change in `393015b`) is unchanged.
   (`useChatDraftBackup`). The user's own unsent message is functional data, so
   it is written straight to `localStorage` (not gated by the `preferences`
   consent category) and registered under the `necessary` category in
-  `nuxt.config.ts`. `chats/new` `onSubmit` snapshots the draft, backs it up,
-  restores the input on failure, clears the backup on success, and restores it
-  on mount (after a `/signin` redirect or a PWA relaunch).
+  `nuxt.config.ts`. It stores `{ text, savedAt }` with a 24h TTL (`peek()`
+  prunes expired/corrupt entries). `chats/new` `onSubmit` snapshots the draft
+  **and the attached files**, restores both on failure (`ChatInput` clears
+  text and files optimistically), backs up the draft only on failure, clears
+  it on success, and restores it on mount (after a `/signin` redirect or a PWA
+  relaunch). The backup is also cleared on `signOut` so it cannot leak to the
+  next user on a shared device.
 - **Reliable 401 recovery** — `fetchSession()` accepts
   `{ disableCookieCache: true }` and bypasses both the cookie cache and its
-  re-entrancy guard (`app/composables/auth.ts`), so the recovery reflects real
-  KV/DB state instead of a cached session. A client-only fetch-generation guard
-  prevents an in-flight cached fetch from resurrecting a session the bypass
-  call just found dead. `chats/new` `onSubmit` and `app.vue` `onException` use
-  this before deciding whether to redirect to `/signin`.
+  in-flight guard (`app/composables/auth.ts`), so the recovery reflects real
+  KV/DB state instead of a cached session. A transport/network error (offline,
+  flaky cell, 5xx) is **not** treated as a dead session — the last-known
+  session is preserved so a blip cannot force a logout; only an authoritative
+  empty response clears it. A fetch-generation guard prevents a stale in-flight
+  cached fetch from resurrecting a session the bypass call just found dead.
+  `chats/new` `onSubmit` and `app.vue` `onException` use this before deciding
+  whether to redirect to `/signin`. (The cache-bypass `get-session` response
+  also expires the session cookies on a dead session, so the redirect does not
+  bounce back through the auth middleware.)
 - **Resume re-validation** — `app/plugins/session-revalidate.client.ts`
   re-validates (cache-bypass) on `visibilitychange`/`focus` and redirects a
-  dead session to `/signin` *before* the user types.
+  dead session to the configured guest route *before* the user types. A
+  transient failure leaves the session intact (no redirect).
 - **Diagnostic** — `useUserSession()` logs
   `sessionCheck.tokenCookiePresent` (a boolean, never the cookie value) when
   `getSession` returns `null`, so a 401 can be classified as a missing
@@ -133,9 +143,20 @@ kept to avoid regressing the auth-middleware change in `393015b`) is unchanged.
 
 ## Tests
 
+- `tests/unit/composables/auth.spec.ts` — `fetchSession` preserves the session
+  on a transport error / thrown error, clears it on an authoritative empty
+  response, passes `disableCookieCache` only on the bypass call, detects a dead
+  session via bypass even when the cached path reports alive, de-dupes
+  concurrent fetches, and blocks a stale in-flight fetch from overwriting a
+  newer bypass result.
 - `tests/unit/composables/chat-draft.spec.ts` — backup save/peek/clear,
-  blank-only rejection, verbatim + cross-instance persistence, graceful
-  degradation without `localStorage`.
-- `tests/unit/pages/chats-new.spec.ts` — on a 401 the draft is backed up, the
-  input is restored and it redirects to `/signin`; on success the backup is
-  cleared; a backed-up draft is restored on mount.
+  blank-only rejection, verbatim + cross-instance persistence, TTL expiry,
+  corrupt/legacy-value discard, and graceful degradation when `localStorage`
+  is missing or throws.
+- `tests/unit/pages/chats-new.spec.ts` — on a failed send the draft and
+  attached files are restored and the request still carries the files; on a
+  dead-session 401 it redirects to `/signin`; on success the backup is cleared;
+  a backed-up draft is restored on mount.
+- `tests/unit/plugins/session-revalidate.client.spec.ts` — redirects only on an
+  authoritative empty session, never on a transient failure, only on user-only
+  routes, skips when logged out, and throttles repeated revalidations.

--- a/docs/session-401-recovery.md
+++ b/docs/session-401-recovery.md
@@ -1,0 +1,141 @@
+# Session 401 recovery on `/chats/new`
+
+Background and fix notes for issue
+[#235](https://github.com/besidka/besidka/issues/235) — users intermittently
+saw a `401 "You don't have access to this resource. Try to sign out and sign in
+again."` on `/chats/new` while the UI still looked logged in, and the message
+they had typed was erased.
+
+## Symptom
+
+A signed-in user opens `/chats/new` (UI shows the logged-in state), types a
+message, and hits send. The message is cleared and a toast shows the 401. The
+production logs for the failing requests are `anonymous: true` /
+`auth.identified: false` — the server resolved **no session at all**:
+
+```
+GET  /api/v1/storage    -> 401 anonymous
+PUT  /api/v1/chats/new  -> 401 anonymous
+```
+
+Signing out and back in fixes it temporarily; it recurs. It was reported by a
+customer on an installed iOS PWA and never reproduced on desktop.
+
+## Root cause
+
+The 401 is a genuinely empty server session: API handlers call
+`useUserSession()` (`server/utils/session.ts`) → Better Auth `getSession()`,
+get `null`, and throw `useUnauthorizedError()`.
+
+How `getSession` resolves (better-auth 1.6.11,
+`node_modules/better-auth/dist/api/routes/session.mjs`):
+
+1. It first reads the signed `__Secure-better-auth.session_token` cookie. If
+   that cookie is missing/invalid it returns `null` immediately
+   (`session.mjs:41-42`). The short-lived `session_data` cache cookie can never
+   sustain — or alone defeat — a session; the token cookie is the gate.
+2. With `session.cookieCache` enabled (5 min), a valid token + valid
+   `session_data` cookie returns the cached session **without reading KV or
+   DB** (`session.mjs:93-186`). Only the cache-miss path runs `updateSession`
+   to extend the session (`session.mjs:235-237`).
+3. On a cache miss, `findSession` reads Cloudflare KV first, then — because
+   `session.storeSessionInDatabase` is on — falls back to a DB lookup by token
+   (`internal-adapter.mjs:222-257`). It returns `null` only when the record is
+   absent from **both** KV and DB.
+
+So a 401 means: the token cookie was present but the session record was gone
+from KV **and** DB (or the token cookie itself was gone). Meanwhile the client
+keeps showing "logged in" because `loggedIn` is derived from in-memory
+`useState('auth:session')` (`app/composables/auth.ts`), last populated from a
+successful `get-session` (possibly the cookie cache), and is not re-validated
+on PWA resume or before submit.
+
+## Why the previous fix (#236) didn't resolve it
+
+[#236](https://github.com/besidka/besidka/pull/236) added
+`storeSessionInDatabase: true` so KV-only sessions gain a DB fallback. That is
+correct, but:
+
+- **It is forward-only.** The DB row is written only at session *creation*
+  (`internal-adapter.mjs:164-185`); `updateSession` updates, it does not create
+  a missing row. Sessions created before the #236 deploy stay KV-only forever,
+  so a KV miss/eviction still yields `null` → 401. This is why the issue
+  recurred after #236 shipped.
+- **The client recovery was unreliable.** #236 added "on 401, refetch the
+  session and redirect to `/signin` if gone." But `fetchSession()` could
+  early-return on its in-flight re-entrancy guard, or observe a still-cached /
+  transiently-flapping session as valid, so `session.value` stayed truthy and
+  the redirect never fired — the user just saw a toast.
+- **It never addressed the lost draft** (see below).
+
+## Why it only affected the iOS PWA user
+
+Not an iOS-specific cookie bug — WebKit's 7-day cap applies to script-writable
+cookies, not the `HttpOnly` `Set-Cookie` session cookie, and there is no stale
+service-worker shell here (`workbox.navigateFallback: null`). The difference is
+behavioral:
+
+| | Desktop reporter | iOS PWA customer |
+|---|---|---|
+| Reloads | Frequent full page loads → frequent `get-session` (cookie refresh) and fresh, DB-backed sessions | Installed PWA rarely hard-reloads; client-side navigation dominates; suspend/resume restores stale in-memory "logged-in" state |
+| Net effect | Practically never sits on a dead-but-masked session | Rides one long-lived (often pre-#236) session for weeks and hits the worst path when it dies |
+
+The PWA does not cause the bug; it maximizes exposure to it and amplifies the
+symptom.
+
+## The typed message was lost
+
+Two independent losses:
+
+1. **Optimistic clear.** `ChatInput.client.vue` clears the textarea
+   synchronously right after emitting `submit`, before the async request
+   resolves — so on any failed send the draft is gone before the failure is
+   known.
+2. **Consent-gated persistence.** `chat_input` is persisted through
+   `usePreferenceStorage`, which writes real `localStorage` only when the
+   cookie-consent `preferences` category is granted; otherwise it lives in an
+   in-memory map that a redirect or relaunch destroys.
+
+## The fix
+
+Client resilience + diagnostics. The session config (including `cookieCache`,
+kept to avoid regressing the auth-middleware change in `393015b`) is unchanged.
+
+- **Durable draft backup** — `app/composables/chat-draft.ts`
+  (`useChatDraftBackup`). The user's own unsent message is functional data, so
+  it is written straight to `localStorage` (not gated by the `preferences`
+  consent category) and registered under the `necessary` category in
+  `nuxt.config.ts`. `chats/new` `onSubmit` snapshots the draft, backs it up,
+  restores the input on failure, clears the backup on success, and restores it
+  on mount (after a `/signin` redirect or a PWA relaunch).
+- **Reliable 401 recovery** — `fetchSession()` accepts
+  `{ disableCookieCache: true }` and bypasses both the cookie cache and its
+  re-entrancy guard (`app/composables/auth.ts`), so the recovery reflects real
+  KV/DB state instead of a cached session. A client-only fetch-generation guard
+  prevents an in-flight cached fetch from resurrecting a session the bypass
+  call just found dead. `chats/new` `onSubmit` and `app.vue` `onException` use
+  this before deciding whether to redirect to `/signin`.
+- **Resume re-validation** — `app/plugins/session-revalidate.client.ts`
+  re-validates (cache-bypass) on `visibilitychange`/`focus` and redirects a
+  dead session to `/signin` *before* the user types.
+- **Diagnostic** — `useUserSession()` logs
+  `sessionCheck.tokenCookiePresent` (a boolean, never the cookie value) when
+  `getSession` returns `null`, so a 401 can be classified as a missing
+  session-token cookie (client-side loss/expiry) vs a present cookie whose
+  record is gone (e.g. a legacy KV-only session).
+
+## Operational notes
+
+- A user stuck on a legacy KV-only session is fixed permanently by one
+  sign-out / sign-in (the new session gets a DB row).
+- After deploy, query the `sessionCheck.tokenCookiePresent` field on 401 events
+  to confirm which failure mode remains, if any.
+
+## Tests
+
+- `tests/unit/composables/chat-draft.spec.ts` — backup save/peek/clear,
+  blank-only rejection, verbatim + cross-instance persistence, graceful
+  degradation without `localStorage`.
+- `tests/unit/pages/chats-new.spec.ts` — on a 401 the draft is backed up, the
+  input is restored and it redirects to `/signin`; on success the backup is
+  cleared; a backed-up draft is restored on mount.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -271,6 +271,11 @@ export default defineNuxtConfig({
             name: 'better_auth.session_token',
             type: 'cookie',
           },
+          {
+            id: 'chat-input-backup',
+            name: 'chat_input_backup',
+            type: 'localStorage',
+          },
         ],
       },
       {

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -116,8 +116,10 @@ export function getAffectedTests(changedFiles) {
   ]
 
   const sessionRecoveryTests = [
+    'tests/unit/composables/auth.spec.ts',
     'tests/unit/composables/chat-draft.spec.ts',
     'tests/unit/pages/chats-new.spec.ts',
+    'tests/unit/plugins/session-revalidate.client.spec.ts',
   ]
 
   const testMappings = [

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -115,6 +115,11 @@ export function getAffectedTests(changedFiles) {
     'tests/e2e/cookies/consent.spec.ts',
   ]
 
+  const sessionRecoveryTests = [
+    'tests/unit/composables/chat-draft.spec.ts',
+    'tests/unit/pages/chats-new.spec.ts',
+  ]
+
   const testMappings = [
     {
       pattern: /^app\/components\/Chat\/(Message|ContextMenu\.client)\.vue$/,
@@ -196,6 +201,19 @@ export function getAffectedTests(changedFiles) {
     {
       pattern: /^app\/pages\/chats\/(history|new)\.vue$/,
       tests: historyProjectsTests,
+    },
+    {
+      pattern:
+        /^(app\/composables\/(chat-draft|auth)\.ts|app\/pages\/chats\/new\.vue|app\/app\.vue|app\/plugins\/session-revalidate\.client\.ts)$/,
+      tests: sessionRecoveryTests,
+    },
+    {
+      pattern: /^server\/utils\/session\.ts$/,
+      tests: [
+        'tests/integration/api/chats-new.spec.ts',
+        'tests/integration/api/projects.spec.ts',
+        'tests/integration/api/chats-branch.spec.ts',
+      ],
     },
     {
       pattern: /^app\/pages\/chats\/projects\/.*\.vue$/,

--- a/server/utils/session.ts
+++ b/server/utils/session.ts
@@ -7,10 +7,11 @@ export function useUnauthorizedError() {
   })
 }
 
-// Matches the better-auth session-token cookie under any prefix:
-// `better-auth.session_token`, `__Secure-...`, or `__Host-...`.
+// Matches the better-auth session-token cookie under any prefix and either
+// separator: better-auth reads `${prefix}.${name}` OR `${prefix}-${name}`,
+// optionally with a `__Secure-`/`__Host-` cookie prefix.
 const SESSION_TOKEN_COOKIE
-  = /(?:^|;\s*)(?:__Secure-|__Host-)?better-auth\.session_token=/
+  = /(?:^|;\s*)(?:__Secure-|__Host-)?better-auth[.-]session_token=/
 
 export async function useUserSession() {
   const event = useEvent()

--- a/server/utils/session.ts
+++ b/server/utils/session.ts
@@ -1,3 +1,5 @@
+import { useLogger } from 'evlog'
+
 export function useUnauthorizedError() {
   throw createError({
     statusCode: 401,
@@ -5,9 +7,31 @@ export function useUnauthorizedError() {
   })
 }
 
+// Matches the better-auth session-token cookie under any prefix:
+// `better-auth.session_token`, `__Secure-...`, or `__Host-...`.
+const SESSION_TOKEN_COOKIE
+  = /(?:^|;\s*)(?:__Secure-|__Host-)?better-auth\.session_token=/
+
 export async function useUserSession() {
-  return await useServerAuth().api.getSession({
+  const event = useEvent()
+  const session = await useServerAuth().api.getSession({
     // @ts-ignore
-    headers: getHeaders(useEvent()),
+    headers: getHeaders(event),
   })
+
+  if (!session) {
+    // Issue #235 diagnostic: distinguish a missing/expired session-token
+    // cookie (client-side cookie loss) from a present cookie whose session
+    // record is gone from KV+DB. Records a boolean only, never the value.
+    const cookieHeader = getHeader(event, 'cookie') || ''
+
+    useLogger(event).set({
+      sessionCheck: {
+        resolved: false,
+        tokenCookiePresent: SESSION_TOKEN_COOKIE.test(cookieHeader),
+      },
+    })
+  }
+
+  return session
 }

--- a/tests/unit/composables/auth.spec.ts
+++ b/tests/unit/composables/auth.spec.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  installMockNuxtState,
+  resetMockNuxtState,
+} from '../../setup/helpers/nuxt-state'
+
+// Controllable getSession so each test drives the { data, error } shape the
+// better-auth client actually returns (200/null, network error, success).
+const { getSessionMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+}))
+
+vi.mock('better-auth/vue', () => ({
+  createAuthClient: () => ({
+    getSession: getSessionMock,
+    $store: {
+      listen: vi.fn(),
+    },
+    $ERROR_CODES: {},
+    signIn: {},
+    signUp: {},
+    signOut: vi.fn(),
+    requestPasswordReset: vi.fn(),
+    resetPassword: vi.fn(),
+  }),
+}))
+
+const { useAuth } = await import('../../../app/composables/auth')
+
+function fakeSession(id: string) {
+  return { id } as unknown as NonNullable<
+    ReturnType<typeof useAuth>['session']['value']
+  >
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+
+  return {
+    promise,
+    resolve,
+  }
+}
+
+describe('useAuth fetchSession', () => {
+  beforeEach(() => {
+    resetMockNuxtState()
+    installMockNuxtState()
+    getSessionMock.mockReset()
+  })
+
+  afterEach(() => {
+    resetMockNuxtState()
+  })
+
+  it('preserves the session on a transport-error result (no false logout)', async () => {
+    const { fetchSession, session } = useAuth()
+
+    session.value = fakeSession('sess-1')
+    getSessionMock.mockResolvedValue({
+      data: null,
+      error: { status: 0, message: 'fetch failed' },
+    })
+
+    await fetchSession({ disableCookieCache: true })
+
+    expect(session.value).toMatchObject({ id: 'sess-1' })
+  })
+
+  it('preserves the session when getSession throws (offline)', async () => {
+    const { fetchSession, session } = useAuth()
+
+    session.value = fakeSession('sess-1')
+    getSessionMock.mockRejectedValue(new Error('Failed to fetch'))
+
+    await fetchSession({ disableCookieCache: true })
+
+    expect(session.value).toMatchObject({ id: 'sess-1' })
+  })
+
+  it('clears the session on an authoritative no-session response', async () => {
+    const { fetchSession, session } = useAuth()
+
+    session.value = fakeSession('sess-1')
+    getSessionMock.mockResolvedValue({ data: null, error: null })
+
+    await fetchSession({ disableCookieCache: true })
+
+    expect(session.value).toBeNull()
+  })
+
+  it('sets the session on a successful response', async () => {
+    const { fetchSession, session, user } = useAuth()
+
+    getSessionMock.mockResolvedValue({
+      data: {
+        session: { id: 'sess-2' },
+        user: { id: '7', name: 'Ada' },
+      },
+      error: null,
+    })
+
+    await fetchSession()
+
+    expect(session.value?.id).toBe('sess-2')
+    expect(user.value?.id).toBe('7')
+  })
+
+  it('de-dupes a concurrent normal fetch while one is in flight', async () => {
+    const { fetchSession } = useAuth()
+    let resolveGet: (value: { data: null, error: null }) => void = () => {}
+
+    getSessionMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve
+      }),
+    )
+
+    const first = fetchSession()
+    const second = fetchSession()
+
+    resolveGet({ data: null, error: null })
+
+    await Promise.all([first, second])
+
+    expect(getSessionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets a bypass fetch run even while a normal fetch is in flight', async () => {
+    const { fetchSession } = useAuth()
+    let resolveGet: (value: { data: null, error: null }) => void = () => {}
+
+    getSessionMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveGet = resolve
+      }),
+    )
+    getSessionMock.mockResolvedValue({ data: null, error: null })
+
+    const normal = fetchSession()
+    const bypass = fetchSession({ disableCookieCache: true })
+
+    resolveGet({ data: null, error: null })
+
+    await Promise.all([normal, bypass])
+
+    expect(getSessionMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes disableCookieCache only on the bypass call', async () => {
+    const { fetchSession } = useAuth()
+
+    getSessionMock.mockResolvedValue({ data: null, error: null })
+
+    await fetchSession()
+
+    expect(getSessionMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ query: undefined }),
+    )
+
+    await fetchSession({ disableCookieCache: true })
+
+    expect(getSessionMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ query: { disableCookieCache: true } }),
+    )
+  })
+
+  it('detects a dead session via bypass even when the cached path reports alive', async () => {
+    const { fetchSession, session } = useAuth()
+
+    getSessionMock.mockImplementation((opts?: {
+      query?: { disableCookieCache?: boolean }
+    }) => {
+      return Promise.resolve(
+        opts?.query?.disableCookieCache
+          ? { data: null, error: null }
+          : {
+            data: { session: { id: 'cached' }, user: { id: '1' } },
+            error: null,
+          },
+      )
+    })
+
+    await fetchSession({ disableCookieCache: true })
+
+    expect(session.value).toBeNull()
+  })
+
+  it('does not let a stale in-flight fetch overwrite a newer bypass result', async () => {
+    const { fetchSession, session } = useAuth()
+    const normalGet = createDeferred<{ data: unknown, error: null }>()
+    const bypassGet = createDeferred<{ data: null, error: null }>()
+
+    session.value = fakeSession('stale-alive')
+    getSessionMock
+      .mockReturnValueOnce(normalGet.promise)
+      .mockReturnValueOnce(bypassGet.promise)
+
+    const normal = fetchSession()
+    const bypass = fetchSession({ disableCookieCache: true })
+
+    // The newer bypass resolves first and finds no session.
+    bypassGet.resolve({ data: null, error: null })
+    await bypass
+
+    expect(session.value).toBeNull()
+
+    // The older normal fetch resolves later with a cached, truthy session — it
+    // must NOT resurrect the session the bypass just found dead.
+    normalGet.resolve({
+      data: { session: { id: 'cached' }, user: { id: '1' } },
+      error: null,
+    })
+    await normal
+
+    expect(session.value).toBeNull()
+  })
+})

--- a/tests/unit/composables/chat-draft.spec.ts
+++ b/tests/unit/composables/chat-draft.spec.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useChatDraftBackup } from '../../../app/composables/chat-draft'
+
+/**
+ * The draft backup deliberately bypasses the cookie-consent 'preferences'
+ * gate (a user's own unsent message is functional/necessary data) and writes
+ * straight to localStorage so it survives a failed send, a /signin redirect,
+ * and a PWA relaunch. Node 26 / the nuxt test env may not provide a real
+ * localStorage, so a minimal shim is stubbed in.
+ */
+function createStorageShim() {
+  const entries = new Map<string, string>()
+
+  return {
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      entries.set(key, String(value))
+    },
+    removeItem: (key: string) => {
+      entries.delete(key)
+    },
+    clear: () => {
+      entries.clear()
+    },
+  }
+}
+
+describe('useChatDraftBackup', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createStorageShim())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('saves a draft and restores it verbatim', () => {
+    const backup = useChatDraftBackup()
+
+    backup.save('  keep my\nwhitespace  ')
+
+    expect(backup.peek()).toBe('  keep my\nwhitespace  ')
+  })
+
+  it('rejects a blank-only draft', () => {
+    const backup = useChatDraftBackup()
+
+    backup.save('   \n  \t ')
+
+    expect(backup.peek()).toBeNull()
+  })
+
+  it('clears the backup', () => {
+    const backup = useChatDraftBackup()
+
+    backup.save('draft to clear')
+    backup.clear()
+
+    expect(backup.peek()).toBeNull()
+  })
+
+  it('persists across instances, surviving a redirect or relaunch', () => {
+    useChatDraftBackup().save('survives navigation')
+
+    // A fresh composable instance models the page mounting again after a
+    // /signin round-trip or a PWA relaunch.
+    expect(useChatDraftBackup().peek()).toBe('survives navigation')
+  })
+
+  it('degrades gracefully when localStorage is unavailable', () => {
+    vi.stubGlobal('localStorage', undefined)
+
+    const backup = useChatDraftBackup()
+
+    expect(() => backup.save('x')).not.toThrow()
+    expect(backup.peek()).toBeNull()
+    expect(() => backup.clear()).not.toThrow()
+  })
+})

--- a/tests/unit/composables/chat-draft.spec.ts
+++ b/tests/unit/composables/chat-draft.spec.ts
@@ -76,4 +76,51 @@ describe('useChatDraftBackup', () => {
     expect(backup.peek()).toBeNull()
     expect(() => backup.clear()).not.toThrow()
   })
+
+  it('discards an expired draft and prunes the entry', () => {
+    const expired = Date.now() - 48 * 60 * 60 * 1000
+
+    window.localStorage.setItem(
+      'chat_input_backup',
+      JSON.stringify({ text: 'stale draft', savedAt: expired }),
+    )
+
+    const backup = useChatDraftBackup()
+
+    expect(backup.peek()).toBeNull()
+    expect(window.localStorage.getItem('chat_input_backup')).toBeNull()
+  })
+
+  it('discards a corrupt or legacy plain-string value', () => {
+    window.localStorage.setItem('chat_input_backup', 'legacy-plain-string')
+
+    const backup = useChatDraftBackup()
+
+    expect(backup.peek()).toBeNull()
+    expect(window.localStorage.getItem('chat_input_backup')).toBeNull()
+  })
+
+  it('does not throw when localStorage access throws (private mode)', () => {
+    const original = Object.getOwnPropertyDescriptor(globalThis, 'localStorage')
+
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new Error('SecurityError')
+      },
+    })
+
+    try {
+      const backup = useChatDraftBackup()
+
+      expect(() => backup.save('x')).not.toThrow()
+      expect(() => backup.peek()).not.toThrow()
+      expect(backup.peek()).toBeNull()
+      expect(() => backup.clear()).not.toThrow()
+    } finally {
+      if (original) {
+        Object.defineProperty(globalThis, 'localStorage', original)
+      }
+    }
+  })
 })

--- a/tests/unit/pages/chats-new.spec.ts
+++ b/tests/unit/pages/chats-new.spec.ts
@@ -59,8 +59,12 @@ function createSendStubs() {
         type: String,
         default: '',
       },
+      files: {
+        type: Array,
+        default: () => [],
+      },
     },
-    emits: ['submit', 'update:message'],
+    emits: ['submit', 'update:message', 'update:files'],
     template: '<div data-testid="chat-input-message">{{ message }}</div>',
   })
   const projectPickerStub = defineComponent({
@@ -349,9 +353,61 @@ describe('chats new page', () => {
     await nextTick()
     await flushPromises()
 
-    expect(storage.getItem('chat_input_backup')).toBe('unsent message')
+    const storedBackup = storage.getItem('chat_input_backup')
+
+    expect(storedBackup).not.toBeNull()
+    expect(JSON.parse(storedBackup as string).text).toBe('unsent message')
     expect(navigateToMock).toHaveBeenCalledWith('/signin')
     expect(chatInput.props('message')).toBe('unsent message')
+  })
+
+  it('restores attached files on a failed send', async () => {
+    const storage = createStorageShim()
+
+    const fetchMock = vi.fn(() => {
+      return Promise.reject(
+        Object.assign(new Error('Server error'), {
+          statusCode: 500,
+          status: 500,
+        }),
+      )
+    })
+
+    vi.stubGlobal('localStorage', storage)
+    navigateToMock.mockClear()
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const { chatInputStub, stubs } = createSendStubs()
+
+    wrapper = await mountSuspended(ChatsNewPage, { global: { stubs } })
+
+    const chatInput = wrapper.findComponent(chatInputStub)
+    const attached = [
+      { name: 'report.pdf', type: 'application/pdf', storageKey: 'k1' },
+    ]
+
+    chatInput.vm.$emit('update:message', 'see attached')
+    chatInput.vm.$emit('update:files', attached)
+    await nextTick()
+
+    chatInput.vm.$emit('submit')
+    // ChatInput clears BOTH the textarea and the files optimistically.
+    chatInput.vm.$emit('update:message', '')
+    chatInput.vm.$emit('update:files', [])
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    // The outgoing request carries the snapshot, not the optimistically
+    // cleared live files.
+    const sentBody = fetchMock.mock.calls[0]?.[1]?.body as {
+      parts: { type: string }[]
+    }
+
+    expect(sentBody.parts.some(part => part.type === 'file')).toBe(true)
+    // The input and its attachments are restored after the failed send.
+    expect(chatInput.props('message')).toBe('see attached')
+    expect(chatInput.props('files')).toEqual(attached)
   })
 
   it('clears the draft backup after a successful send', async () => {
@@ -385,7 +441,13 @@ describe('chats new page', () => {
     const storage = createStorageShim()
 
     storage.setItem('chat_input', '')
-    storage.setItem('chat_input_backup', 'recovered after relaunch')
+    storage.setItem(
+      'chat_input_backup',
+      JSON.stringify({
+        text: 'recovered after relaunch',
+        savedAt: Date.now(),
+      }),
+    )
 
     vi.stubGlobal('localStorage', storage)
     vi.stubGlobal('$fetch', vi.fn())

--- a/tests/unit/pages/chats-new.spec.ts
+++ b/tests/unit/pages/chats-new.spec.ts
@@ -1,11 +1,17 @@
 import { defineComponent, nextTick, reactive } from 'vue'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ChatsNewPage from '../../../app/pages/chats/new.vue'
 import {
   installMockNuxtState,
   resetMockNuxtState,
 } from '../../setup/helpers/nuxt-state'
+
+const { navigateToMock } = vi.hoisted(() => ({
+  navigateToMock: vi.fn(),
+}))
+
+mockNuxtImport('navigateTo', () => navigateToMock)
 
 async function flushPromises() {
   await Promise.resolve()
@@ -25,6 +31,68 @@ function createDeferred<T>() {
     promise,
     resolve,
     reject,
+  }
+}
+
+function createStorageShim() {
+  const entries = new Map<string, string>()
+
+  return {
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      entries.set(key, String(value))
+    },
+    removeItem: (key: string) => {
+      entries.delete(key)
+    },
+    clear: () => {
+      entries.clear()
+    },
+  }
+}
+
+function createSendStubs() {
+  const chatInputStub = defineComponent({
+    name: 'ChatInputStub',
+    props: {
+      message: {
+        type: String,
+        default: '',
+      },
+    },
+    emits: ['submit', 'update:message'],
+    template: '<div data-testid="chat-input-message">{{ message }}</div>',
+  })
+  const projectPickerStub = defineComponent({
+    name: 'ChatInputProjectPicker',
+    emits: ['submit'],
+    methods: {
+      open() {},
+      close() {},
+    },
+    template: '<div />',
+  })
+
+  const stubs = {
+    ChatContainer: {
+      template: '<div><slot /></div>',
+    },
+    ChatProjectInstructions: {
+      props: ['instructions', 'memory'],
+      template: '<div />',
+    },
+    ChatMessage: {
+      template: '<div><slot /></div>',
+    },
+    LazyBackgroundLogo: true,
+    ChatInput: chatInputStub,
+    ChatInputProjectPicker: projectPickerStub,
+    LazyChatInputProjectPicker: projectPickerStub,
+  }
+
+  return {
+    chatInputStub,
+    stubs,
   }
 }
 
@@ -247,5 +315,88 @@ describe('chats new page', () => {
     expect(wrapper.get('[data-testid="project-instructions"]').text()).toBe(
       'Stay focused on milestones|User prefers concise updates.',
     )
+  })
+
+  it('backs up the draft and redirects to /signin on a dead-session 401', async () => {
+    // createAuthClient is mocked so getSession() resolves { data: null }; the
+    // cache-bypassing recovery therefore finds no session and must redirect.
+    const storage = createStorageShim()
+
+    vi.stubGlobal('localStorage', storage)
+    navigateToMock.mockClear()
+    vi.stubGlobal('$fetch', vi.fn(() => {
+      return Promise.reject(
+        Object.assign(new Error('No access'), {
+          statusCode: 401,
+          status: 401,
+        }),
+      )
+    }))
+
+    const { chatInputStub, stubs } = createSendStubs()
+
+    wrapper = await mountSuspended(ChatsNewPage, { global: { stubs } })
+
+    const chatInput = wrapper.findComponent(chatInputStub)
+
+    chatInput.vm.$emit('update:message', 'unsent message')
+    await nextTick()
+
+    chatInput.vm.$emit('submit')
+    // ChatInput clears the textarea optimistically right after emitting submit.
+    chatInput.vm.$emit('update:message', '')
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(storage.getItem('chat_input_backup')).toBe('unsent message')
+    expect(navigateToMock).toHaveBeenCalledWith('/signin')
+    expect(chatInput.props('message')).toBe('unsent message')
+  })
+
+  it('clears the draft backup after a successful send', async () => {
+    const storage = createStorageShim()
+
+    vi.stubGlobal('localStorage', storage)
+    navigateToMock.mockClear()
+    vi.stubGlobal('$fetch', vi.fn(() => {
+      return Promise.resolve({ slug: 'created-chat' })
+    }))
+
+    const { chatInputStub, stubs } = createSendStubs()
+
+    wrapper = await mountSuspended(ChatsNewPage, { global: { stubs } })
+
+    const chatInput = wrapper.findComponent(chatInputStub)
+
+    chatInput.vm.$emit('update:message', 'hello there')
+    await nextTick()
+
+    chatInput.vm.$emit('submit')
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(navigateToMock).toHaveBeenCalledWith('/chats/created-chat')
+    expect(storage.getItem('chat_input_backup')).toBeNull()
+  })
+
+  it('restores a backed-up draft on mount', async () => {
+    const storage = createStorageShim()
+
+    storage.setItem('chat_input', '')
+    storage.setItem('chat_input_backup', 'recovered after relaunch')
+
+    vi.stubGlobal('localStorage', storage)
+    vi.stubGlobal('$fetch', vi.fn())
+
+    const { chatInputStub, stubs } = createSendStubs()
+
+    wrapper = await mountSuspended(ChatsNewPage, { global: { stubs } })
+    await nextTick()
+
+    expect(
+      wrapper.findComponent(chatInputStub).props('message'),
+    ).toBe('recovered after relaunch')
   })
 })

--- a/tests/unit/plugins/session-revalidate.client.spec.ts
+++ b/tests/unit/plugins/session-revalidate.client.spec.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import plugin from '../../../app/plugins/session-revalidate.client'
+
+const mocks = vi.hoisted(() => ({
+  fetchSession: vi.fn(),
+  session: { value: null as unknown },
+  loggedIn: { value: false },
+  options: { redirectGuestTo: '/signin' },
+  routeAuth: { only: 'user' } as unknown,
+  navigateTo: vi.fn(),
+}))
+
+mockNuxtImport('useAuth', () => {
+  return () => ({
+    fetchSession: mocks.fetchSession,
+    session: mocks.session,
+    loggedIn: mocks.loggedIn,
+    options: mocks.options,
+  })
+})
+
+mockNuxtImport('useRoute', () => {
+  return () => ({ meta: { auth: mocks.routeAuth } })
+})
+
+mockNuxtImport('navigateTo', () => mocks.navigateTo)
+
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('session-revalidate plugin', () => {
+  let visibilityHandler: (() => void) | null = null
+
+  beforeEach(() => {
+    visibilityHandler = null
+    mocks.fetchSession.mockReset()
+    mocks.navigateTo.mockReset()
+    mocks.session.value = { id: 'live' }
+    mocks.loggedIn.value = true
+    mocks.routeAuth = { only: 'user' }
+
+    vi.spyOn(document, 'addEventListener').mockImplementation((type, handler) => {
+      if (type === 'visibilitychange') {
+        visibilityHandler = handler as () => void
+      }
+    })
+    vi.spyOn(window, 'addEventListener').mockImplementation(() => {})
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function install() {
+    plugin({ runWithContext: (fn: () => unknown) => fn() } as never)
+  }
+
+  it('redirects to the guest route when the session is authoritatively gone', async () => {
+    mocks.fetchSession.mockImplementation(async () => {
+      mocks.session.value = null
+    })
+
+    install()
+    visibilityHandler?.()
+    await flushPromises()
+
+    expect(mocks.fetchSession).toHaveBeenCalledWith({
+      disableCookieCache: true,
+    })
+    expect(mocks.navigateTo).toHaveBeenCalledWith('/signin')
+  })
+
+  it('does not redirect when a transient failure leaves the session intact', async () => {
+    mocks.fetchSession.mockResolvedValue(undefined)
+
+    install()
+    visibilityHandler?.()
+    await flushPromises()
+
+    expect(mocks.fetchSession).toHaveBeenCalled()
+    expect(mocks.navigateTo).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the user is not logged in', async () => {
+    mocks.loggedIn.value = false
+
+    install()
+    visibilityHandler?.()
+    await flushPromises()
+
+    expect(mocks.fetchSession).not.toHaveBeenCalled()
+  })
+
+  it('does not redirect on routes that are not user-only', async () => {
+    mocks.routeAuth = { only: 'guest' }
+    mocks.fetchSession.mockImplementation(async () => {
+      mocks.session.value = null
+    })
+
+    install()
+    visibilityHandler?.()
+    await flushPromises()
+
+    expect(mocks.navigateTo).not.toHaveBeenCalled()
+  })
+
+  it('throttles repeated revalidations within the interval', async () => {
+    mocks.fetchSession.mockResolvedValue(undefined)
+
+    install()
+    visibilityHandler?.()
+    visibilityHandler?.()
+    await flushPromises()
+
+    expect(mocks.fetchSession).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Reopened #235: an iPhone-PWA user sees a logged-in /chats/new, sends a
message, and the draft is erased while the API returns 401 "You don't
have access to this resource". PR #236 did not resolve it.

Root cause: the 401 is a genuinely null server session. getSession gates
on the signed session_token cookie, then reads KV with a DB fallback. But
so it is forward-only — sessions created before the deploy stay KV-only,
and a KV miss/eviction yields null. The 5-minute cookieCache masks this
client-side (the UI stays "logged in"), and the input is cleared
optimistically before the request resolves, so the draft is lost before
the failure is known. It surfaces on the iOS PWA because it rarely
hard-reloads (so get-session, which refreshes the cookie, rarely runs) and
resumes with stale in-memory state; a desktop session reloads constantly
and never sits on a dead-but-masked session.

Draft preservation:
- Add useChatDraftBackup(): a durable localStorage backup of the unsent
  message, deliberately NOT gated behind the 'preferences' consent
  category (a user's own draft is functional data). Registered under the
  'necessary' category in nuxt.config.
- chats/new onSubmit snapshots the draft, backs it up, restores the input
  on failure, clears it on success, and restores it on mount so the draft
  survives a /signin redirect or a PWA relaunch.

Reliable 401 recovery:
- fetchSession() accepts { disableCookieCache } and bypasses both the
  cookie cache and its re-entrancy guard, so the recovery reflects real
  KV/DB state instead of a cached truthy session. A client-only
  fetch-generation guard prevents an in-flight cached fetch from
  resurrecting a session the bypass call just found dead.
- chats/new onSubmit and app.vue onException use the cache-bypassing check
  before deciding to redirect to /signin.
- New session-revalidate.client.ts re-validates (cache-bypass) on PWA
  resume/focus and redirects a dead session to /signin before the user
  types.

Diagnostics:
- useUserSession() logs sessionCheck.tokenCookiePresent (boolean only,
  never the cookie value) when getSession returns null, to classify future
  401s as a missing session-token cookie vs a present cookie whose record
  is gone.

Tests:
- tests/unit/composables/chat-draft.spec.ts: backup save/peek/clear,
  blank-only rejection, verbatim + cross-instance persistence, graceful
  degradation without localStorage.
- tests/unit/pages/chats-new.spec.ts: on a 401 the draft is backed up, the
  input is restored, and it redirects to /signin; on success the backup is
  cleared; a backed-up draft is restored on mount.
- Register the new specs in scripts/test-affected-check.mjs.

Docs:
- docs/session-401-recovery.md explains the symptom, root cause, why #236
  did not hold, the platform difference, the fix, and the diagnostic.

cookieCache is intentionally kept (added in 393015b to stabilise the auth
middleware); this makes the client resilient to it rather than removing it.

Closes #235
