### PR TITLE
feat(chat): show per-message metadata in the context menu

### DIFF
--- a/.drizzle/migrations/20260704223209_dapper_cardiac/migration.sql
+++ b/.drizzle/migrations/20260704223209_dapper_cardiac/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `messages` ADD `usage` text;

--- a/.drizzle/migrations/20260704223209_dapper_cardiac/snapshot.json
+++ b/.drizzle/migrations/20260704223209_dapper_cardiac/snapshot.json
@@ -1,0 +1,2113 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "6de2c06a-ad24-4076-9f8a-82e40a5dc74d",
+  "prevIds": [
+    "c02cce0b-10cd-4982-8d1d-de213d3d2928"
+  ],
+  "ddl": [
+    {
+      "name": "accounts",
+      "entityType": "tables"
+    },
+    {
+      "name": "sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "users",
+      "entityType": "tables"
+    },
+    {
+      "name": "verifications",
+      "entityType": "tables"
+    },
+    {
+      "name": "user_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "projects",
+      "entityType": "tables"
+    },
+    {
+      "name": "chats",
+      "entityType": "tables"
+    },
+    {
+      "name": "messages",
+      "entityType": "tables"
+    },
+    {
+      "name": "keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "files",
+      "entityType": "tables"
+    },
+    {
+      "name": "chat_share_files",
+      "entityType": "tables"
+    },
+    {
+      "name": "chat_shares",
+      "entityType": "tables"
+    },
+    {
+      "name": "storages",
+      "entityType": "tables"
+    },
+    {
+      "name": "image_transform_usage_monthly",
+      "entityType": "tables"
+    },
+    {
+      "name": "push_subscriptions",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_login_method",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "reasoning_expanded",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "reasoning_auto_hide",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "allow_external_links",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "notification_prompt_state",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "instructions",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'idle'",
+      "generated": null,
+      "name": "memory_status",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_updated_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_dirty_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_provider",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_model",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_error",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pinned_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activity_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "''",
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shared",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pinned_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_memory_summary",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_memory_summary_updated_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activity_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "parts",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "tools",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'off'",
+      "generated": null,
+      "name": "reasoning",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "usage",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "api_key",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_key",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "size",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_message_id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_provider",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_share_id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "revoked",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "20971520",
+      "generated": null,
+      "name": "storage",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'free'",
+      "generated": null,
+      "name": "tier",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "10",
+      "generated": null,
+      "name": "max_files_per_message",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1048576000",
+      "generated": null,
+      "name": "max_message_files_bytes",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "30",
+      "generated": null,
+      "name": "file_retention_days",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "image_transform_limit_total",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "image_transform_used_total",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "month_key",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "transforms_used",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1000",
+      "generated": null,
+      "name": "transforms_limit",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "endpoint",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "p256dh_key",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "auth_key",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "accounts_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "accounts"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sessions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "user_settings_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "user_settings"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "projects_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chats_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "projects",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "chats_project_id_projects_id_fk",
+      "entityType": "fks",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "messages_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "messages"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "keys_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "files_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "files"
+    },
+    {
+      "columns": [
+        "origin_message_id"
+      ],
+      "tableTo": "messages",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "files_origin_message_id_messages_id_fk",
+      "entityType": "fks",
+      "table": "files"
+    },
+    {
+      "columns": [
+        "chat_share_id"
+      ],
+      "tableTo": "chat_shares",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_share_files_chat_share_id_chat_shares_id_fk",
+      "entityType": "fks",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        "file_id"
+      ],
+      "tableTo": "files",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_share_files_file_id_files_id_fk",
+      "entityType": "fks",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_shares_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "storages_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "storages"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "push_subscriptions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pk",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pk",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pk",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pk",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_settings_pk",
+      "table": "user_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pk",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chats_pk",
+      "table": "chats",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "messages_pk",
+      "table": "messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "keys_pk",
+      "table": "keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "files_pk",
+      "table": "files",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chat_share_files_pk",
+      "table": "chat_share_files",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chat_shares_pk",
+      "table": "chat_shares",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "storages_pk",
+      "table": "storages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "month_key"
+      ],
+      "nameExplicit": false,
+      "name": "image_transform_usage_monthly_pk",
+      "table": "image_transform_usage_monthly",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "push_subscriptions_pk",
+      "table": "push_subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "table": "accounts"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "table": "verifications"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_user_settings_user",
+      "entityType": "indexes",
+      "table": "user_settings"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_project_user",
+      "entityType": "indexes",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        {
+          "value": "activity_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_projects_activity_at",
+      "entityType": "indexes",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_user",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_slug",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "activity_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_chats_activity_at",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "chat_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_message_chat",
+      "entityType": "indexes",
+      "table": "messages"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_key_user",
+      "entityType": "indexes",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_key_user_provider",
+      "entityType": "indexes",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_file_user",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "storage_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_file_storageKey",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_files_expires_at",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_share_id",
+          "isExpression": false
+        },
+        {
+          "value": "file_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_file",
+      "entityType": "indexes",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_chat",
+      "entityType": "indexes",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_storage_user",
+      "entityType": "indexes",
+      "table": "storages"
+    },
+    {
+      "columns": [
+        {
+          "value": "endpoint",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_push_subscriptions_endpoint",
+      "entityType": "indexes",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_push_subscriptions_user_id",
+      "entityType": "indexes",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        "token"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_token_unique",
+      "entityType": "uniques",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "email"
+      ],
+      "nameExplicit": false,
+      "name": "users_email_unique",
+      "entityType": "uniques",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "chats_slug_unique",
+      "entityType": "uniques",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "public_id"
+      ],
+      "nameExplicit": false,
+      "name": "messages_public_id_unique",
+      "entityType": "uniques",
+      "table": "messages"
+    }
+  ],
+  "renames": []
+}

--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -20,7 +20,7 @@
             <div
               v-if="dateTimeInfo.date"
               data-testid="message-menu-datetime"
-              class="text-xs font-normal text-base-content/50"
+              class="text-right text-xs font-normal text-base-content/50"
             >
               {{ dateTimeInfo.date }} · {{ dateTimeInfo.time }}
             </div>
@@ -35,12 +35,33 @@
               </span>
             </div>
             <div
+              v-if="info.reasoning && info.reasoning !== 'off'"
+              data-testid="message-menu-reasoning"
+              class="flex items-center justify-between gap-3 text-xs"
+            >
+              <span class="font-normal text-base-content/50">Reasoning</span>
+              <span
+                class="flex items-center gap-1.5 font-normal capitalize
+                  text-base-content"
+              >
+                <component
+                  :is="reasoningIconName"
+                  class="size-3.5"
+                />
+                {{ info.reasoning }}
+              </span>
+            </div>
+            <div
               v-if="toolsLabel"
               data-testid="message-menu-tools"
               class="flex items-center justify-between gap-3 text-xs"
             >
               <span class="font-normal text-base-content/50">Tools</span>
-              <span class="truncate font-normal text-base-content">
+              <span
+                class="flex items-center gap-1.5 font-normal
+                  text-base-content"
+              >
+                <Icon name="lucide:globe" size="14" />
                 {{ toolsLabel }}
               </span>
             </div>
