### PR TITLE
ci: set up node 24 in wrangler deploy jobs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -241,9 +241,7 @@ back to a standard `wrangler deploy` for preview.
 
 Build-time workflows (`preview-build.yml`) require no secrets. Deploy-time workflows use the `preview` or `production` GitHub Environment.
 
-| Variable | Description |
-|----------|-------------|
-| `WRANGLER_VERSION` | Wrangler CLI version (default: `4.62.0`) |
+No repository variables are required. The Wrangler CLI version is pinned as a `devDependency` in `pnpm-lock.yaml` and installed via `pnpm install --frozen-lockfile`; deploy steps use that pinned binary directly, so no `wranglerVersion` input or `WRANGLER_VERSION` variable is needed.
 
 ## Fork PR Handling
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -100,6 +100,17 @@ jobs:
         with:
           run_install: false
 
+      - name: Install Node.js
+        if: steps.fork-check.outputs.is-fork == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        if: steps.fork-check.outputs.is-fork == 'false'
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Record deploy start time
         if: steps.fork-check.outputs.is-fork == 'false'
         id: deploy-start
@@ -112,7 +123,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           packageManager: pnpm
-          wranglerVersion: ${{ vars.WRANGLER_VERSION }}
           command: -v
           postCommands: yes | pnpm exec wrangler d1 migrations apply DB --remote
 
@@ -123,7 +133,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           packageManager: pnpm
-          wranglerVersion: ${{ vars.WRANGLER_VERSION }}
           command: -v
           postCommands: yes | pnpm exec wrangler d1 migrations apply CONSENT_DB --remote
 
@@ -135,7 +144,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           packageManager: pnpm
-          wranglerVersion: ${{ vars.WRANGLER_VERSION }}
           command: versions upload --preview-alias pr-${{ steps.pr.outputs.number }} --message "https://github.com/${{ github.repository }}/pull/${{ steps.pr.outputs.number }}"
 
       - name: Calculate deploy time

--- a/.github/workflows/preview-fork-deploy.yml
+++ b/.github/workflows/preview-fork-deploy.yml
@@ -76,6 +76,15 @@ jobs:
         with:
           run_install: false
 
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Record deploy start time
         id: deploy-start
         run: echo "start-time=$(date +%s)" >> $GITHUB_OUTPUT
@@ -87,7 +96,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           packageManager: pnpm
-          wranglerVersion: ${{ vars.WRANGLER_VERSION }}
           command: versions upload --preview-alias pr-${{ steps.pr.outputs.number }} --message "https://github.com/${{ github.repository }}/pull/${{ steps.pr.outputs.number }}"
 
       - name: Calculate deploy time

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -443,6 +443,9 @@ jobs:
           node-version: 24
           cache: 'pnpm'
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Apply migrations to preview database
         if: needs.resolve-preview-context.outputs.drizzle-changed == 'true'
         uses: cloudflare/wrangler-action@v4


### PR DESCRIPTION
## Problem

`Preview Deploy` (and the other Wrangler deploy jobs) failed with `ERR_PNPM_ADDING_TO_ROOT`.

Root cause: the deploy-only jobs invoke `cloudflare/wrangler-action@v4` **without an `actions/setup-node` step**, so they run on the runner's default **Node v20**. Wrangler 4.x requires Node ≥22 — `wrangler --version` exits non-zero, the action falls into its reinstall branch and runs `pnpm add wrangler@4`, which pnpm v11 rejects in a workspace root. The `pnpm add` error was the symptom; the missing Node pin was the cause.

## Fix

Mirror the already-working build jobs:

- **Checkout-based deploy jobs** — `preview-deploy` → `deploy`, `preview-fork-deploy` → `deploy-fork-preview`, `production` → `deploy-preview-direct-push`: add `actions/setup-node@v4` (node 24, `cache: pnpm`) + `pnpm install --frozen-lockfile --ignore-scripts`. The lockfile-pinned Wrangler is then present before the action runs, so the broken reinstall branch is never reached.
- **`production` → `update-preview`** (no checkout, no pnpm): add `actions/setup-node@v4` (node 24) only — no cache, no install — so `npx wrangler` and the npm-fallback action run on Node 24.

`--ignore-scripts` skips `nuxt prepare` / husky / native builds that a prebuilt-`.output/`-artifact deploy doesn't need; `cache: pnpm` keeps installs fast on warm cache.

## Why it's future-proof

Every Wrangler-invoking job now pins Node 24 (matching `engines.node: ">=24"` and the build jobs), so they can't silently drop below Wrangler's rising Node floor again.
