### PR TITLE
fix(chat-input): match detach-all button radius to carousel thumbnails

### DIFF
--- a/app/components/ChatInput/Files/Attached/Preview.client.vue
+++ b/app/components/ChatInput/Files/Attached/Preview.client.vue
@@ -245,7 +245,7 @@
         class="group sticky right-0 carousel-item flex items-center"
       >
         <button
-          class="btn btn-error btn-soft size-16 flex flex-col gap-1 shadow-sm"
+          class="btn btn-error btn-soft size-16 rounded-box flex flex-col gap-1 shadow-sm"
           aria-label="Detach all files"
           title="Detach all files"
           data-testid="files-preview-detach-all"


### PR DESCRIPTION
## Summary
- The "Detach all files" button in the attached-files carousel (shown when 2+ files are attached) had no explicit radius override, so it inherited DaisyUI's `--radius-field` (bumped to `2rem` by the welcome-screen theme change in #267), rendering as a near-circle instead of matching the `rounded-box` radius used by the image thumbnails right next to it in the same carousel.
- Added the `rounded-box` utility class to the button so its corner radius matches `--radius-box` (`.5rem`), the same token already used by the thumbnails, the non-image file chips, and the carousel container in this component.

Fixes #273

## Test plan
- [x] `pnpm run format` / `pnpm run typecheck` / `pnpm run lint` — clean
- [x] `pnpm vitest run` — 470/470 tests passed, no regressions
- [x] Visually verified in browser: injected the carousel markup using the app's real compiled DaisyUI theme and confirmed the button now renders with the same boxy `rounded-box` corner radius as the thumbnails, instead of the near-circular shape from the inherited `--radius-field`
- [x] Code review (independent agent pass): 0 critical, 0 warnings — confirmed `rounded-box` reliably overrides DaisyUI's `.btn` radius per the library's layer-nesting design, and that the other `.btn-circle` buttons in the same file are unaffected/out of scope