@@ -130,6 +151,12 @@ const menuStyle = shallowRef<Record<string, string> | null>(
 
 const dateTimeInfo = computed(() => {
   return formatMessageDateTime(props.info?.createdAt)
+})
+
+const reasoningIconName = computed<string>(() => {
+  const level = props.info?.reasoning ?? 'off'
+
+  return `SvgoThink${level.charAt(0).toUpperCase()}${level.slice(1)}`
 })
 
 const toolsLabel = computed<string>(() => {

--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -45,6 +45,7 @@
               </span>
             </div>
             <div
+              v-if="info.tokens !== undefined"
               data-testid="message-menu-tokens"
               class="flex items-center justify-between gap-3 text-xs"
             >
@@ -54,6 +55,7 @@
               </span>
             </div>
             <div
+              v-if="info.cost !== undefined"
               data-testid="message-menu-cost"
               class="flex items-center justify-between gap-3 text-xs"
             >
@@ -76,7 +78,10 @@
             </div>
           </div>
         </li>
-        <li aria-hidden="true">
+        <li
+          aria-hidden="true"
+          class="pointer-events-none"
+        >
           <hr class="my-1 border-base-200">
         </li>
       </template>

--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -5,12 +5,81 @@
   >
     <ul
       ref="menu"
-      class="absolute z-[9999] menu menu-xs bg-base-100 rounded-xl shadow-lg border border-base-200 w-44 p-1"
+      class="absolute z-[9999] menu menu-xs bg-base-100 rounded-xl shadow-lg border border-base-200 w-64 p-1"
       :class="{ invisible: !menuStyle }"
       :style="menuStyle"
       @pointerdown.stop
       @contextmenu.stop.prevent
     >
+      <template v-if="info">
+        <li>
+          <div
+            data-testid="message-menu-info"
+            class="menu-title flex flex-col gap-1 !p-2 cursor-default"
+          >
+            <div
+              v-if="dateTimeInfo.date"
+              data-testid="message-menu-datetime"
+              class="text-xs font-normal text-base-content/50"
+            >
+              {{ dateTimeInfo.date }} · {{ dateTimeInfo.time }}
+            </div>
+            <div
+              v-if="info.model"
+              data-testid="message-menu-model"
+              class="flex items-center justify-between gap-3 text-xs"
+            >
+              <span class="font-normal text-base-content/50">Model</span>
+              <span class="truncate font-normal text-base-content">
+                {{ info.model }}
+              </span>
+            </div>
+            <div
+              v-if="toolsLabel"
+              data-testid="message-menu-tools"
+              class="flex items-center justify-between gap-3 text-xs"
+            >
+              <span class="font-normal text-base-content/50">Tools</span>
+              <span class="truncate font-normal text-base-content">
+                {{ toolsLabel }}
+              </span>
+            </div>
+            <div
+              data-testid="message-menu-tokens"
+              class="flex items-center justify-between gap-3 text-xs"
+            >
+              <span class="font-normal text-base-content/50">Tokens</span>
+              <span class="truncate font-normal text-base-content">
+                {{ tokensLabel }}
+              </span>
+            </div>
+            <div
+              data-testid="message-menu-cost"
+              class="flex items-center justify-between gap-3 text-xs"
+            >
+              <span class="font-normal text-base-content/50">Cost</span>
+              <span class="font-normal text-base-content">
+                {{ formatMessageCost(info.cost) }}
+              </span>
+            </div>
+            <div
+              v-if="info.turnTotalCost !== undefined"
+              data-testid="message-menu-turn-total"
+              class="flex items-center justify-between gap-3 text-xs"
+            >
+              <span class="font-normal text-base-content/50">
+                Turn total
+              </span>
+              <span class="font-normal text-base-content">
+                {{ formatMessageCost(info.turnTotalCost) }}
+              </span>
+            </div>
+          </div>
+        </li>
+        <li aria-hidden="true">
+          <hr class="my-1 border-base-200">
+        </li>
+      </template>
       <li>
         <button
           type="button"
@@ -25,9 +94,21 @@
 </template>
 
 <script setup lang="ts">
+import type { MessageMenuInfo } from '#shared/utils/message-metadata'
+import {
+  formatMessageCost,
+  formatMessageDateTime,
+  formatTokenCount,
+} from '#shared/utils/message-format'
+
+const TOOL_LABELS: Record<'web_search', string> = {
+  web_search: 'Web search',
+}
+
 const props = defineProps<{
   messageId: string | null
   anchorEl: HTMLElement | null
+  info?: MessageMenuInfo | null
 }>()
 
 const emit = defineEmits<{
@@ -41,6 +122,40 @@ let pointerDownTime = 0
 const menuStyle = shallowRef<Record<string, string> | null>(
   null,
 )
+
+const dateTimeInfo = computed(() => {
+  return formatMessageDateTime(props.info?.createdAt)
+})
+
+const toolsLabel = computed<string>(() => {
+  if (!props.info?.usedTools?.length) {
+    return ''
+  }
+
+  return props.info.usedTools
+    .map(tool => TOOL_LABELS[tool])
+    .join(', ')
+})
+
+const tokensLabel = computed<string>(() => {
+  if (!props.info) {
+    return ''
+  }
+
+  const tokens = formatTokenCount(props.info.tokens)
+
+  if (props.info.role === 'user') {
+    return `${tokens} input`
+  }
+
+  if (props.info.reasoningTokens !== undefined) {
+    const reasoningTokens = formatTokenCount(props.info.reasoningTokens)
+
+    return `${tokens} output · ${reasoningTokens} reasoning`
+  }
+
+  return `${tokens} output`
+})
 
 onMounted(async () => {
   await nextTick()

--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -29,8 +29,8 @@
               data-testid="message-menu-model"
               class="flex items-center justify-between gap-3 text-xs"
             >
-              <span class="font-normal text-base-content/50">Model</span>
-              <span class="truncate font-normal text-base-content">
+              <span class="shrink-0 font-normal text-base-content/50">Model</span>
+              <span class="min-w-0 truncate font-normal text-base-content">
                 {{ info.model }}
               </span>
             </div>
@@ -39,16 +39,16 @@
               data-testid="message-menu-reasoning"
               class="flex items-center justify-between gap-3 text-xs"
             >
-              <span class="font-normal text-base-content/50">Reasoning</span>
-              <span
-                class="flex items-center gap-1.5 font-normal capitalize
-                  text-base-content"
-              >
-                <component
-                  :is="reasoningIconName"
-                  class="size-3.5"
-                />
-                {{ info.reasoning }}
+              <span class="shrink-0 font-normal text-base-content/50">Reasoning</span>
+              <span class="flex min-w-0 flex-wrap items-center justify-end gap-1.5 font-normal text-base-content">
+                <component :is="reasoningIconName" class="size-3.5 shrink-0" />
+                <span class="capitalize">{{ info.reasoning }}</span>
+                <span
+                  v-if="info.reasoningTokens !== undefined"
+                  class="text-base-content/50"
+                >
+                  ({{ formatTokenCount(info.reasoningTokens) }} tokens)
+                </span>
               </span>
             </div>
             <div
@@ -56,12 +56,9 @@
               data-testid="message-menu-tools"
               class="flex items-center justify-between gap-3 text-xs"
             >
-              <span class="font-normal text-base-content/50">Tools</span>
-              <span
-                class="flex items-center gap-1.5 font-normal
-                  text-base-content"
-              >
-                <Icon name="lucide:globe" size="14" />
+              <span class="shrink-0 font-normal text-base-content/50">Tools</span>
+              <span class="flex min-w-0 flex-wrap items-center justify-end gap-1.5 font-normal text-base-content">
+                <Icon name="lucide:globe" size="14" class="shrink-0" />
                 {{ toolsLabel }}
               </span>
             </div>
@@ -70,9 +67,11 @@
               data-testid="message-menu-tokens"
               class="flex items-center justify-between gap-3 text-xs"
             >
-              <span class="font-normal text-base-content/50">Tokens</span>
-              <span class="truncate font-normal text-base-content">
+              <span class="shrink-0 font-normal text-base-content/50">
                 {{ tokensLabel }}
+              </span>
+              <span class="min-w-0 truncate font-normal text-base-content">
+                {{ formatTokenCount(info.tokens) }}
               </span>
             </div>
             <div
@@ -80,8 +79,8 @@
               data-testid="message-menu-cost"
               class="flex items-center justify-between gap-3 text-xs"
             >
-              <span class="font-normal text-base-content/50">Cost</span>
-              <span class="font-normal text-base-content">
+              <span class="shrink-0 font-normal text-base-content/50">Cost</span>
+              <span class="min-w-0 truncate font-normal text-base-content">
                 {{ formatMessageCost(info.cost) }}
               </span>
             </div>
@@ -90,10 +89,10 @@
               data-testid="message-menu-turn-total"
               class="flex items-center justify-between gap-3 text-xs"
             >
-              <span class="font-normal text-base-content/50">
+              <span class="shrink-0 font-normal text-base-content/50">
                 Turn total
               </span>
-              <span class="font-normal text-base-content">
+              <span class="min-w-0 truncate font-normal text-base-content">
                 {{ formatMessageCost(info.turnTotalCost) }}
               </span>
             </div>
@@ -170,23 +169,9 @@ const toolsLabel = computed<string>(() => {
 })
 
 const tokensLabel = computed<string>(() => {
-  if (!props.info) {
-    return ''
-  }
-
-  const tokens = formatTokenCount(props.info.tokens)
-
-  if (props.info.role === 'user') {
-    return `${tokens} input`
-  }
-
-  if (props.info.reasoningTokens !== undefined) {
-    const reasoningTokens = formatTokenCount(props.info.reasoningTokens)
-
-    return `${tokens} output · ${reasoningTokens} reasoning`
-  }
-
-  return `${tokens} output`
+  return props.info?.role === 'user'
+    ? 'Tokens (input)'
+    : 'Tokens (output)'
 })
 
 onMounted(async () => {

--- a/app/composables/chat.ts
+++ b/app/composables/chat.ts
@@ -8,6 +8,7 @@ import type {
 import type { ChatErrorPayload } from '#shared/types/chat-errors.d'
 import type { Chat, Tools } from '#shared/types/chats.d'
 import type { FileMetadata } from '#shared/types/files.d'
+import type { ChatMessageMetadata } from '#shared/types/message-usage.d'
 import type { ReasoningLevel } from '#shared/types/reasoning.d'
 import { parseError } from 'evlog'
 import { DefaultChatTransport } from 'ai'
@@ -529,6 +530,16 @@ export function useChat(chat: MaybeRefOrGetter<Chat>) {
   // elapsed time, with no special-casing needed for the remount itself.
   const currentTurnStartedAt = shallowRef<number>(0)
 
+  const hydratedMessages = chat.messages.map((message) => {
+    return {
+      ...message,
+      metadata: {
+        usage: message.usage ?? undefined,
+        createdAt: message.createdAt,
+      } satisfies ChatMessageMetadata,
+    }
+  })
+
   const {
     messages: sdkMessages,
     status: sdkStatus,
@@ -538,7 +549,7 @@ export function useChat(chat: MaybeRefOrGetter<Chat>) {
     clearError: sdkClearError,
   } = useChatSdk<UIMessage>({
     id: chat.id,
-    messages: chat.messages as unknown as UIMessage[],
+    messages: hydratedMessages as unknown as UIMessage[],
     transport: new DefaultChatTransport({
       api: api.value,
       async fetch(input, init) {

--- a/app/composables/haptics.ts
+++ b/app/composables/haptics.ts
@@ -4,8 +4,10 @@ import { useWebHaptics } from 'web-haptics/vue'
  * @docs https://haptics.lochie.me/
  */
 export function useHaptics() {
+  const { isDesktop } = useDevice()
+
   const { trigger } = useWebHaptics({
-    debug: true,
+    debug: isDesktop,
   })
 
   return {

--- a/app/pages/chats/[slug].vue
+++ b/app/pages/chats/[slug].vue
@@ -497,10 +497,16 @@ async function clearProjectContext() {
   })
 }
 
+const { hapticRigid, hapticSoft } = useHaptics()
+
 const selectedMessageId = shallowRef<string | null>(null)
 const selectedAnchorEl = shallowRef<HTMLElement | null>(null)
 
 function onMessageSelect(messageId: string) {
+  if (selectedMessageId.value === messageId) return
+
+  hapticRigid()
+
   selectedMessageId.value = messageId
 
   nuxtApp.callHook('chat:message-selected', messageId)
@@ -511,6 +517,8 @@ function onMessageSelect(messageId: string) {
 }
 
 function clearMessageSelection() {
+  hapticSoft()
+
   selectedMessageId.value = null
   selectedAnchorEl.value = null
 

--- a/app/pages/chats/[slug].vue
+++ b/app/pages/chats/[slug].vue
@@ -136,6 +136,7 @@
       v-if="selectedMessageId"
       :message-id="selectedMessageId"
       :anchor-el="selectedAnchorEl"
+      :info="selectedMessageInfo"
       @branch="branchFromMessage"
       @close="clearMessageSelection"
     />
@@ -144,6 +145,11 @@
 <script setup lang="ts">
 import { parseError } from 'evlog'
 import { isChatTestErrorId } from '#shared/utils/chat-test-errors'
+import {
+  getMessageMetadata,
+  getMessageUsedTools,
+} from '#shared/utils/message-metadata'
+import type { MessageMenuInfo } from '#shared/utils/message-metadata'
 
 definePageMeta({
   layout: 'chat',
@@ -514,6 +520,59 @@ function clearMessageSelection() {
 
   nuxtApp.callHook('chat:message-selected', null)
 }
+
+const selectedMessageInfo = computed<MessageMenuInfo | null>(() => {
+  if (!selectedMessageId.value) {
+    return null
+  }
+
+  const messageIndex = chatSdk.messages.findIndex((message) => {
+    return message.id === selectedMessageId.value
+  })
+
+  const message = chatSdk.messages[messageIndex]
+
+  if (!message) {
+    return null
+  }
+
+  const metadata = getMessageMetadata(message)
+
+  if (message.role === 'assistant') {
+    const turnTotalCost = (
+      metadata.usage?.inputCost !== undefined
+      && metadata.usage?.outputCost !== undefined
+    )
+      ? metadata.usage.inputCost + metadata.usage.outputCost
+      : undefined
+
+    return {
+      role: 'assistant',
+      createdAt: metadata.createdAt,
+      model: metadata.usage?.model,
+      usedTools: getMessageUsedTools(message),
+      tokens: metadata.usage?.outputTokens,
+      reasoningTokens: metadata.usage?.reasoningTokens,
+      cost: metadata.usage?.outputCost,
+      turnTotalCost,
+    }
+  }
+
+  const followingAssistant = chatSdk.messages
+    .slice(messageIndex + 1)
+    .find(candidate => candidate.role === 'assistant')
+
+  const followingUsage = followingAssistant
+    ? getMessageMetadata(followingAssistant).usage
+    : undefined
+
+  return {
+    role: 'user',
+    createdAt: metadata.createdAt,
+    tokens: followingUsage?.inputTokens,
+    cost: followingUsage?.inputCost,
+  }
+})
 
 if (import.meta.client) {
   onMounted(() => {

--- a/app/pages/chats/[slug].vue
+++ b/app/pages/chats/[slug].vue
@@ -145,11 +145,7 @@
 <script setup lang="ts">
 import { parseError } from 'evlog'
 import { isChatTestErrorId } from '#shared/utils/chat-test-errors'
-import {
-  getMessageMetadata,
-  getMessageUsedTools,
-} from '#shared/utils/message-metadata'
-import type { MessageMenuInfo } from '#shared/utils/message-metadata'
+import { resolveMessageMenuInfo } from '#shared/utils/message-metadata'
 
 definePageMeta({
   layout: 'chat',
@@ -521,57 +517,8 @@ function clearMessageSelection() {
   nuxtApp.callHook('chat:message-selected', null)
 }
 
-const selectedMessageInfo = computed<MessageMenuInfo | null>(() => {
-  if (!selectedMessageId.value) {
-    return null
-  }
-
-  const messageIndex = chatSdk.messages.findIndex((message) => {
-    return message.id === selectedMessageId.value
-  })
-
-  const message = chatSdk.messages[messageIndex]
-
-  if (!message) {
-    return null
-  }
-
-  const metadata = getMessageMetadata(message)
-
-  if (message.role === 'assistant') {
-    const turnTotalCost = (
-      metadata.usage?.inputCost !== undefined
-      && metadata.usage?.outputCost !== undefined
-    )
-      ? metadata.usage.inputCost + metadata.usage.outputCost
-      : undefined
-
-    return {
-      role: 'assistant',
-      createdAt: metadata.createdAt,
-      model: metadata.usage?.model,
-      usedTools: getMessageUsedTools(message),
-      tokens: metadata.usage?.outputTokens,
-      reasoningTokens: metadata.usage?.reasoningTokens,
-      cost: metadata.usage?.outputCost,
-      turnTotalCost,
-    }
-  }
-
-  const followingAssistant = chatSdk.messages
-    .slice(messageIndex + 1)
-    .find(candidate => candidate.role === 'assistant')
-
-  const followingUsage = followingAssistant
-    ? getMessageMetadata(followingAssistant).usage
-    : undefined
-
-  return {
-    role: 'user',
-    createdAt: metadata.createdAt,
-    tokens: followingUsage?.inputTokens,
-    cost: followingUsage?.inputCost,
-  }
+const selectedMessageInfo = computed(() => {
+  return resolveMessageMenuInfo(chatSdk.messages, selectedMessageId.value)
 })
 
 if (import.meta.client) {

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -203,7 +203,10 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern: /^app\/pages\/chats\/\[slug\]\.vue$/,
-      tests: messageUsageTests,
+      tests: [
+        ...messageUsageTests,
+        'tests/unit/composables/haptics.spec.ts',
+      ],
     },
     {
       pattern:

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -109,6 +109,13 @@ export function getAffectedTests(changedFiles) {
     'tests/e2e/chat/context-menu.spec.ts',
   ]
 
+  const messageUsageTests = [
+    'tests/unit/utils/message-format.spec.ts',
+    'tests/unit/utils/message-metadata.spec.ts',
+    'tests/unit/utils/message-usage.spec.ts',
+    'tests/unit/components/Chat/ContextMenu.client.spec.ts',
+  ]
+
   const cookieConsentTests = [
     'tests/unit/composables/preference-storage.spec.ts',
     'tests/unit/utils/consents.spec.ts',
@@ -191,6 +198,15 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern:
+        /^(shared\/utils\/message-format\.ts|shared\/utils\/message-metadata\.ts|server\/utils\/ai\/message-usage\.ts|shared\/types\/message-usage\.d\.ts|server\/utils\/ai\/cost-map\.ts)$/,
+      tests: messageUsageTests,
+    },
+    {
+      pattern: /^app\/pages\/chats\/\[slug\]\.vue$/,
+      tests: messageUsageTests,
+    },
+    {
+      pattern:
         /^(modules\/cookie-consent\/|app\/components\/Cookies\/|app\/components\/Sidebar\/Development\.vue$|i18n\/|app\/composables\/preference-storage\.ts$|app\/plugins\/cookie-consent-gate\.client\.ts$|server\/api\/v1\/consents\/|server\/utils\/consents(-db)?\.ts$|server\/db\/consent\/)/,
       tests: cookieConsentTests,
     },
@@ -236,7 +252,7 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern: /^app\/composables\/chat\.ts$/,
-      tests: chatStreamBranchTests,
+      tests: [...chatStreamBranchTests, ...messageUsageTests],
     },
     {
       pattern: /^app\/composables\/chat-test\.ts$/,
@@ -296,6 +312,7 @@ export function getAffectedTests(changedFiles) {
         ...historyProjectsTests,
         ...chatStreamBranchTests,
         ...chatTestEndpointTests,
+        ...messageUsageTests,
       ],
     },
     {

--- a/server/api/v1/chats/[slug]/index.get.ts
+++ b/server/api/v1/chats/[slug]/index.get.ts
@@ -39,6 +39,8 @@ export default defineEventHandler(async (event) => {
           parts: true,
           tools: true,
           reasoning: true,
+          createdAt: true,
+          usage: true,
         },
       },
     },

--- a/server/api/v1/chats/[slug]/index.post.ts
+++ b/server/api/v1/chats/[slug]/index.post.ts
@@ -7,6 +7,7 @@ import type {
 import type { SharedV2ProviderOptions } from '@ai-sdk/provider'
 import type { H3Event } from 'h3'
 import type { ChatErrorPayload } from '#shared/types/chat-errors.d'
+import type { MessageUsage } from '#shared/types/message-usage.d'
 import { isPersistedMessageRole } from '#shared/utils/chat-message-role'
 import type { FormattedTools } from '~~/server/types/tools.d'
 import { useLogger, createError, createRequestLogger, log } from 'evlog'
@@ -22,6 +23,7 @@ import {
   toUIMessageStream,
 } from 'ai'
 import * as schema from '~~/server/db/schema'
+import { buildMessageUsage } from '~~/server/utils/ai/message-usage'
 import { normalizeChatError } from '~~/server/utils/chats/errors'
 import { filterRecoverableUIMessageStreamErrors } from '~~/server/utils/chats/filter-ui-message-stream'
 import { validateMessageFilePolicy } from '~~/server/utils/files/file-governance'
@@ -604,7 +606,7 @@ export default defineEventHandler(async (event) => {
                     total: usage.totalTokens
                       ?? ((usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)),
                   },
-                  cost: computeModelCost(model.id, usage),
+                  cost: computeModelCost(model.id, provider.id, usage),
                 },
               })
             },
@@ -647,6 +649,22 @@ export default defineEventHandler(async (event) => {
           generateMessageId: () => messagePublicId,
           sendSources: true,
           sendReasoning: body.data.reasoning !== 'off',
+          messageMetadata({ part }) {
+            if (part.type !== 'finish') {
+              return undefined
+            }
+
+            const usage = buildMessageUsage(
+              part.totalUsage,
+              model.id,
+              provider.id,
+            )
+
+            return {
+              createdAt: new Date().toISOString(),
+              ...(usage ? { usage } : {}),
+            }
+          },
           onError(error) {
             const chatError = normalizeChatError({
               error,
@@ -683,6 +701,7 @@ export default defineEventHandler(async (event) => {
 
         const wasPersisted = await persistAssistantMessageFromStream({
           stream: persistenceStream,
+          result,
           db,
           event,
           providerId: provider.id,
@@ -774,23 +793,22 @@ export default defineEventHandler(async (event) => {
   })
 })
 
-// Dollars spent on a single generation, derived from the per-1M-token prices
-// in `getModelCostMap()`. Returns undefined when the model has no known price
-// so callers omit `ai.cost` rather than logging a misleading 0.
+// Dollars spent on a single generation, derived from the same per-1M-token
+// pricing `buildMessageUsage()` uses for persisted/streamed usage. Returns
+// undefined when the usage is incomplete or the model has no known price, so
+// callers omit `ai.cost` rather than logging a misleading 0.
 function computeModelCost(
   modelId: string,
+  providerId: string,
   usage: LanguageModelUsage,
 ): number | undefined {
-  const cost = getModelCostMap()[modelId]
+  const messageUsage = buildMessageUsage(usage, modelId, providerId)
 
-  if (!cost) {
+  if (!messageUsage || messageUsage.inputCost === undefined) {
     return undefined
   }
 
-  const inputTokens = usage.inputTokens ?? 0
-  const outputTokens = usage.outputTokens ?? 0
-
-  return (inputTokens * cost.input + outputTokens * cost.output) / 1_000_000
+  return messageUsage.inputCost + (messageUsage.outputCost ?? 0)
 }
 
 // Returns the inserted { id, publicId } row, OR `undefined` when
@@ -922,6 +940,7 @@ function buildPersistedAssistantReplayChunks(input: {
 
 async function persistAssistantMessageFromStream(input: {
   stream: ReadableStream<any>
+  result: ReturnType<typeof streamText>
   db: ReturnType<typeof useDb>
   event: H3Event
   providerId: string
@@ -971,6 +990,24 @@ async function persistAssistantMessageFromStream(input: {
       normalizationInput,
     )
 
+    let usage: MessageUsage | undefined
+
+    try {
+      usage = buildMessageUsage(
+        await input.result.usage,
+        input.modelId,
+        input.providerId,
+      )
+    } catch (exception) {
+      input.logger.set({
+        usageCapture: {
+          error: exception instanceof Error
+            ? exception.message
+            : String(exception),
+        },
+      })
+    }
+
     await insertMessageWithPublicId({
       db: input.db,
       values: {
@@ -979,6 +1016,7 @@ async function persistAssistantMessageFromStream(input: {
         parts: normalizedParts,
         tools: [],
         reasoning: input.reasoning,
+        usage: usage ?? null,
       },
       publicId: input.publicId,
     })

--- a/server/api/v1/chats/branch/index.post.ts
+++ b/server/api/v1/chats/branch/index.post.ts
@@ -48,6 +48,8 @@ export default defineEventHandler(async (event) => {
           parts: true,
           tools: true,
           reasoning: true,
+          usage: true,
+          createdAt: true,
         },
       },
     },
@@ -103,6 +105,8 @@ export default defineEventHandler(async (event) => {
         parts: message.parts,
         tools: message.tools,
         reasoning: message.reasoning,
+        usage: message.usage,
+        createdAt: message.createdAt,
       })
   }) as unknown as [BatchItem<'sqlite'>]
 

--- a/server/db/schemas/chats.ts
+++ b/server/db/schemas/chats.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from 'ai'
+import type { MessageUsage } from '#shared/types/message-usage.d'
 import { persistedMessageRoles } from '#shared/utils/chat-message-role'
 import { sql } from 'drizzle-orm'
 import {
@@ -54,6 +55,7 @@ export const messages = snakeCase.table(
     reasoning: text({ enum: ['off', 'low', 'medium', 'high'] })
       .notNull()
       .default('off'),
+    usage: text({ mode: 'json' }).$type<MessageUsage>(),
     publicId: text('public_id').unique().$defaultFn(() => ulid()),
   }, table => [
     uniqueIndex('uq_message_chat').on(table.id, table.chatId),

--- a/server/utils/ai/message-usage.ts
+++ b/server/utils/ai/message-usage.ts
@@ -1,0 +1,51 @@
+import type { LanguageModelUsage } from 'ai'
+import type { MessageUsage } from '#shared/types/message-usage.d'
+import { getModelCostMap } from '~~/server/utils/ai/cost-map'
+
+/**
+ * Build the persisted/streamed usage shape for one assistant message from
+ * the AI SDK's final `LanguageModelUsage`. Returns `undefined` when the
+ * generation was aborted or otherwise incomplete: the SDK reports every
+ * token field as `undefined` (never `0`) in that case, so a `0` here would
+ * misrepresent an unknown cost as a free one. Cost fields are likewise
+ * omitted (never fabricated as `0`) when the model has no known price in
+ * `getModelCostMap()`.
+ */
+export function buildMessageUsage(
+  usage: LanguageModelUsage,
+  modelId: string,
+  providerId: string,
+): MessageUsage | undefined {
+  const isIncompleteUsage = usage.inputTokens === undefined
+    && usage.outputTokens === undefined
+    && usage.totalTokens === undefined
+
+  if (isIncompleteUsage) {
+    return undefined
+  }
+
+  const inputTokens = usage.inputTokens ?? 0
+  const outputTokens = usage.outputTokens ?? 0
+  const totalTokens = usage.totalTokens ?? inputTokens + outputTokens
+  const reasoningTokens = usage.outputTokenDetails?.reasoningTokens
+  const cachedInputTokens = usage.inputTokenDetails?.cacheReadTokens
+  const cost = getModelCostMap()[modelId]
+  const inputCost = cost
+    ? (inputTokens * cost.input) / 1_000_000
+    : undefined
+  const outputCost = cost
+    ? (outputTokens * cost.output) / 1_000_000
+    : undefined
+
+  return {
+    model: modelId,
+    provider: providerId,
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
+    ...(cachedInputTokens === undefined ? {} : { cachedInputTokens }),
+    ...(inputCost === undefined ? {} : { inputCost }),
+    ...(outputCost === undefined ? {} : { outputCost }),
+  }
+}

--- a/shared/types/message-usage.d.ts
+++ b/shared/types/message-usage.d.ts
@@ -1,0 +1,16 @@
+export type MessageUsage = {
+  model: string
+  provider: string
+  inputTokens: number
+  outputTokens: number
+  reasoningTokens?: number
+  cachedInputTokens?: number
+  totalTokens: number
+  inputCost?: number
+  outputCost?: number
+}
+
+export type ChatMessageMetadata = {
+  usage?: MessageUsage
+  createdAt?: string | number | Date
+}

--- a/shared/utils/message-format.ts
+++ b/shared/utils/message-format.ts
@@ -1,0 +1,91 @@
+const TOKEN_COUNT_FORMATTER = new Intl.NumberFormat('en-US')
+
+const COST_ABOVE_CENT_FORMATTER = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 4,
+  useGrouping: false,
+})
+
+const COST_BELOW_CENT_FORMATTER = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 6,
+  useGrouping: false,
+})
+
+const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+})
+
+const TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+})
+
+export function formatTokenCount(
+  count: number | undefined | null,
+): string {
+  if (count === undefined || count === null) {
+    return '—'
+  }
+
+  return TOKEN_COUNT_FORMATTER.format(count)
+}
+
+/**
+ * Formats a US dollar cost for display.
+ *
+ * Contract:
+ * - `undefined`/`null` renders as an em-dash.
+ * - `0` renders as `$0.00`.
+ * - Values below one hundredth of a cent (`0.0001`) render as
+ *   `< $0.0001` instead of misleadingly rounding down to `$0.0000`.
+ * - Values at or above one cent (`0.01`) render with 2 to 4 decimals,
+ *   always keeping at least 2 decimals.
+ * - Smaller positive values render with up to 6 decimals.
+ * - In both cases, trailing zeros beyond the minimum are trimmed.
+ */
+export function formatMessageCost(
+  cost: number | undefined | null,
+): string {
+  if (cost === undefined || cost === null) {
+    return '—'
+  }
+
+  if (cost === 0) {
+    return '$0.00'
+  }
+
+  if (cost > 0 && cost < 0.0001) {
+    return '< $0.0001'
+  }
+
+  const formatter = cost >= 0.01
+    ? COST_ABOVE_CENT_FORMATTER
+    : COST_BELOW_CENT_FORMATTER
+
+  return `$${formatter.format(cost)}`
+}
+
+export function formatMessageDateTime(
+  value: string | number | Date | undefined | null,
+): { date: string, time: string } {
+  const empty = { date: '', time: '' }
+
+  if (value === undefined || value === null) {
+    return empty
+  }
+
+  const parsedDate = new Date(value)
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return empty
+  }
+
+  return {
+    date: DATE_FORMATTER.format(parsedDate),
+    time: TIME_FORMATTER.format(parsedDate),
+  }
+}

--- a/shared/utils/message-metadata.ts
+++ b/shared/utils/message-metadata.ts
@@ -11,6 +11,14 @@ export type MessageMenuInfo = {
   turnTotalCost?: number
 }
 
+type MenuMessage = {
+  id?: string
+  role: string
+  metadata?: unknown
+  parts?: unknown
+  createdAt?: string | number | Date
+}
+
 export function getMessageMetadata(
   message: { metadata?: unknown, createdAt?: string | number | Date },
 ): ChatMessageMetadata {
@@ -39,4 +47,61 @@ export function getMessageUsedTools(
   })
 
   return hasWebSearchPart ? ['web_search'] : []
+}
+
+export function resolveMessageMenuInfo(
+  messages: MenuMessage[],
+  selectedMessageId: string | null,
+): MessageMenuInfo | null {
+  if (!selectedMessageId) {
+    return null
+  }
+
+  const messageIndex = messages.findIndex((message) => {
+    return message.id === selectedMessageId
+  })
+
+  const message = messages[messageIndex]
+
+  if (!message) {
+    return null
+  }
+
+  const metadata = getMessageMetadata(message)
+
+  if (message.role === 'assistant') {
+    const usage = metadata.usage
+    const turnTotalCost
+      = usage?.inputCost !== undefined && usage?.outputCost !== undefined
+        ? usage.inputCost + usage.outputCost
+        : undefined
+
+    return {
+      role: 'assistant',
+      createdAt: metadata.createdAt,
+      model: usage?.model,
+      usedTools: getMessageUsedTools(message),
+      tokens: usage?.outputTokens,
+      reasoningTokens: usage?.reasoningTokens,
+      cost: usage?.outputCost,
+      turnTotalCost,
+    }
+  }
+
+  const nextMessage = messages
+    .slice(messageIndex + 1)
+    .find((candidate) => {
+      return candidate.role === 'user' || candidate.role === 'assistant'
+    })
+
+  const followingUsage = nextMessage?.role === 'assistant'
+    ? getMessageMetadata(nextMessage).usage
+    : undefined
+
+  return {
+    role: 'user',
+    createdAt: metadata.createdAt,
+    tokens: followingUsage?.inputTokens,
+    cost: followingUsage?.inputCost,
+  }
 }

--- a/shared/utils/message-metadata.ts
+++ b/shared/utils/message-metadata.ts
@@ -1,0 +1,42 @@
+import type { ChatMessageMetadata } from '#shared/types/message-usage.d'
+
+export type MessageMenuInfo = {
+  role: 'user' | 'assistant'
+  createdAt?: string | number | Date
+  model?: string
+  usedTools?: Array<'web_search'>
+  tokens?: number
+  reasoningTokens?: number
+  cost?: number
+  turnTotalCost?: number
+}
+
+export function getMessageMetadata(
+  message: { metadata?: unknown, createdAt?: string | number | Date },
+): ChatMessageMetadata {
+  const metadata = (message.metadata ?? {}) as ChatMessageMetadata
+
+  return {
+    usage: metadata.usage,
+    createdAt: metadata.createdAt ?? message.createdAt,
+  }
+}
+
+export function getMessageUsedTools(
+  message: { parts?: unknown },
+): Array<'web_search'> {
+  if (!Array.isArray(message.parts)) {
+    return []
+  }
+
+  const hasWebSearchPart = message.parts.some((part) => {
+    return (
+      typeof part === 'object'
+      && part !== null
+      && 'type' in part
+      && (part.type === 'source-url' || part.type === 'source-document')
+    )
+  })
+
+  return hasWebSearchPart ? ['web_search'] : []
+}

--- a/shared/utils/message-metadata.ts
+++ b/shared/utils/message-metadata.ts
@@ -1,10 +1,12 @@
 import type { ChatMessageMetadata } from '#shared/types/message-usage.d'
+import type { ReasoningLevel } from '#shared/types/reasoning.d'
 
 export type MessageMenuInfo = {
   role: 'user' | 'assistant'
   createdAt?: string | number | Date
   model?: string
   usedTools?: Array<'web_search'>
+  reasoning?: ReasoningLevel
   tokens?: number
   reasoningTokens?: number
   cost?: number
@@ -16,6 +18,7 @@ type MenuMessage = {
   role: string
   metadata?: unknown
   parts?: unknown
+  reasoning?: ReasoningLevel
   createdAt?: string | number | Date
 }
 
@@ -81,6 +84,7 @@ export function resolveMessageMenuInfo(
       createdAt: metadata.createdAt,
       model: usage?.model,
       usedTools: getMessageUsedTools(message),
+      reasoning: message.reasoning,
       tokens: usage?.outputTokens,
       reasoningTokens: usage?.reasoningTokens,
       cost: usage?.outputCost,

--- a/tests/integration/api/chats-branch.spec.ts
+++ b/tests/integration/api/chats-branch.spec.ts
@@ -36,9 +36,14 @@ interface PreparedInsert {
   __values: unknown
 }
 
+type BranchTestMessage = ReturnType<typeof createMessages>[number] & {
+  usage?: unknown
+  createdAt?: unknown
+}
+
 function createDb(overrides: {
   projectId?: string | null
-  messages?: ReturnType<typeof createMessages>
+  messages?: BranchTestMessage[]
 } = {}) {
   const batchedQueries: PreparedInsert[][] = []
 
@@ -212,6 +217,56 @@ describe('chat branch API', () => {
       expect(value).not.toHaveProperty('id')
       expect(value).not.toHaveProperty('publicId')
     }
+  })
+
+  it('copies usage and original createdAt onto branched messages', async () => {
+    const handler = await getHandler()
+    const usage = {
+      model: 'gpt-5.4',
+      provider: 'openai',
+      inputTokens: 5240,
+      outputTokens: 1180,
+      totalTokens: 6420,
+      inputCost: 0.0131,
+      outputCost: 0.0177,
+    }
+    const createdAt = new Date('2026-07-05T12:00:00.000Z')
+    const messages: BranchTestMessage[] = [
+      {
+        id: 'message-1',
+        publicId: 'public-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Reply' }],
+        tools: [],
+        reasoning: 'off',
+        usage,
+        createdAt,
+      },
+    ]
+    const { db, insertValues } = createDb({ messages })
+
+    vi.stubGlobal('useDb', () => db)
+
+    await handler({
+      body: {
+        chatSlug: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        messageId: 'message-1',
+      },
+    } as never)
+
+    const messageInsertCalls = insertValues.mock.calls.filter(
+      ([value]) => {
+        return value.role === 'user'
+          || value.role === 'assistant'
+      },
+    )
+
+    expect(messageInsertCalls[0][0]).toMatchObject({
+      chatId: 'new-chat',
+      role: 'assistant',
+      usage,
+      createdAt,
+    })
   })
 
   it('copies only messages up to the branch point', async () => {

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -1,5 +1,6 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MessageMenuInfo } from '#shared/utils/message-metadata'
 import ContextMenu from '../../../../app/components/Chat/ContextMenu.client.vue'
 
 describe('Chat/ContextMenu.client', () => {
@@ -129,5 +130,100 @@ describe('Chat/ContextMenu.client', () => {
     }))
 
     expect(wrapper.emitted('close')).toBeUndefined()
+  })
+
+  describe('usage info rendering', () => {
+    it('renders assistant usage info with model, tools, and costs', async () => {
+      const info: MessageMenuInfo = {
+        role: 'assistant',
+        createdAt: '2026-01-15T10:30:00.000Z',
+        model: 'gpt-5.4',
+        usedTools: ['web_search'],
+        tokens: 1180,
+        reasoningTokens: 320,
+        cost: 0.0047,
+        turnTotalCost: 0.0178,
+      }
+
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: {
+          messageId: 'm1',
+          anchorEl,
+          info,
+        },
+        attachTo: document.body,
+      })
+
+      expect(
+        wrapper.find('[data-testid="message-menu-model"]').text(),
+      ).toContain('gpt-5.4')
+      expect(
+        wrapper.find('[data-testid="message-menu-tools"]').text(),
+      ).toContain('Web search')
+      expect(
+        wrapper.find('[data-testid="message-menu-tokens"]').text(),
+      ).toContain('1,180 output')
+      expect(
+        wrapper.find('[data-testid="message-menu-tokens"]').text(),
+      ).toContain('320 reasoning')
+      expect(
+        wrapper.find('[data-testid="message-menu-cost"]').text(),
+      ).toContain('$0.0047')
+      expect(
+        wrapper.find('[data-testid="message-menu-turn-total"]').text(),
+      ).toContain('$0.0178')
+      expect(
+        wrapper.find('[data-testid="message-menu-datetime"]').exists(),
+      ).toBe(true)
+    })
+
+    it('renders user usage info without model, tools, or turn total', async () => {
+      const info: MessageMenuInfo = {
+        role: 'user',
+        createdAt: '2026-01-15T10:30:00.000Z',
+        tokens: 5240,
+        cost: 0.0131,
+      }
+
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: {
+          messageId: 'm1',
+          anchorEl,
+          info,
+        },
+        attachTo: document.body,
+      })
+
+      expect(
+        wrapper.find('[data-testid="message-menu-tokens"]').text(),
+      ).toContain('5,240 input')
+      expect(
+        wrapper.find('[data-testid="message-menu-cost"]').text(),
+      ).toContain('$0.0131')
+      expect(
+        wrapper.find('[data-testid="message-menu-model"]').exists(),
+      ).toBe(false)
+      expect(
+        wrapper.find('[data-testid="message-menu-tools"]').exists(),
+      ).toBe(false)
+      expect(
+        wrapper.find('[data-testid="message-menu-turn-total"]').exists(),
+      ).toBe(false)
+    })
+
+    it('renders no info block when info is omitted', async () => {
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: {
+          messageId: 'm1',
+          anchorEl,
+        },
+        attachTo: document.body,
+      })
+
+      expect(
+        wrapper.find('[data-testid="message-menu-info"]').exists(),
+      ).toBe(false)
+      expect(wrapper.text()).toContain('New chat from here')
+    })
   })
 })

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -165,11 +165,14 @@ describe('Chat/ContextMenu.client', () => {
         wrapper.find('[data-testid="message-menu-reasoning"]').text(),
       ).toContain('medium')
       expect(
-        wrapper.find('[data-testid="message-menu-tokens"]').text(),
-      ).toContain('1,180 output')
+        wrapper.find('[data-testid="message-menu-reasoning"]').text(),
+      ).toContain('320 tokens')
       expect(
         wrapper.find('[data-testid="message-menu-tokens"]').text(),
-      ).toContain('320 reasoning')
+      ).toContain('Tokens (output)')
+      expect(
+        wrapper.find('[data-testid="message-menu-tokens"]').text(),
+      ).toContain('1,180')
       expect(
         wrapper.find('[data-testid="message-menu-cost"]').text(),
       ).toContain('$0.0047')
@@ -200,7 +203,10 @@ describe('Chat/ContextMenu.client', () => {
 
       expect(
         wrapper.find('[data-testid="message-menu-tokens"]').text(),
-      ).toContain('5,240 input')
+      ).toContain('Tokens (input)')
+      expect(
+        wrapper.find('[data-testid="message-menu-tokens"]').text(),
+      ).toContain('5,240')
       expect(
         wrapper.find('[data-testid="message-menu-cost"]').text(),
       ).toContain('$0.0131')

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -225,5 +225,37 @@ describe('Chat/ContextMenu.client', () => {
       ).toBe(false)
       expect(wrapper.text()).toContain('New chat from here')
     })
+
+    it('hides tokens and cost rows when they are unavailable', async () => {
+      const info: MessageMenuInfo = {
+        role: 'assistant',
+        createdAt: '2026-01-15T10:30:00.000Z',
+        usedTools: ['web_search'],
+        tokens: undefined,
+        cost: undefined,
+      }
+
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: {
+          messageId: 'm1',
+          anchorEl,
+          info,
+        },
+        attachTo: document.body,
+      })
+
+      expect(
+        wrapper.find('[data-testid="message-menu-tokens"]').exists(),
+      ).toBe(false)
+      expect(
+        wrapper.find('[data-testid="message-menu-cost"]').exists(),
+      ).toBe(false)
+      expect(
+        wrapper.find('[data-testid="message-menu-datetime"]').exists(),
+      ).toBe(true)
+      expect(
+        wrapper.find('[data-testid="message-menu-tools"]').text(),
+      ).toContain('Web search')
+    })
   })
 })

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -139,6 +139,7 @@ describe('Chat/ContextMenu.client', () => {
         createdAt: '2026-01-15T10:30:00.000Z',
         model: 'gpt-5.4',
         usedTools: ['web_search'],
+        reasoning: 'medium',
         tokens: 1180,
         reasoningTokens: 320,
         cost: 0.0047,
@@ -160,6 +161,9 @@ describe('Chat/ContextMenu.client', () => {
       expect(
         wrapper.find('[data-testid="message-menu-tools"]').text(),
       ).toContain('Web search')
+      expect(
+        wrapper.find('[data-testid="message-menu-reasoning"]').text(),
+      ).toContain('medium')
       expect(
         wrapper.find('[data-testid="message-menu-tokens"]').text(),
       ).toContain('1,180 output')

--- a/tests/unit/composables/haptics.spec.ts
+++ b/tests/unit/composables/haptics.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { useHaptics } from '../../../app/composables/haptics'
+
+const mocks = vi.hoisted(() => ({
+  useWebHaptics: vi.fn(),
+  isDesktop: false,
+}))
+
+vi.mock('web-haptics/vue', () => ({
+  useWebHaptics: mocks.useWebHaptics,
+}))
+
+mockNuxtImport('useDevice', () => {
+  return () => ({ isDesktop: mocks.isDesktop })
+})
+
+describe('useHaptics', () => {
+  beforeEach(() => {
+    mocks.useWebHaptics.mockClear()
+    mocks.useWebHaptics.mockImplementation(() => ({
+      trigger: vi.fn(),
+      cancel: vi.fn(),
+      isSupported: false,
+    }))
+    mocks.isDesktop = false
+  })
+
+  it('enables the debug click sound on desktop', () => {
+    mocks.isDesktop = true
+
+    useHaptics()
+
+    expect(mocks.useWebHaptics).toHaveBeenCalledWith({ debug: true })
+  })
+
+  it('disables the debug click sound off desktop', () => {
+    mocks.isDesktop = false
+
+    useHaptics()
+
+    expect(mocks.useWebHaptics).toHaveBeenCalledWith({ debug: false })
+  })
+
+  it('returns the haptic trigger functions', () => {
+    const haptics = useHaptics()
+
+    expect(typeof haptics.hapticRigid).toBe('function')
+    expect(typeof haptics.hapticSoft).toBe('function')
+    expect(typeof haptics.haptic).toBe('function')
+  })
+})

--- a/tests/unit/utils/message-format.spec.ts
+++ b/tests/unit/utils/message-format.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatMessageCost,
+  formatMessageDateTime,
+  formatTokenCount,
+} from '../../../shared/utils/message-format'
+
+describe('formatTokenCount', () => {
+  it('renders an em-dash for undefined or null', () => {
+    expect(formatTokenCount(undefined)).toBe('—')
+    expect(formatTokenCount(null)).toBe('—')
+  })
+
+  it('renders a grouped token count', () => {
+    expect(formatTokenCount(5240)).toBe('5,240')
+  })
+
+  it('renders zero as-is', () => {
+    expect(formatTokenCount(0)).toBe('0')
+  })
+})
+
+describe('formatMessageCost', () => {
+  it('renders an em-dash for undefined or null', () => {
+    expect(formatMessageCost(undefined)).toBe('—')
+    expect(formatMessageCost(null)).toBe('—')
+  })
+
+  it('renders zero as $0.00', () => {
+    expect(formatMessageCost(0)).toBe('$0.00')
+  })
+
+  it('renders sub hundredth-of-a-cent costs as a lower bound', () => {
+    expect(formatMessageCost(0.00005)).toBe('< $0.0001')
+  })
+
+  it('renders below-cent costs with up to 6 decimals', () => {
+    expect(formatMessageCost(0.005)).toBe('$0.005')
+  })
+
+  it('renders at-or-above-cent costs with 2 to 4 decimals', () => {
+    expect(formatMessageCost(0.0131)).toBe('$0.0131')
+  })
+
+  it('pads whole-cent costs to 2 decimals', () => {
+    expect(formatMessageCost(2.5)).toBe('$2.50')
+  })
+})
+
+describe('formatMessageDateTime', () => {
+  it('renders empty parts for undefined or null', () => {
+    expect(formatMessageDateTime(undefined)).toEqual({
+      date: '',
+      time: '',
+    })
+    expect(formatMessageDateTime(null)).toEqual({
+      date: '',
+      time: '',
+    })
+  })
+
+  it('renders empty parts for an invalid date string', () => {
+    expect(formatMessageDateTime('not-a-date')).toEqual({
+      date: '',
+      time: '',
+    })
+  })
+
+  it('renders non-empty date and time parts for a valid value', () => {
+    const result = formatMessageDateTime('2026-01-15T10:30:00.000Z')
+
+    expect(result.date).toEqual(expect.any(String))
+    expect(result.time).toEqual(expect.any(String))
+    expect(result.date).not.toBe('')
+    expect(result.time).not.toBe('')
+  })
+})

--- a/tests/unit/utils/message-metadata.spec.ts
+++ b/tests/unit/utils/message-metadata.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getMessageMetadata,
+  getMessageUsedTools,
+} from '../../../shared/utils/message-metadata'
+
+describe('getMessageMetadata', () => {
+  it('returns usage and createdAt from message metadata', () => {
+    const usage = {
+      model: 'gpt-5.4',
+      provider: 'openai',
+      inputTokens: 100,
+      outputTokens: 200,
+      totalTokens: 300,
+    }
+
+    const result = getMessageMetadata({
+      metadata: { usage, createdAt: 'x' },
+    })
+
+    expect(result).toEqual({ usage, createdAt: 'x' })
+  })
+
+  it('falls back to the top-level createdAt when no metadata', () => {
+    const result = getMessageMetadata({ createdAt: 'top-level' })
+
+    expect(result).toEqual({
+      usage: undefined,
+      createdAt: 'top-level',
+    })
+  })
+
+  it('returns undefined usage and createdAt for an empty message', () => {
+    const result = getMessageMetadata({})
+
+    expect(result).toEqual({ usage: undefined, createdAt: undefined })
+  })
+})
+
+describe('getMessageUsedTools', () => {
+  it('returns web_search when a source-url part is present', () => {
+    const result = getMessageUsedTools({
+      parts: [
+        { type: 'text', text: 'hello' },
+        { type: 'source-url' },
+      ],
+    })
+
+    expect(result).toEqual(['web_search'])
+  })
+
+  it('returns web_search when a source-document part is present', () => {
+    const result = getMessageUsedTools({
+      parts: [{ type: 'source-document' }],
+    })
+
+    expect(result).toEqual(['web_search'])
+  })
+
+  it('returns an empty array for text-only parts', () => {
+    const result = getMessageUsedTools({
+      parts: [{ type: 'text', text: 'hello' }],
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it('returns an empty array when parts is missing', () => {
+    expect(getMessageUsedTools({})).toEqual([])
+  })
+
+  it('returns an empty array when parts is not an array', () => {
+    expect(getMessageUsedTools({ parts: 'not-an-array' })).toEqual([])
+  })
+})

--- a/tests/unit/utils/message-metadata.spec.ts
+++ b/tests/unit/utils/message-metadata.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   getMessageMetadata,
   getMessageUsedTools,
+  resolveMessageMenuInfo,
 } from '../../../shared/utils/message-metadata'
 
 describe('getMessageMetadata', () => {
@@ -71,5 +72,91 @@ describe('getMessageUsedTools', () => {
 
   it('returns an empty array when parts is not an array', () => {
     expect(getMessageUsedTools({ parts: 'not-an-array' })).toEqual([])
+  })
+})
+
+describe('resolveMessageMenuInfo', () => {
+  const assistantUsage = {
+    model: 'gpt-5.4',
+    provider: 'openai',
+    inputTokens: 5240,
+    outputTokens: 1180,
+    reasoningTokens: 320,
+    totalTokens: 6420,
+    inputCost: 0.0131,
+    outputCost: 0.0177,
+  }
+
+  it('returns null when no message is selected', () => {
+    expect(resolveMessageMenuInfo([], null)).toBeNull()
+  })
+
+  it('returns null when the selected message is not found', () => {
+    const messages = [{ id: 'a1', role: 'assistant' }]
+
+    expect(resolveMessageMenuInfo(messages, 'missing')).toBeNull()
+  })
+
+  it('resolves assistant info from its own usage', () => {
+    const messages = [{
+      id: 'a1',
+      role: 'assistant',
+      metadata: { usage: assistantUsage, createdAt: 'when' },
+      parts: [{ type: 'source-url' }],
+    }]
+
+    expect(resolveMessageMenuInfo(messages, 'a1')).toEqual({
+      role: 'assistant',
+      createdAt: 'when',
+      model: 'gpt-5.4',
+      usedTools: ['web_search'],
+      tokens: 1180,
+      reasoningTokens: 320,
+      cost: 0.0177,
+      turnTotalCost: 0.0131 + 0.0177,
+    })
+  })
+
+  it('attributes the input side of the next reply to a user message', () => {
+    const messages = [
+      { id: 'u1', role: 'user', metadata: { createdAt: 'sent' } },
+      { id: 'a1', role: 'assistant', metadata: { usage: assistantUsage } },
+    ]
+
+    expect(resolveMessageMenuInfo(messages, 'u1')).toEqual({
+      role: 'user',
+      createdAt: 'sent',
+      tokens: 5240,
+      cost: 0.0131,
+    })
+  })
+
+  it('does not borrow usage across an intervening user message', () => {
+    const messages = [
+      { id: 'u1', role: 'user', metadata: { createdAt: 'first' } },
+      { id: 'u2', role: 'user', metadata: { createdAt: 'second' } },
+      { id: 'a1', role: 'assistant', metadata: { usage: assistantUsage } },
+    ]
+
+    expect(resolveMessageMenuInfo(messages, 'u1')).toEqual({
+      role: 'user',
+      createdAt: 'first',
+      tokens: undefined,
+      cost: undefined,
+    })
+  })
+
+  it('leaves a trailing user message without token or cost data', () => {
+    const messages = [
+      { id: 'a1', role: 'assistant', metadata: { usage: assistantUsage } },
+      { id: 'u1', role: 'user', metadata: { createdAt: 'last' } },
+    ]
+
+    expect(resolveMessageMenuInfo(messages, 'u1')).toEqual({
+      role: 'user',
+      createdAt: 'last',
+      tokens: undefined,
+      cost: undefined,
+    })
   })
 })

--- a/tests/unit/utils/message-metadata.spec.ts
+++ b/tests/unit/utils/message-metadata.spec.ts
@@ -117,6 +117,17 @@ describe('resolveMessageMenuInfo', () => {
     })
   })
 
+  it('exposes the stored reasoning level for assistant messages', () => {
+    const messages = [{
+      id: 'a1',
+      role: 'assistant',
+      metadata: { usage: assistantUsage },
+      reasoning: 'medium' as const,
+    }]
+
+    expect(resolveMessageMenuInfo(messages, 'a1')?.reasoning).toBe('medium')
+  })
+
   it('attributes the input side of the next reply to a user message', () => {
     const messages = [
       { id: 'u1', role: 'user', metadata: { createdAt: 'sent' } },

--- a/tests/unit/utils/message-usage.spec.ts
+++ b/tests/unit/utils/message-usage.spec.ts
@@ -1,0 +1,130 @@
+import type { LanguageModelUsage } from 'ai'
+import { describe, expect, it } from 'vitest'
+import { buildMessageUsage } from '../../../server/utils/ai/message-usage'
+
+const PRICED_MODEL_ID = 'gpt-5.4'
+const PRICED_PROVIDER_ID = 'openai'
+const PRICED_MODEL_INPUT_PER_MILLION = 2.5
+const PRICED_MODEL_OUTPUT_PER_MILLION = 15
+
+function createUsage(
+  overrides: Partial<LanguageModelUsage> = {},
+): LanguageModelUsage {
+  return {
+    inputTokens: undefined,
+    inputTokenDetails: {
+      noCacheTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+    },
+    outputTokens: undefined,
+    outputTokenDetails: {
+      textTokens: undefined,
+      reasoningTokens: undefined,
+    },
+    totalTokens: undefined,
+    ...overrides,
+  }
+}
+
+describe('buildMessageUsage', () => {
+  it('returns undefined for incomplete usage', () => {
+    const usage = createUsage()
+
+    const result = buildMessageUsage(
+      usage,
+      PRICED_MODEL_ID,
+      PRICED_PROVIDER_ID,
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it('maps tokens and costs for a known-priced model', () => {
+    const usage = createUsage({
+      inputTokens: 1000,
+      inputTokenDetails: {
+        noCacheTokens: 800,
+        cacheReadTokens: 200,
+        cacheWriteTokens: undefined,
+      },
+      outputTokens: 500,
+      outputTokenDetails: {
+        textTokens: 380,
+        reasoningTokens: 120,
+      },
+      totalTokens: 1500,
+    })
+
+    const result = buildMessageUsage(
+      usage,
+      PRICED_MODEL_ID,
+      PRICED_PROVIDER_ID,
+    )
+
+    expect(result).toEqual({
+      model: PRICED_MODEL_ID,
+      provider: PRICED_PROVIDER_ID,
+      inputTokens: 1000,
+      outputTokens: 500,
+      totalTokens: 1500,
+      reasoningTokens: 120,
+      cachedInputTokens: 200,
+      inputCost: (1000 * PRICED_MODEL_INPUT_PER_MILLION) / 1_000_000,
+      outputCost: (500 * PRICED_MODEL_OUTPUT_PER_MILLION) / 1_000_000,
+    })
+  })
+
+  it('omits cost fields for an unpriced model', () => {
+    const usage = createUsage({
+      inputTokens: 1000,
+      outputTokens: 500,
+      totalTokens: 1500,
+    })
+
+    const result = buildMessageUsage(
+      usage,
+      'unknown-model-xyz',
+      PRICED_PROVIDER_ID,
+    )
+
+    expect(result?.inputTokens).toBe(1000)
+    expect(result?.outputTokens).toBe(500)
+    expect(result?.totalTokens).toBe(1500)
+    expect(result?.inputCost).toBeUndefined()
+    expect(result?.outputCost).toBeUndefined()
+  })
+
+  it('coalesces missing totalTokens to inputTokens plus outputTokens', () => {
+    const usage = createUsage({
+      inputTokens: 10,
+      outputTokens: 20,
+      totalTokens: undefined,
+    })
+
+    const result = buildMessageUsage(
+      usage,
+      PRICED_MODEL_ID,
+      PRICED_PROVIDER_ID,
+    )
+
+    expect(result?.totalTokens).toBe(30)
+  })
+
+  it('omits reasoningTokens and cachedInputTokens when absent', () => {
+    const usage = createUsage({
+      inputTokens: 10,
+      outputTokens: 20,
+      totalTokens: 30,
+    })
+
+    const result = buildMessageUsage(
+      usage,
+      PRICED_MODEL_ID,
+      PRICED_PROVIDER_ID,
+    )
+
+    expect(result).not.toHaveProperty('reasoningTokens')
+    expect(result).not.toHaveProperty('cachedInputTokens')
+  })
+})


### PR DESCRIPTION
## What

Adds a metadata panel to the existing per-message context menu in chats (right-click / long-press a bubble). No changes to the conversation bubbles themselves — the data lives only in the menu.

Per message it shows:

| Field | User message | AI reply |
|---|---|---|
| Date / time | ✅ | ✅ |
| Model | — | ✅ |
| Used tools (web search) | — | ✅ (when actually used) |
| Tokens | ✅ (input) | ✅ (output + reasoning) |
| Cost | ✅ (input cost) | ✅ (output cost) + turn total |

### Cost attribution

A user message never calls the model on its own — the model bills per turn (whole prompt in, reply out). So cost is split by turn side:

- **User message** → the turn's **input** tokens + input cost (the prompt it triggered).
- **AI reply** → **output** (+ reasoning) tokens + output cost, plus a **turn total** (`input + output`).

The two sum to what the turn actually cost. A user message reads its numbers from the nearest following assistant reply.

## How

- **Schema** — one nullable JSON column `usage` on `messages` (typed `MessageUsage`). The generated migration is a single additive `ALTER TABLE messages ADD COLUMN usage text` — **no table rebuild**, so no D1 cascade risk to `chats`/`messages` children.
- **Write path** (`index.post.ts`) — one `MessageUsage` object is built from the AI SDK's final `LanguageModelUsage` (`buildMessageUsage`, reusing the existing per-1M-token pricing map) and used for two channels from the same teed stream:
  - `await result.usage` → persisted into the assistant row's `usage` column.
  - `toUIMessageStream({ messageMetadata })` at the `finish` part → `message.metadata` so a **live** reply shows its data with no refetch.
  - Incomplete / aborted generations report `undefined` token fields (never `0`), so those persist as `usage: null` rather than a misleading free/zero cost. Usage capture is wrapped so it can never sink an otherwise-successful persist.
- **Read path** (`index.get.ts` + `chat.ts`) — GET now returns `createdAt` + `usage`; loaded messages are hydrated with `metadata: { usage, createdAt }` so historical messages carry the data.
- **UI** (`[slug].vue` + `ContextMenu.client.vue`) — the page resolves a per-message info object (attribution + web-search-used derivation from source parts); the menu renders it. `info` is optional and every row degrades to `—` / hides, so pre-migration and aborted messages render gracefully (date/time still shows).

## ⚠️ Migration note (remote D1)

The migration is additive and non-destructive, but per the repo runbook it still needs a careful remote apply:

1. Take a Time Travel bookmark first: `npx wrangler d1 time-travel info chat` (and `chat-preview`).
2. Apply to `chat-preview`, verify, then `chat`.
3. The SQL is exactly: `ALTER TABLE messages ADD usage text;` (verified — no `DROP TABLE` / rebuild).

Historical messages created before the migration simply show date/time + `—` for model/tokens/cost until they're regenerated.

## Testing

- 31 new unit tests: formatters (`message-format`), metadata + attribution helpers (`message-metadata`), usage builder (`message-usage`, against real `gpt-5.4` pricing), and menu rendering (assistant / user / no-info).
- New specs registered in `scripts/test-affected-check.mjs` (also closed a pre-existing gap: `[slug].vue` had no test mapping).
- Full suite green: **84 files / 592 tests passing**; `format` + `typecheck` clean.
