### PR TITLE
fix(chat): dismiss context menu on any tap outside it, not just outside the bubble

### DIFF
--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -526,7 +526,11 @@ function swallowNextClick() {
   function onClick(event: Event) {
     event.preventDefault()
     event.stopImmediatePropagation()
-    cleanup()
+    cleanup(true)
+  }
+
+  function onPointerDown() {
+    cleanup(false)
   }
 
   // Releasing on the next pointerdown (a new interaction starting) is a
@@ -535,24 +539,40 @@ function swallowNextClick() {
   // touch starting before this gesture's delayed synthetic click arrives
   // would let that click through unswallowed. The backstop timer bounds
   // the same window if no pointerdown happens at all.
-  function cleanup() {
+  //
+  // deferRelease is true only when THIS click was the one being swallowed:
+  // the image-preview guard must stay elevated for that click's entire
+  // synchronous dispatch (checked by GeneratedImage/Files in their own
+  // click handler), even if stopImmediatePropagation somehow failed to
+  // halt it beforehand. A pointerdown/backstop-triggered release means no
+  // click is currently mid-dispatch, so releasing immediately is both safe
+  // and necessary — deferring here would risk still reading "suppressed"
+  // for a fresh, unrelated click dispatched synchronously right after.
+  function cleanup(deferRelease: boolean) {
     document.removeEventListener('click', onClick, { capture: true })
-    document.removeEventListener('pointerdown', cleanup, { capture: true })
+    document.removeEventListener('pointerdown', onPointerDown, {
+      capture: true,
+    })
     clearTimeout(backstopTimer)
     cancelSwallowedClick = null
 
-    // Deferred a tick so the image-preview guard (checked synchronously by
-    // GeneratedImage/Files on their own click handler) stays elevated for
-    // the entire dispatch of a swallowed click, even if this handler's own
-    // stopImmediatePropagation somehow failed to halt it beforehand.
-    setTimeout(releaseImagePreview, 0)
+    if (deferRelease) {
+      setTimeout(releaseImagePreview, 0)
+
+      return
+    }
+
+    releaseImagePreview()
   }
 
-  const backstopTimer = setTimeout(cleanup, SWALLOWED_CLICK_BACKSTOP_MS)
+  const backstopTimer = setTimeout(
+    () => cleanup(false),
+    SWALLOWED_CLICK_BACKSTOP_MS,
+  )
 
   document.addEventListener('click', onClick, { capture: true })
-  document.addEventListener('pointerdown', cleanup, { capture: true })
-  cancelSwallowedClick = cleanup
+  document.addEventListener('pointerdown', onPointerDown, { capture: true })
+  cancelSwallowedClick = () => cleanup(false)
 }
 
 function onDocumentContextMenu(event: Event) {

--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -217,6 +217,8 @@ const emit = defineEmits<{
 const POINTER_MOVE_THRESHOLD_PX = 8
 const SWALLOWED_CLICK_BACKSTOP_MS = 500
 
+const { suppressImagePreview, releaseImagePreview } = useImagePreviewGuard()
+
 const menu = useTemplateRef<HTMLUListElement>('menu')
 let pointerDownTime = 0
 let pointerDownX = 0
@@ -538,6 +540,12 @@ function swallowNextClick() {
     document.removeEventListener('pointerdown', cleanup, { capture: true })
     clearTimeout(backstopTimer)
     cancelSwallowedClick = null
+
+    // Deferred a tick so the image-preview guard (checked synchronously by
+    // GeneratedImage/Files on their own click handler) stays elevated for
+    // the entire dispatch of a swallowed click, even if this handler's own
+    // stopImmediatePropagation somehow failed to halt it beforehand.
+    setTimeout(releaseImagePreview, 0)
   }
 
   const backstopTimer = setTimeout(cleanup, SWALLOWED_CLICK_BACKSTOP_MS)
@@ -562,6 +570,7 @@ function onSelectionChange() {
 }
 
 onMounted(() => {
+  suppressImagePreview()
   document.addEventListener('keydown', onKeyDown)
   document.addEventListener('pointerdown', onDocumentPointerDown)
   document.addEventListener('pointerup', onDocumentPointerUp)
@@ -571,6 +580,14 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  // Only release immediately when no swallow is pending for this instance
+  // — if one is, its own cleanup() releases the guard once the swallowed
+  // click (or the backstop) actually resolves, since this component can
+  // unmount well before that.
+  if (!cancelSwallowedClick) {
+    releaseImagePreview()
+  }
+
   document.removeEventListener('keydown', onKeyDown)
   document.removeEventListener('pointerdown', onDocumentPointerDown)
   document.removeEventListener('pointerup', onDocumentPointerUp)

--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -214,8 +214,12 @@ const emit = defineEmits<{
   close: []
 }>()
 
+const POINTER_MOVE_THRESHOLD_PX = 8
+
 const menu = useTemplateRef<HTMLUListElement>('menu')
 let pointerDownTime = 0
+let pointerDownX = 0
+let pointerDownY = 0
 
 const menuStyle = shallowRef<Record<string, string> | null>(
   null,
@@ -480,8 +484,10 @@ function onKeyDown(event: KeyboardEvent) {
   }
 }
 
-function onDocumentPointerDown() {
+function onDocumentPointerDown(event: PointerEvent) {
   pointerDownTime = Date.now()
+  pointerDownX = event.clientX
+  pointerDownY = event.clientY
 }
 
 function onDocumentPointerUp(event: PointerEvent) {
@@ -492,7 +498,15 @@ function onDocumentPointerUp(event: PointerEvent) {
   const target = event.target as HTMLElement
 
   if (menu.value?.contains(target)) return
-  if (bubbleEl.value?.contains(target)) return
+
+  const dx = Math.abs(event.clientX - pointerDownX)
+  const dy = Math.abs(event.clientY - pointerDownY)
+
+  if (dx > POINTER_MOVE_THRESHOLD_PX || dy > POINTER_MOVE_THRESHOLD_PX) return
+
+  const selection = window.getSelection()
+
+  if (selection && !selection.isCollapsed) return
 
   event.preventDefault()
   event.stopImmediatePropagation()

--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -504,9 +504,11 @@ function onDocumentPointerUp(event: PointerEvent) {
 
   if (dx > POINTER_MOVE_THRESHOLD_PX || dy > POINTER_MOVE_THRESHOLD_PX) return
 
-  const selection = window.getSelection()
+  if (bubbleEl.value?.contains(target)) {
+    const selection = window.getSelection()
 
-  if (selection && !selection.isCollapsed) return
+    if (selection && !selection.isCollapsed) return
+  }
 
   event.preventDefault()
   event.stopImmediatePropagation()

--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -215,11 +215,13 @@ const emit = defineEmits<{
 }>()
 
 const POINTER_MOVE_THRESHOLD_PX = 8
+const SWALLOWED_CLICK_BACKSTOP_MS = 500
 
 const menu = useTemplateRef<HTMLUListElement>('menu')
 let pointerDownTime = 0
 let pointerDownX = 0
 let pointerDownY = 0
+let cancelSwallowedClick: (() => void) | null = null
 
 const menuStyle = shallowRef<Record<string, string> | null>(
   null,
@@ -517,19 +519,32 @@ function onDocumentPointerUp(event: PointerEvent) {
 }
 
 function swallowNextClick() {
-  const handler = (event: Event) => {
+  cancelSwallowedClick?.()
+
+  function onClick(event: Event) {
     event.preventDefault()
     event.stopImmediatePropagation()
+    cleanup()
   }
 
-  document.addEventListener('click', handler, {
-    capture: true,
-    once: true,
-  })
+  // Releasing on the next pointerdown (a new interaction starting) is a
+  // deliberate trade-off: it avoids over-swallowing a legitimate click that
+  // follows quickly, at the cost of a narrow window where an unrelated
+  // touch starting before this gesture's delayed synthetic click arrives
+  // would let that click through unswallowed. The backstop timer bounds
+  // the same window if no pointerdown happens at all.
+  function cleanup() {
+    document.removeEventListener('click', onClick, { capture: true })
+    document.removeEventListener('pointerdown', cleanup, { capture: true })
+    clearTimeout(backstopTimer)
+    cancelSwallowedClick = null
+  }
 
-  setTimeout(() => {
-    document.removeEventListener('click', handler, { capture: true })
-  }, 100)
+  const backstopTimer = setTimeout(cleanup, SWALLOWED_CLICK_BACKSTOP_MS)
+
+  document.addEventListener('click', onClick, { capture: true })
+  document.addEventListener('pointerdown', cleanup, { capture: true })
+  cancelSwallowedClick = cleanup
 }
 
 function onDocumentContextMenu(event: Event) {

--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -224,6 +224,8 @@ let pointerDownTime = 0
 let pointerDownX = 0
 let pointerDownY = 0
 let cancelSwallowedClick: (() => void) | null = null
+let hasReleasedGuard = false
+let isSwallowScheduled = false
 
 const menuStyle = shallowRef<Record<string, string> | null>(
   null,
@@ -520,17 +522,36 @@ function onDocumentPointerUp(event: PointerEvent) {
   dismiss()
 }
 
+// Guarantees the mount-time suppressImagePreview() is matched by exactly
+// one release, no matter which of the paths below (swallowed click,
+// pointerdown/backstop cleanup, or plain unmount) gets there first.
+function releaseGuardOnce() {
+  if (hasReleasedGuard) return
+
+  hasReleasedGuard = true
+  releaseImagePreview()
+}
+
 function swallowNextClick() {
+  isSwallowScheduled = true
   cancelSwallowedClick?.()
 
   function onClick(event: Event) {
+    // Third-party libraries can dispatch untrusted synthetic clicks at
+    // arbitrary times (e.g. web-haptics' debug-mode toggle fires one as
+    // a side effect of playing feedback on message selection). Since this
+    // listener swallows only the NEXT click it sees, a stray synthetic
+    // click here would consume it instead of the real trailing click of
+    // this dismiss gesture, letting that real click through unguarded.
+    if (!event.isTrusted) return
+
     event.preventDefault()
     event.stopImmediatePropagation()
-    cleanup(true)
+    cleanup()
   }
 
   function onPointerDown() {
-    cleanup(false)
+    cleanup()
   }
 
   // Releasing on the next pointerdown (a new interaction starting) is a
@@ -539,40 +560,21 @@ function swallowNextClick() {
   // touch starting before this gesture's delayed synthetic click arrives
   // would let that click through unswallowed. The backstop timer bounds
   // the same window if no pointerdown happens at all.
-  //
-  // deferRelease is true only when THIS click was the one being swallowed:
-  // the image-preview guard must stay elevated for that click's entire
-  // synchronous dispatch (checked by GeneratedImage/Files in their own
-  // click handler), even if stopImmediatePropagation somehow failed to
-  // halt it beforehand. A pointerdown/backstop-triggered release means no
-  // click is currently mid-dispatch, so releasing immediately is both safe
-  // and necessary — deferring here would risk still reading "suppressed"
-  // for a fresh, unrelated click dispatched synchronously right after.
-  function cleanup(deferRelease: boolean) {
+  function cleanup() {
     document.removeEventListener('click', onClick, { capture: true })
     document.removeEventListener('pointerdown', onPointerDown, {
       capture: true,
     })
     clearTimeout(backstopTimer)
     cancelSwallowedClick = null
-
-    if (deferRelease) {
-      setTimeout(releaseImagePreview, 0)
-
-      return
-    }
-
-    releaseImagePreview()
+    releaseGuardOnce()
   }
 
-  const backstopTimer = setTimeout(
-    () => cleanup(false),
-    SWALLOWED_CLICK_BACKSTOP_MS,
-  )
+  const backstopTimer = setTimeout(cleanup, SWALLOWED_CLICK_BACKSTOP_MS)
 
   document.addEventListener('click', onClick, { capture: true })
   document.addEventListener('pointerdown', onPointerDown, { capture: true })
-  cancelSwallowedClick = () => cleanup(false)
+  cancelSwallowedClick = cleanup
 }
 
 function onDocumentContextMenu(event: Event) {
@@ -600,12 +602,14 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  // Only release immediately when no swallow is pending for this instance
-  // — if one is, its own cleanup() releases the guard once the swallowed
-  // click (or the backstop) actually resolves, since this component can
-  // unmount well before that.
-  if (!cancelSwallowedClick) {
-    releaseImagePreview()
+  // Only release immediately when no swallow was ever scheduled for this
+  // instance — if one was, its own cleanup() releases the guard once the
+  // swallowed click (or the backstop) actually resolves, since this
+  // component can unmount well before that. isSwallowScheduled (unlike
+  // cancelSwallowedClick) stays true even after the swallow resolves, so
+  // this check can't race with cleanup() already having run.
+  if (!isSwallowScheduled) {
+    releaseGuardOnce()
   }
 
   document.removeEventListener('keydown', onKeyDown)

--- a/app/components/Chat/Files.vue
+++ b/app/components/Chat/Files.vue
@@ -15,7 +15,8 @@
             ? 'Hidden file'
             : `File ${file.filename || 'attachment'}`
         "
-        class="group carousel-item relative overflow-hidden flex items-center justify-center size-48 rounded-box aspect-square bg-base-300"
+        class="group/file carousel-item relative overflow-hidden flex items-center justify-center size-48 rounded-box aspect-square bg-base-300"
+        :class="{ 'pointer-events-none': isImagePreviewSuppressed }"
       >
         <Icon
           :name="getFileIcon(file.mediaType)"
@@ -53,8 +54,7 @@
         <button
           v-else-if="file.links && isImageFile(file.mediaType)"
           type="button"
-          class="absolute inset-0 z-20 block size-full"
-          :class="isImagePreviewSuppressed ? 'cursor-default' : 'cursor-zoom-in'"
+          class="absolute inset-0 z-20 block size-full cursor-zoom-in focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
           :aria-label="`Preview ${file.filename || 'attached image'}`"
           data-testid="chat-file-preview-trigger"
           @click="openImagePreview(file)"
@@ -72,7 +72,7 @@
           class="absolute z-30 top-2 right-2 flex gap-1"
           :class="{
             [
-              'md:opacity-0 md:group-hover:opacity-100 '
+              'md:opacity-0 md:group-hover/file:opacity-100 '
               + 'md:focus-within:opacity-100 transition-opacity'
             ]: $device.isDesktop,
           }"
@@ -126,7 +126,7 @@
             [`
               md:transition-transform
               md:translate-y-full
-              md:group-hover:translate-y-0
+              md:group-hover/file:translate-y-0
             `]: $device.isDesktop && isImageFile(file.mediaType),
           }"
         >

--- a/app/components/Chat/Files.vue
+++ b/app/components/Chat/Files.vue
@@ -162,6 +162,8 @@ const props = defineProps<{
   message: UIMessage
 }>()
 
+const { isSuppressed: isImagePreviewSuppressed } = useImagePreviewGuard()
+
 const containerRef = useTemplateRef<HTMLDivElement>('containerRef')
 const failedUrls = reactive<Record<string, boolean>>({})
 const previewFile = shallowRef<DisplayFile | null>(null)
@@ -204,6 +206,8 @@ function onImageError(url: string) {
 }
 
 function openImagePreview(file: DisplayFile) {
+  if (isImagePreviewSuppressed.value) return
+
   if (!file.links || !isImageFile(file.mediaType)) {
     return
   }

--- a/app/components/Chat/Files.vue
+++ b/app/components/Chat/Files.vue
@@ -53,7 +53,8 @@
         <button
           v-else-if="file.links && isImageFile(file.mediaType)"
           type="button"
-          class="absolute inset-0 z-20 block size-full cursor-zoom-in"
+          class="absolute inset-0 z-20 block size-full"
+          :class="isImagePreviewSuppressed ? 'cursor-default' : 'cursor-zoom-in'"
           :aria-label="`Preview ${file.filename || 'attached image'}`"
           data-testid="chat-file-preview-trigger"
           @click="openImagePreview(file)"

--- a/app/components/Chat/GeneratedImage.vue
+++ b/app/components/Chat/GeneratedImage.vue
@@ -169,6 +169,8 @@ const { messageRole, part } = defineProps<{
   part: UIMessage['parts'][number]
 }>()
 
+const { isSuppressed: isImagePreviewSuppressed } = useImagePreviewGuard()
+
 const isImageLoaded = shallowRef<boolean>(false)
 const hasImageLoadError = shallowRef<boolean>(false)
 const isImagePreviewOpen = shallowRef<boolean>(false)
@@ -288,6 +290,8 @@ function onImageError() {
 }
 
 function openImagePreview() {
+  if (isImagePreviewSuppressed.value) return
+
   isImagePreviewOpen.value = true
 }
 

--- a/app/components/Chat/GeneratedImage.vue
+++ b/app/components/Chat/GeneratedImage.vue
@@ -26,7 +26,8 @@
     >
       <button
         type="button"
-        class="relative block w-full cursor-zoom-in overflow-hidden rounded-t-box bg-base-300 disabled:cursor-default"
+        class="relative block w-full overflow-hidden rounded-t-box bg-base-300 disabled:cursor-default"
+        :class="isImagePreviewSuppressed ? 'cursor-default' : 'cursor-zoom-in'"
         :style="{ aspectRatio: imageAspectRatio }"
         :disabled="hasImageLoadError"
         :aria-label="`Preview ${readyFile.name}`"

--- a/app/components/Chat/GeneratedImage.vue
+++ b/app/components/Chat/GeneratedImage.vue
@@ -26,8 +26,8 @@
     >
       <button
         type="button"
-        class="relative block w-full overflow-hidden rounded-t-box bg-base-300 disabled:cursor-default"
-        :class="isImagePreviewSuppressed ? 'cursor-default' : 'cursor-zoom-in'"
+        class="relative block w-full cursor-zoom-in overflow-hidden rounded-t-box bg-base-300 disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
+        :class="{ 'pointer-events-none': isImagePreviewSuppressed }"
         :style="{ aspectRatio: imageAspectRatio }"
         :disabled="hasImageLoadError"
         :aria-label="`Preview ${readyFile.name}`"

--- a/app/composables/chat-image-preview-guard.ts
+++ b/app/composables/chat-image-preview-guard.ts
@@ -1,0 +1,19 @@
+export function useImagePreviewGuard() {
+  const guardCount = useState<number>('image-preview-guard-count', () => 0)
+
+  const isSuppressed = computed<boolean>(() => guardCount.value > 0)
+
+  function suppressImagePreview() {
+    guardCount.value += 1
+  }
+
+  function releaseImagePreview() {
+    guardCount.value = Math.max(0, guardCount.value - 1)
+  }
+
+  return {
+    isSuppressed,
+    suppressImagePreview,
+    releaseImagePreview,
+  }
+}

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -68,6 +68,7 @@ export function getAffectedTests(changedFiles) {
     'tests/integration/server/convert-files-for-ai.spec.ts',
     'tests/e2e/chat/files.spec.ts',
     'tests/e2e/chat/files-carousel-scroll.spec.ts',
+    'tests/e2e/shared/context-menu-image-hover.spec.ts',
   ]
   const profileSettingsTests = [
     'tests/integration/api/profile-settings.spec.ts',
@@ -129,6 +130,7 @@ export function getAffectedTests(changedFiles) {
     'tests/e2e/chat/context-menu-image.spec.ts',
     'tests/e2e/chat/context-menu-image-desktop.spec.ts',
     'tests/e2e/shared/context-menu-clipping.spec.ts',
+    'tests/e2e/shared/context-menu-image-hover.spec.ts',
     'tests/unit/utils/markdown-plain.spec.ts',
   ]
 

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -95,6 +95,7 @@ export function getAffectedTests(changedFiles) {
   const chatTestEndpointTests = [
     'tests/integration/api/chats-test-endpoint.spec.ts',
     'tests/e2e/chat/context-menu-image.spec.ts',
+    'tests/e2e/chat/context-menu-image-desktop.spec.ts',
   ]
   const historyProjectsTests = [
     'tests/unit/components/History/PageShell.spec.ts',
@@ -126,6 +127,7 @@ export function getAffectedTests(changedFiles) {
     'tests/unit/components/Chat/Message.spec.ts',
     'tests/e2e/chat/context-menu.spec.ts',
     'tests/e2e/chat/context-menu-image.spec.ts',
+    'tests/e2e/chat/context-menu-image-desktop.spec.ts',
     'tests/e2e/shared/context-menu-clipping.spec.ts',
     'tests/unit/utils/markdown-plain.spec.ts',
   ]

--- a/tests/e2e/chat/context-menu-image-desktop.spec.ts
+++ b/tests/e2e/chat/context-menu-image-desktop.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('chat context menu for AI-generated-image messages (desktop mouse)', () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(30_000)
+
+    await page.goto('/chats/test?scenario=image&messages=2')
+    await page.waitForSelector('[data-role="assistant"]')
+  })
+
+  test('right-clicking a message then left-clicking a different message\'s image dismisses the menu without opening the preview', async ({
+    page,
+  }) => {
+    const userMessage = page.locator('[data-role="user"]').first()
+    const previewTrigger = page.getByTestId('generated-image-preview-trigger')
+
+    await expect(userMessage).toBeVisible()
+    await expect(previewTrigger).toBeVisible()
+
+    await userMessage.click({ button: 'right' })
+
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeVisible()
+
+    await previewTrigger.click()
+
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeHidden()
+
+    // The preview is a lazy-loaded async component that can take a couple
+    // of seconds to compile in dev mode on first use. Asserting "hidden"
+    // immediately would trivially pass before it ever had a chance to
+    // render, whether or not the click actually got through — wait out
+    // that window first so this proves it never opens, not that it merely
+    // hasn't opened yet.
+    await page.waitForTimeout(3000)
+
+    await expect(page.getByTestId('image-preview-modal')).toBeHidden()
+  })
+
+  test('right-clicking the assistant message with its own image dismisses the menu without opening the preview', async ({
+    page,
+  }) => {
+    const assistantMessage = page.locator('[data-role="assistant"]').first()
+    const previewTrigger = page.getByTestId('generated-image-preview-trigger')
+    // Right-clicking directly on the <img>/preview trigger is intentionally
+    // exempt from opening the context menu (preserves the browser's native
+    // image context menu), so target the filename caption below the image
+    // instead — same message bubble, not an image/link element.
+    const filenameCaption = page.getByTestId('generated-image-ready')
+      .locator('p').first()
+
+    await expect(assistantMessage).toBeVisible()
+    await expect(previewTrigger).toBeVisible()
+
+    await filenameCaption.click({ button: 'right' })
+
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeVisible()
+
+    await previewTrigger.click()
+
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeHidden()
+
+    await page.waitForTimeout(3000)
+
+    await expect(page.getByTestId('image-preview-modal')).toBeHidden()
+  })
+})

--- a/tests/e2e/chat/context-menu-image-desktop.spec.ts
+++ b/tests/e2e/chat/context-menu-image-desktop.spec.ts
@@ -23,7 +23,21 @@ test.describe('chat context menu for AI-generated-image messages (desktop mouse)
       page.getByRole('button', { name: 'Branch chat from here' }),
     ).toBeVisible()
 
-    await previewTrigger.click()
+    // The trigger becomes pointer-events-none while a context menu is
+    // suppressing it, so a real click at its on-screen position now
+    // resolves to its parent container instead — mirror that with a raw
+    // coordinate click rather than clicking the (now unreachable) locator
+    // directly.
+    const triggerBox = await previewTrigger.boundingBox()
+
+    if (!triggerBox) {
+      throw new Error('Preview trigger has no bounding box')
+    }
+
+    await page.mouse.click(
+      triggerBox.x + triggerBox.width / 2,
+      triggerBox.y + triggerBox.height / 2,
+    )
 
     await expect(
       page.getByRole('button', { name: 'Branch chat from here' }),
@@ -61,7 +75,21 @@ test.describe('chat context menu for AI-generated-image messages (desktop mouse)
       page.getByRole('button', { name: 'Branch chat from here' }),
     ).toBeVisible()
 
-    await previewTrigger.click()
+    // The trigger becomes pointer-events-none while a context menu is
+    // suppressing it, so a real click at its on-screen position now
+    // resolves to its parent container instead — mirror that with a raw
+    // coordinate click rather than clicking the (now unreachable) locator
+    // directly.
+    const triggerBox = await previewTrigger.boundingBox()
+
+    if (!triggerBox) {
+      throw new Error('Preview trigger has no bounding box')
+    }
+
+    await page.mouse.click(
+      triggerBox.x + triggerBox.width / 2,
+      triggerBox.y + triggerBox.height / 2,
+    )
 
     await expect(
       page.getByRole('button', { name: 'Branch chat from here' }),

--- a/tests/e2e/chat/context-menu-image.spec.ts
+++ b/tests/e2e/chat/context-menu-image.spec.ts
@@ -28,6 +28,82 @@ async function longPress(locator: Locator): Promise<void> {
   }, messageId)
 }
 
+// The context menu can visually overlap the image preview trigger on a
+// small viewport, especially with few messages. A tap that lands on the
+// menu itself (e.g. the Branch button) proves nothing about click-through
+// to the image underneath, so this picks a corner of the trigger's own
+// bounding box that falls outside the menu's, then verifies via
+// elementFromPoint that the point genuinely resolves onto the trigger
+// before dispatching the touch — failing loudly instead of silently
+// testing the wrong thing if a future layout change reintroduces overlap.
+async function quickTapOnImagePreviewTrigger(
+  previewTrigger: Locator,
+): Promise<void> {
+  const page = previewTrigger.page()
+  const box = await previewTrigger.boundingBox()
+
+  if (!box) {
+    throw new Error('Preview trigger has no bounding box')
+  }
+
+  const menuBox = await page.getByTestId('chat-messages-container')
+    .getByRole('list')
+    .boundingBox()
+
+  const candidates = [
+    { x: box.x + box.width - 4, y: box.y + box.height - 4 },
+    { x: box.x + 4, y: box.y + 4 },
+    { x: box.x + 4, y: box.y + box.height - 4 },
+    { x: box.x + box.width - 4, y: box.y + 4 },
+  ]
+
+  const point = candidates.find((candidate) => {
+    if (!menuBox) return true
+
+    const insideMenu = candidate.x >= menuBox.x
+      && candidate.x <= menuBox.x + menuBox.width
+      && candidate.y >= menuBox.y
+      && candidate.y <= menuBox.y + menuBox.height
+
+    return !insideMenu
+  })
+
+  if (!point) {
+    throw new Error(
+      'The context menu fully covers the image preview trigger — cannot '
+      + 'construct a tap point that avoids it',
+    )
+  }
+
+  const isOnTrigger = await page.evaluate(([px, py]) => {
+    const element = document.elementFromPoint(px, py)
+
+    return !!element?.closest(
+      '[data-testid="generated-image-preview-trigger"]',
+    )
+  }, [point.x, point.y] as const)
+
+  if (!isOnTrigger) {
+    throw new Error(
+      `Tap point (${point.x}, ${point.y}) does not resolve onto the image `
+      + 'preview trigger — test setup is unsound',
+    )
+  }
+
+  const client = await page.context().newCDPSession(page)
+
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [
+      { x: point.x, y: point.y, radiusX: 1, radiusY: 1, force: 1, id: 1 },
+    ],
+  })
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchEnd',
+    touchPoints: [],
+  })
+}
+
 interface ClippingCheckResult {
   hasClippingAncestor: boolean
   fitsWithinAncestor: boolean
@@ -115,5 +191,73 @@ test.describe('chat context menu for AI-generated-image messages', () => {
     const clipping = await getClippingViolation(lastMenuItem)
 
     expect(clipping.fitsWithinAncestor).toBe(true)
+  })
+
+  test('tapping a blurred generated image under a different selected message dismisses the menu without opening the preview', async ({
+    page,
+  }) => {
+    const userMessage = page.locator('[data-role="user"]').first()
+    const previewTrigger = page.getByTestId(
+      'generated-image-preview-trigger',
+    )
+
+    await expect(userMessage).toBeVisible()
+    await expect(previewTrigger).toBeVisible()
+
+    await longPress(userMessage)
+
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeVisible()
+
+    await quickTapOnImagePreviewTrigger(previewTrigger)
+
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeHidden()
+
+    // The preview is a lazy-loaded async component that can take a couple
+    // of seconds to compile in dev mode on first use. Asserting "hidden"
+    // immediately would trivially pass before it ever had a chance to
+    // render, whether or not the click actually got through — wait out
+    // that window first so this proves it never opens, not that it merely
+    // hasn't opened yet.
+    await page.waitForTimeout(3000)
+
+    await expect(page.getByTestId('image-preview-modal')).toBeHidden()
+  })
+
+  test('tapping the selected message\'s own generated image dismisses the menu without opening the preview', async ({
+    page,
+  }) => {
+    const assistantMessage = page.locator('[data-role="assistant"]').first()
+    const previewTrigger = page.getByTestId(
+      'generated-image-preview-trigger',
+    )
+
+    await expect(assistantMessage).toBeVisible()
+    await expect(previewTrigger).toBeVisible()
+
+    await longPress(assistantMessage)
+
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeVisible()
+
+    await quickTapOnImagePreviewTrigger(previewTrigger)
+
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeHidden()
+
+    // The preview is a lazy-loaded async component that can take a couple
+    // of seconds to compile in dev mode on first use. Asserting "hidden"
+    // immediately would trivially pass before it ever had a chance to
+    // render, whether or not the click actually got through — wait out
+    // that window first so this proves it never opens, not that it merely
+    // hasn't opened yet.
+    await page.waitForTimeout(3000)
+
+    await expect(page.getByTestId('image-preview-modal')).toBeHidden()
   })
 })

--- a/tests/e2e/chat/context-menu-image.spec.ts
+++ b/tests/e2e/chat/context-menu-image.spec.ts
@@ -75,18 +75,23 @@ async function quickTapOnImagePreviewTrigger(
     )
   }
 
-  const isOnTrigger = await page.evaluate(([px, py]) => {
+  // The trigger goes pointer-events-none while a context menu is
+  // suppressing it, so a genuine tap there resolves onto its
+  // `generated-image-ready` parent instead — both are valid depending on
+  // whether the guard is currently active.
+  const isOnTriggerOrParent = await page.evaluate(([px, py]) => {
     const element = document.elementFromPoint(px, py)
 
     return !!element?.closest(
-      '[data-testid="generated-image-preview-trigger"]',
+      '[data-testid="generated-image-preview-trigger"], '
+      + '[data-testid="generated-image-ready"]',
     )
   }, [point.x, point.y] as const)
 
-  if (!isOnTrigger) {
+  if (!isOnTriggerOrParent) {
     throw new Error(
       `Tap point (${point.x}, ${point.y}) does not resolve onto the image `
-      + 'preview trigger — test setup is unsound',
+      + 'preview trigger or its container — test setup is unsound',
     )
   }
 

--- a/tests/e2e/chat/context-menu.spec.ts
+++ b/tests/e2e/chat/context-menu.spec.ts
@@ -51,6 +51,40 @@ async function quickTap(locator: Locator): Promise<void> {
   })
 }
 
+async function longPressDrag(locator: Locator): Promise<void> {
+  const target = locator.locator('.group').first()
+  const box = await target.boundingBox()
+
+  if (!box) {
+    throw new Error('Element has no bounding box')
+  }
+
+  const page = locator.page()
+  const client = await page.context().newCDPSession(page)
+  const startX = Math.round(box.x + box.width / 4)
+  const startY = Math.round(box.y + box.height / 2)
+  const endX = Math.round(box.x + (box.width * 3) / 4)
+  const endY = Math.round(box.y + box.height / 2)
+
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [
+      { x: startX, y: startY, radiusX: 1, radiusY: 1, force: 1, id: 1 },
+    ],
+  })
+  await page.waitForTimeout(400)
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchMove',
+    touchPoints: [
+      { x: endX, y: endY, radiusX: 1, radiusY: 1, force: 1, id: 1 },
+    ],
+  })
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchEnd',
+    touchPoints: [],
+  })
+}
+
 test.describe('chat context menu selection state', () => {
   test.beforeEach(async ({ page }) => {
     test.setTimeout(30_000)
@@ -102,7 +136,7 @@ test.describe('chat context menu selection state', () => {
     ).toBeHidden()
   })
 
-  test('quick tap on selected message does not dismiss context menu', async ({ page }) => {
+  test('quick tap on selected message dismisses context menu', async ({ page }) => {
     const assistantMessage = page
       .locator('[data-role="assistant"]')
       .first()
@@ -116,6 +150,26 @@ test.describe('chat context menu selection state', () => {
     ).toBeVisible()
 
     await quickTap(assistantMessage)
+
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeHidden()
+  })
+
+  test('drag gesture on selected message does not dismiss context menu', async ({ page }) => {
+    const assistantMessage = page
+      .locator('[data-role="assistant"]')
+      .first()
+
+    await expect(assistantMessage).toBeVisible()
+
+    await longPress(assistantMessage)
+
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeVisible()
+
+    await longPressDrag(assistantMessage)
 
     await expect(
       page.getByRole('button', { name: 'Branch chat from here' }),

--- a/tests/e2e/chat/context-menu.spec.ts
+++ b/tests/e2e/chat/context-menu.spec.ts
@@ -156,7 +156,10 @@ test.describe('chat context menu selection state', () => {
     ).toBeHidden()
   })
 
-  test('drag gesture on selected message does not dismiss context menu', async ({ page }) => {
+  // End-to-end guarantee, not gate isolation: CDP round-trip overhead makes
+  // it unreliable to isolate a single guard's timing here. That precise
+  // coverage lives in the ContextMenu.client unit tests (fake timers).
+  test('long-press-and-drag on selected message does not dismiss context menu', async ({ page }) => {
     const assistantMessage = page
       .locator('[data-role="assistant"]')
       .first()

--- a/tests/e2e/shared/context-menu-image-hover.spec.ts
+++ b/tests/e2e/shared/context-menu-image-hover.spec.ts
@@ -1,0 +1,114 @@
+import type { Locator, Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+
+async function selectMessage(page: Page, locator: Locator): Promise<void> {
+  const messageId = await locator.getAttribute('data-message-id')
+
+  if (!messageId) {
+    throw new Error('Message is missing data-message-id')
+  }
+
+  await page.evaluate((id) => {
+    ;(window as typeof window & {
+      __besidkaChatTest?: {
+        selectMessage: (messageId: string) => void
+      }
+    }).__besidkaChatTest?.selectMessage(id)
+  }, messageId)
+}
+
+async function getCtaOpacity(page: Page): Promise<string> {
+  const openButton = page.getByTestId('chat-file-open')
+
+  return openButton.evaluate((el) => {
+    return getComputedStyle(el.parentElement || el).opacity
+  })
+}
+
+test.describe('shared chat image hover affordances', () => {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(30_000)
+
+    await page.goto('/shared/test')
+    await page.waitForSelector('[data-role="assistant"]')
+    await page.waitForFunction(() => {
+      return Boolean((window as typeof window & {
+        __besidkaChatTest?: {
+          selectMessage: (messageId: string) => void
+        }
+      }).__besidkaChatTest?.selectMessage)
+    })
+  })
+
+  test('reveals the preview/download CTAs on a normal hover when nothing is selected', async ({
+    page,
+  }) => {
+    const previewTrigger = page.getByTestId('chat-file-preview-trigger')
+
+    await previewTrigger.hover()
+
+    await expect.poll(() => getCtaOpacity(page)).toBe('1')
+  })
+
+  test('does not reveal CTAs while hovering a blurred, non-selected message\'s image', async ({
+    page,
+  }) => {
+    const userMessage = page.locator('[data-role="user"]').first()
+    const previewTrigger = page.getByTestId('chat-file-preview-trigger')
+
+    await selectMessage(page, userMessage)
+    await expect(
+      page.getByRole('button', { name: 'Branch chat from here' }),
+    ).toBeVisible()
+
+    await previewTrigger.hover({ force: true })
+
+    await expect.poll(() => getCtaOpacity(page)).toBe('0')
+    expect(
+      await previewTrigger.evaluate((el) => {
+        return getComputedStyle(el.parentElement || el).pointerEvents
+      }),
+    ).toBe('none')
+  })
+
+  test('does not reveal CTAs when hovering the wide reserved space beside the image tile', async ({
+    page,
+  }) => {
+    const previewTrigger = page.getByTestId('chat-file-preview-trigger')
+    const box = await previewTrigger.boundingBox()
+
+    if (!box) {
+      throw new Error('Preview trigger has no bounding box')
+    }
+
+    // Well outside the (fit-content) image tile but still inside the
+    // message row's much wider reserved width (sm:w-4xl) — this used to
+    // incorrectly satisfy Tailwind's unscoped group-hover, which matches
+    // ANY ancestor with class "group", including Message.vue's outer
+    // wrapper, not just this tile's own group.
+    await page.mouse.move(box.x + box.width + 300, box.y + box.height / 2)
+
+    await expect.poll(() => getCtaOpacity(page)).toBe('0')
+  })
+
+  test('shows a themed accent focus ring instead of the browser default outline', async ({
+    page,
+  }) => {
+    const previewTrigger = page.getByTestId('chat-file-preview-trigger')
+
+    await previewTrigger.focus()
+
+    const style = await previewTrigger.evaluate((el) => {
+      const computed = getComputedStyle(el)
+
+      return {
+        outlineStyle: computed.outlineStyle,
+        boxShadow: computed.boxShadow,
+      }
+    })
+
+    expect(style.outlineStyle).toBe('none')
+    expect(style.boxShadow).not.toContain('none')
+    expect(style.boxShadow.toLowerCase()).not.toContain('blue')
+  })
+})

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -245,6 +245,125 @@ describe('Chat/ContextMenu.client', () => {
     expect(wrapper.emitted('close')).toEqual([[]])
   })
 
+  describe('swallowed click after dismiss', () => {
+    let underlyingButton: HTMLButtonElement
+    let onUnderlyingClick: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      underlyingButton = document.createElement('button')
+      onUnderlyingClick = vi.fn()
+
+      underlyingButton.addEventListener('click', onUnderlyingClick)
+      document.body.appendChild(underlyingButton)
+    })
+
+    afterEach(() => {
+      underlyingButton.remove()
+    })
+
+    it('swallows a synthetic click that arrives after the dismiss tap, even past the old 100ms window', async () => {
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: {
+          messageId: 'msg-1',
+          anchorEl,
+        },
+        attachTo: document.body,
+      })
+
+      outsideEl.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+      vi.advanceTimersByTime(100)
+      outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+      }))
+
+      expect(wrapper.emitted('close')).toEqual([[]])
+
+      vi.advanceTimersByTime(150)
+      underlyingButton.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }))
+
+      expect(onUnderlyingClick).not.toHaveBeenCalled()
+    })
+
+    it('does not swallow a click that follows a genuinely new pointerdown', async () => {
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: {
+          messageId: 'msg-1',
+          anchorEl,
+        },
+        attachTo: document.body,
+      })
+
+      outsideEl.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+      vi.advanceTimersByTime(100)
+      outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+      }))
+
+      expect(wrapper.emitted('close')).toEqual([[]])
+
+      underlyingButton.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+      underlyingButton.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }))
+
+      expect(onUnderlyingClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels a still-pending swallow before installing a new one', async () => {
+      const addSpy = vi.spyOn(document, 'addEventListener')
+      const removeSpy = vi.spyOn(document, 'removeEventListener')
+
+      function countClickCaptureCalls(spy: typeof addSpy) {
+        return spy.mock.calls.filter(([type, , options]) => {
+          return type === 'click'
+            && typeof options === 'object'
+            && (options as AddEventListenerOptions).capture === true
+        }).length
+      }
+
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: {
+          messageId: 'msg-1',
+          anchorEl,
+        },
+        attachTo: document.body,
+      })
+
+      outsideEl.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+      vi.advanceTimersByTime(50)
+      outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+      }))
+      outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+      }))
+
+      expect(wrapper.emitted('close')).toEqual([[], []])
+
+      underlyingButton.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }))
+
+      expect(onUnderlyingClick).not.toHaveBeenCalled()
+      expect(countClickCaptureCalls(removeSpy)).toBe(
+        countClickCaptureCalls(addSpy),
+      )
+    })
+  })
+
   describe('positioning', () => {
     let originalInnerHeight: number
     let originalInnerWidth: number

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -201,6 +201,30 @@ describe('Chat/ContextMenu.client', () => {
     expect(wrapper.emitted('close')).toBeUndefined()
   })
 
+  it('emits close on a quick tap outside the bubble even with an unrelated selection present', async () => {
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+      isCollapsed: false,
+    } as Selection)
+
+    const wrapper = await mountSuspended(ContextMenu, {
+      props: {
+        messageId: 'msg-1',
+        anchorEl,
+      },
+      attachTo: document.body,
+    })
+
+    outsideEl.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true,
+    }))
+    vi.advanceTimersByTime(100)
+    outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+      bubbles: true,
+    }))
+
+    expect(wrapper.emitted('close')).toEqual([[]])
+  })
+
   it('emits close when the quick tap happens on the anchor row outside the bubble', async () => {
     const wrapper = await mountSuspended(ContextMenu, {
       props: {

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -125,7 +125,7 @@ describe('Chat/ContextMenu.client', () => {
     expect(wrapper.emitted('close')).toBeUndefined()
   })
 
-  it('does not emit close when the quick tap happens on the bubble', async () => {
+  it('emits close on a quick tap on the bubble when nothing is selected', async () => {
     const wrapper = await mountSuspended(ContextMenu, {
       props: {
         messageId: 'msg-1',
@@ -136,10 +136,66 @@ describe('Chat/ContextMenu.client', () => {
 
     bubbleEl.dispatchEvent(new PointerEvent('pointerdown', {
       bubbles: true,
+      clientX: 100,
+      clientY: 100,
     }))
     vi.advanceTimersByTime(100)
     bubbleEl.dispatchEvent(new PointerEvent('pointerup', {
       bubbles: true,
+      clientX: 100,
+      clientY: 100,
+    }))
+
+    expect(wrapper.emitted('close')).toEqual([[]])
+  })
+
+  it('does not emit close when a tap on the bubble moves past the threshold', async () => {
+    const wrapper = await mountSuspended(ContextMenu, {
+      props: {
+        messageId: 'msg-1',
+        anchorEl,
+      },
+      attachTo: document.body,
+    })
+
+    bubbleEl.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true,
+      clientX: 100,
+      clientY: 100,
+    }))
+    vi.advanceTimersByTime(100)
+    bubbleEl.dispatchEvent(new PointerEvent('pointerup', {
+      bubbles: true,
+      clientX: 120,
+      clientY: 100,
+    }))
+
+    expect(wrapper.emitted('close')).toBeUndefined()
+  })
+
+  it('does not emit close when the tap results in a text selection', async () => {
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+      isCollapsed: false,
+    } as Selection)
+
+    const wrapper = await mountSuspended(ContextMenu, {
+      props: {
+        messageId: 'msg-1',
+        anchorEl,
+      },
+      attachTo: document.body,
+    })
+
+    bubbleEl.dispatchEvent(new PointerEvent('pointerdown', {
+      bubbles: true,
+      clientX: 100,
+      clientY: 100,
+    }))
+    vi.advanceTimersByTime(100)
+    bubbleEl.dispatchEvent(new PointerEvent('pointerup', {
+      bubbles: true,
+      clientX: 100,
+      clientY: 100,
     }))
 
     expect(wrapper.emitted('close')).toBeUndefined()

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -1268,5 +1268,94 @@ describe('Chat/ContextMenu.client', () => {
 
       expect(guardCount().value).toBe(0)
     })
+
+    it('releases the guard synchronously on a fresh pointerdown so a legitimate click right after is not wrongly suppressed', async () => {
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: { messageId: 'msg-1', anchorEl },
+        attachTo: document.body,
+      })
+
+      outsideEl.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+      vi.advanceTimersByTime(100)
+      outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+      }))
+
+      wrapper.unmount()
+
+      expect(guardCount().value).toBe(1)
+
+      const freshTarget = document.createElement('button')
+
+      document.body.appendChild(freshTarget)
+
+      freshTarget.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+
+      expect(guardCount().value).toBe(0)
+
+      freshTarget.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }))
+
+      expect(guardCount().value).toBe(0)
+
+      freshTarget.remove()
+    })
+
+    it('keeps the guard active across an overlapping reselection until both the old and new instance release it', async () => {
+      const wrapperA = await mountSuspended(ContextMenu, {
+        props: { messageId: 'msg-a', anchorEl },
+        attachTo: document.body,
+      })
+
+      outsideEl.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+      vi.advanceTimersByTime(100)
+      outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+      }))
+
+      wrapperA.unmount()
+
+      expect(guardCount().value).toBe(1)
+
+      const anchorElB = document.createElement('div')
+      const bubbleElB = document.createElement('div')
+
+      bubbleElB.className = 'js-chat-bubble'
+      anchorElB.appendChild(bubbleElB)
+      document.body.appendChild(anchorElB)
+      vi.spyOn(anchorElB, 'getBoundingClientRect')
+        .mockReturnValue(anchorEl.getBoundingClientRect())
+      vi.spyOn(bubbleElB, 'getBoundingClientRect')
+        .mockReturnValue(bubbleEl.getBoundingClientRect())
+
+      const wrapperB = await mountSuspended(ContextMenu, {
+        props: { messageId: 'msg-b', anchorEl: anchorElB },
+        attachTo: document.body,
+      })
+
+      expect(guardCount().value).toBe(2)
+
+      outsideEl.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }))
+      vi.advanceTimersByTime(0)
+
+      expect(guardCount().value).toBe(1)
+
+      wrapperB.unmount()
+
+      expect(guardCount().value).toBe(0)
+
+      anchorElB.remove()
+    })
   })
 })

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -14,6 +14,22 @@ async function flushPromises() {
   }
 }
 
+// happy-dom reports `isTrusted` as undefined on constructed events rather
+// than the spec's `false`, so a plain dispatch already reads as "untrusted"
+// by ContextMenu's own check. Tests simulating a real user click need to
+// mark the event trusted explicitly to exercise the swallow-and-resolve
+// path; tests simulating a third-party library's synthetic click (e.g.
+// web-haptics' debug toggle) can dispatch a plain click as-is.
+function dispatchTrustedClick(target: EventTarget) {
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+
+  Object.defineProperty(event, 'isTrusted', {
+    value: true,
+    configurable: true,
+  })
+  target.dispatchEvent(event)
+}
+
 describe('Chat/ContextMenu.client', () => {
   let anchorEl: HTMLDivElement
   let bubbleEl: HTMLDivElement
@@ -283,10 +299,7 @@ describe('Chat/ContextMenu.client', () => {
       expect(wrapper.emitted('close')).toEqual([[]])
 
       vi.advanceTimersByTime(150)
-      underlyingButton.dispatchEvent(new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }))
+      dispatchTrustedClick(underlyingButton)
 
       expect(onUnderlyingClick).not.toHaveBeenCalled()
     })
@@ -313,10 +326,7 @@ describe('Chat/ContextMenu.client', () => {
       underlyingButton.dispatchEvent(new PointerEvent('pointerdown', {
         bubbles: true,
       }))
-      underlyingButton.dispatchEvent(new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }))
+      dispatchTrustedClick(underlyingButton)
 
       expect(onUnderlyingClick).toHaveBeenCalledTimes(1)
     })
@@ -354,15 +364,50 @@ describe('Chat/ContextMenu.client', () => {
 
       expect(wrapper.emitted('close')).toEqual([[], []])
 
-      underlyingButton.dispatchEvent(new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }))
+      dispatchTrustedClick(underlyingButton)
 
       expect(onUnderlyingClick).not.toHaveBeenCalled()
       expect(countClickCaptureCalls(removeSpy)).toBe(
         countClickCaptureCalls(addSpy),
       )
+    })
+
+    it('ignores an untrusted synthetic click and still swallows the real trailing click that follows it', async () => {
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: {
+          messageId: 'msg-1',
+          anchorEl,
+        },
+        attachTo: document.body,
+      })
+
+      outsideEl.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+      vi.advanceTimersByTime(100)
+      outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+      }))
+
+      expect(wrapper.emitted('close')).toEqual([[]])
+
+      // A third-party library (e.g. web-haptics' debug-mode toggle) can
+      // dispatch an untrusted click at any time, unrelated to this dismiss
+      // gesture. It must not consume the one-shot swallow meant for the
+      // real trailing click.
+      const unrelatedTarget = document.createElement('label')
+
+      document.body.appendChild(unrelatedTarget)
+      unrelatedTarget.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }))
+
+      dispatchTrustedClick(underlyingButton)
+
+      expect(onUnderlyingClick).not.toHaveBeenCalled()
+
+      unrelatedTarget.remove()
     })
   })
 
@@ -1237,10 +1282,7 @@ describe('Chat/ContextMenu.client', () => {
 
       expect(guardCount().value).toBe(1)
 
-      outsideEl.dispatchEvent(new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }))
+      dispatchTrustedClick(outsideEl)
       vi.advanceTimersByTime(0)
 
       expect(guardCount().value).toBe(0)
@@ -1297,10 +1339,7 @@ describe('Chat/ContextMenu.client', () => {
 
       expect(guardCount().value).toBe(0)
 
-      freshTarget.dispatchEvent(new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }))
+      dispatchTrustedClick(freshTarget)
 
       expect(guardCount().value).toBe(0)
 
@@ -1343,10 +1382,7 @@ describe('Chat/ContextMenu.client', () => {
 
       expect(guardCount().value).toBe(2)
 
-      outsideEl.dispatchEvent(new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }))
+      dispatchTrustedClick(outsideEl)
       vi.advanceTimersByTime(0)
 
       expect(guardCount().value).toBe(1)

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -23,6 +23,8 @@ describe('Chat/ContextMenu.client', () => {
   beforeEach(() => {
     vi.useFakeTimers()
 
+    useState<number>('image-preview-guard-count', () => 0).value = 0
+
     anchorEl = document.createElement('div')
     outsideEl = document.createElement('div')
 
@@ -1189,6 +1191,82 @@ describe('Chat/ContextMenu.client', () => {
       await flushPromises()
 
       expect(useErrorMessage).toHaveBeenCalledWith('Failed to copy message')
+    })
+  })
+
+  describe('image preview guard', () => {
+    function guardCount() {
+      return useState<number>('image-preview-guard-count', () => 0)
+    }
+
+    it('activates the guard while mounted', async () => {
+      await mountSuspended(ContextMenu, {
+        props: { messageId: 'msg-1', anchorEl },
+        attachTo: document.body,
+      })
+
+      expect(guardCount().value).toBe(1)
+    })
+
+    it('releases the guard on unmount when no swallow is pending', async () => {
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: { messageId: 'msg-1', anchorEl },
+        attachTo: document.body,
+      })
+
+      wrapper.unmount()
+
+      expect(guardCount().value).toBe(0)
+    })
+
+    it('keeps the guard active across unmount while a click is being swallowed, releasing it once the click resolves', async () => {
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: { messageId: 'msg-1', anchorEl },
+        attachTo: document.body,
+      })
+
+      outsideEl.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+      vi.advanceTimersByTime(100)
+      outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+      }))
+
+      wrapper.unmount()
+
+      expect(guardCount().value).toBe(1)
+
+      outsideEl.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }))
+      vi.advanceTimersByTime(0)
+
+      expect(guardCount().value).toBe(0)
+    })
+
+    it('keeps the guard active across unmount until the backstop elapses', async () => {
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: { messageId: 'msg-1', anchorEl },
+        attachTo: document.body,
+      })
+
+      outsideEl.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+      vi.advanceTimersByTime(100)
+      outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+      }))
+
+      wrapper.unmount()
+
+      expect(guardCount().value).toBe(1)
+
+      vi.advanceTimersByTime(501)
+
+      expect(guardCount().value).toBe(0)
     })
   })
 })

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -1283,7 +1283,6 @@ describe('Chat/ContextMenu.client', () => {
       expect(guardCount().value).toBe(1)
 
       dispatchTrustedClick(outsideEl)
-      vi.advanceTimersByTime(0)
 
       expect(guardCount().value).toBe(0)
     })
@@ -1383,7 +1382,58 @@ describe('Chat/ContextMenu.client', () => {
       expect(guardCount().value).toBe(2)
 
       dispatchTrustedClick(outsideEl)
-      vi.advanceTimersByTime(0)
+
+      expect(guardCount().value).toBe(1)
+
+      wrapperB.unmount()
+
+      expect(guardCount().value).toBe(0)
+
+      anchorElB.remove()
+    })
+
+    it('does not double-release the guard when a swallow resolves while still mounted and the instance unmounts afterward', async () => {
+      const wrapperA = await mountSuspended(ContextMenu, {
+        props: { messageId: 'msg-a', anchorEl },
+        attachTo: document.body,
+      })
+
+      outsideEl.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+      }))
+      vi.advanceTimersByTime(100)
+      outsideEl.dispatchEvent(new PointerEvent('pointerup', {
+        bubbles: true,
+      }))
+
+      const anchorElB = document.createElement('div')
+      const bubbleElB = document.createElement('div')
+
+      bubbleElB.className = 'js-chat-bubble'
+      anchorElB.appendChild(bubbleElB)
+      document.body.appendChild(anchorElB)
+      vi.spyOn(anchorElB, 'getBoundingClientRect')
+        .mockReturnValue(anchorEl.getBoundingClientRect())
+      vi.spyOn(bubbleElB, 'getBoundingClientRect')
+        .mockReturnValue(bubbleEl.getBoundingClientRect())
+
+      const wrapperB = await mountSuspended(ContextMenu, {
+        props: { messageId: 'msg-b', anchorEl: anchorElB },
+        attachTo: document.body,
+      })
+
+      expect(guardCount().value).toBe(2)
+
+      // Resolve A's swallow (its own click-capture cleanup releases the
+      // guard) while A is STILL mounted, then unmount A afterward. A's
+      // onUnmounted must not release a second time on top of the swallow's
+      // own release — otherwise this drops to 0 and wrongly cancels B's
+      // still-active suppression.
+      dispatchTrustedClick(outsideEl)
+
+      expect(guardCount().value).toBe(1)
+
+      wrapperA.unmount()
 
       expect(guardCount().value).toBe(1)
 

--- a/tests/unit/components/Chat/Files.spec.ts
+++ b/tests/unit/components/Chat/Files.spec.ts
@@ -70,6 +70,8 @@ describe('Chat/Files', () => {
     expect(
       wrapper.get('[data-testid="chat-file-preview-trigger"]').classes(),
     ).toContain('cursor-zoom-in')
+    expect(wrapper.get('.carousel-item').classes())
+      .not.toContain('pointer-events-none')
     expect(open.attributes('href')).toBeUndefined()
     expect(
       wrapper.get('[data-testid="chat-file-download"]').attributes('href'),
@@ -123,7 +125,7 @@ describe('Chat/Files', () => {
       .toBe(false)
   })
 
-  it('shows a default cursor instead of zoom-in while a context menu is suppressing preview', async () => {
+  it('disables pointer interaction on the carousel item while a context menu is suppressing preview', async () => {
     useState<number>('image-preview-guard-count', () => 0).value = 1
 
     const wrapper = await mountSuspended(Files, {
@@ -147,10 +149,8 @@ describe('Chat/Files', () => {
       },
     })
 
-    const preview = wrapper.get('[data-testid="chat-file-preview-trigger"]')
-
-    expect(preview.classes()).toContain('cursor-default')
-    expect(preview.classes()).not.toContain('cursor-zoom-in')
+    expect(wrapper.get('.carousel-item').classes())
+      .toContain('pointer-events-none')
   })
 
   it('renders malformed legacy file parts without actionable URLs', async () => {

--- a/tests/unit/components/Chat/Files.spec.ts
+++ b/tests/unit/components/Chat/Files.spec.ts
@@ -29,6 +29,7 @@ describe('Chat/Files', () => {
       .mockImplementation(function () {
         this.removeAttribute('open')
       })
+    useState<number>('image-preview-guard-count', () => 0).value = 0
   })
 
   afterEach(() => {
@@ -84,6 +85,39 @@ describe('Chat/Files', () => {
       .attributes('src')).toBe(
       '/files/shared.webp?token=header.payload.signature#preview',
     )
+  })
+
+  it('does not open the preview while a context menu is suppressing it', async () => {
+    useState<number>('image-preview-guard-count', () => 0).value = 1
+
+    const wrapper = await mountSuspended(Files, {
+      props: {
+        message: {
+          id: 'message-1',
+          role: 'assistant',
+          parts: [{
+            type: 'file',
+            mediaType: 'image/webp',
+            filename: 'shared.webp',
+            url: '/files/shared.webp',
+          }],
+        },
+      },
+      global: {
+        stubs: {
+          LazyChatImagePreview: LazyImagePreview,
+          teleport: true,
+        },
+      },
+    })
+
+    await wrapper.get('[data-testid="chat-file-preview-trigger"]')
+      .trigger('click')
+    await flushPromises()
+
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="image-preview-modal"]').exists())
+      .toBe(false)
   })
 
   it('renders malformed legacy file parts without actionable URLs', async () => {

--- a/tests/unit/components/Chat/Files.spec.ts
+++ b/tests/unit/components/Chat/Files.spec.ts
@@ -67,6 +67,9 @@ describe('Chat/Files', () => {
     const open = wrapper.get('[data-testid="chat-file-open"]')
 
     expect(open.element.tagName).toBe('BUTTON')
+    expect(
+      wrapper.get('[data-testid="chat-file-preview-trigger"]').classes(),
+    ).toContain('cursor-zoom-in')
     expect(open.attributes('href')).toBeUndefined()
     expect(
       wrapper.get('[data-testid="chat-file-download"]').attributes('href'),
@@ -118,6 +121,36 @@ describe('Chat/Files', () => {
     expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled()
     expect(wrapper.find('[data-testid="image-preview-modal"]').exists())
       .toBe(false)
+  })
+
+  it('shows a default cursor instead of zoom-in while a context menu is suppressing preview', async () => {
+    useState<number>('image-preview-guard-count', () => 0).value = 1
+
+    const wrapper = await mountSuspended(Files, {
+      props: {
+        message: {
+          id: 'message-1',
+          role: 'assistant',
+          parts: [{
+            type: 'file',
+            mediaType: 'image/webp',
+            filename: 'shared.webp',
+            url: '/files/shared.webp',
+          }],
+        },
+      },
+      global: {
+        stubs: {
+          LazyChatImagePreview: LazyImagePreview,
+          teleport: true,
+        },
+      },
+    })
+
+    const preview = wrapper.get('[data-testid="chat-file-preview-trigger"]')
+
+    expect(preview.classes()).toContain('cursor-default')
+    expect(preview.classes()).not.toContain('cursor-zoom-in')
   })
 
   it('renders malformed legacy file parts without actionable URLs', async () => {

--- a/tests/unit/components/Chat/GeneratedImage.spec.ts
+++ b/tests/unit/components/Chat/GeneratedImage.spec.ts
@@ -181,6 +181,7 @@ describe('Chat/GeneratedImage', () => {
     expect(image.attributes('src')).toBe('/files/generated.webp')
     expect(preview.element.tagName).toBe('BUTTON')
     expect(preview.classes()).toContain('cursor-zoom-in')
+    expect(preview.classes()).not.toContain('pointer-events-none')
     expect(preview.element.querySelector('div')).toBeNull()
     expect(wrapper.get('[data-testid="generated-image-open"]')
       .element.tagName).toBe('BUTTON')
@@ -250,7 +251,7 @@ describe('Chat/GeneratedImage', () => {
       .toBe(false)
   })
 
-  it('shows a default cursor instead of zoom-in while a context menu is suppressing preview', async () => {
+  it('disables pointer interaction on the trigger while a context menu is suppressing preview', async () => {
     useState<number>('image-preview-guard-count', () => 0).value = 1
 
     const wrapper = await mountSuspended(GeneratedImage, {
@@ -288,8 +289,7 @@ describe('Chat/GeneratedImage', () => {
       '[data-testid="generated-image-preview-trigger"]',
     )
 
-    expect(preview.classes()).toContain('cursor-default')
-    expect(preview.classes()).not.toContain('cursor-zoom-in')
+    expect(preview.classes()).toContain('pointer-events-none')
   })
 
   it('attaches the ready file for the next prompt via the shared hook', async () => {

--- a/tests/unit/components/Chat/GeneratedImage.spec.ts
+++ b/tests/unit/components/Chat/GeneratedImage.spec.ts
@@ -180,6 +180,7 @@ describe('Chat/GeneratedImage', () => {
     expect(wrapper.classes()).toContain('w-80')
     expect(image.attributes('src')).toBe('/files/generated.webp')
     expect(preview.element.tagName).toBe('BUTTON')
+    expect(preview.classes()).toContain('cursor-zoom-in')
     expect(preview.element.querySelector('div')).toBeNull()
     expect(wrapper.get('[data-testid="generated-image-open"]')
       .element.tagName).toBe('BUTTON')
@@ -247,6 +248,48 @@ describe('Chat/GeneratedImage', () => {
     expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled()
     expect(wrapper.find('[data-testid="image-preview-modal"]').exists())
       .toBe(false)
+  })
+
+  it('shows a default cursor instead of zoom-in while a context menu is suppressing preview', async () => {
+    useState<number>('image-preview-guard-count', () => 0).value = 1
+
+    const wrapper = await mountSuspended(GeneratedImage, {
+      props: {
+        messageRole: 'assistant',
+        part: {
+          type: 'tool-generate_image',
+          state: 'output-available',
+          output: {
+            status: 'ready',
+            provider: 'google',
+            model: 'gemini-3.1-flash-image',
+            file: {
+              id: 'file-1',
+              storageKey: 'generated.webp',
+              name: 'sunset.webp',
+              size: 2048,
+              type: 'image/webp',
+              source: 'assistant',
+              url: '/files/generated.webp',
+              downloadUrl: '/files/generated.webp?download=1',
+            },
+          },
+        } as any,
+      },
+      global: {
+        stubs: {
+          LazyChatImagePreview: LazyImagePreview,
+          teleport: true,
+        },
+      },
+    })
+
+    const preview = wrapper.get(
+      '[data-testid="generated-image-preview-trigger"]',
+    )
+
+    expect(preview.classes()).toContain('cursor-default')
+    expect(preview.classes()).not.toContain('cursor-zoom-in')
   })
 
   it('attaches the ready file for the next prompt via the shared hook', async () => {

--- a/tests/unit/components/Chat/GeneratedImage.spec.ts
+++ b/tests/unit/components/Chat/GeneratedImage.spec.ts
@@ -36,6 +36,7 @@ describe('Chat/GeneratedImage', () => {
         this.removeAttribute('open')
         this.dispatchEvent(new Event('close'))
       })
+    useState<number>('image-preview-guard-count', () => 0).value = 0
   })
 
   afterEach(() => {
@@ -200,6 +201,52 @@ describe('Chat/GeneratedImage', () => {
     await image.trigger('load')
 
     expect(image.classes()).toContain('generated-image--loaded')
+  })
+
+  it('does not open the preview while a context menu is suppressing it', async () => {
+    useState<number>('image-preview-guard-count', () => 0).value = 1
+
+    const wrapper = await mountSuspended(GeneratedImage, {
+      props: {
+        messageRole: 'assistant',
+        part: {
+          type: 'tool-generate_image',
+          state: 'output-available',
+          output: {
+            status: 'ready',
+            provider: 'google',
+            model: 'gemini-3.1-flash-image',
+            file: {
+              id: 'file-1',
+              storageKey: 'generated.webp',
+              name: 'sunset.webp',
+              size: 2048,
+              type: 'image/webp',
+              source: 'assistant',
+              url: '/files/generated.webp',
+              downloadUrl: '/files/generated.webp?download=1',
+            },
+          },
+        } as any,
+      },
+      global: {
+        stubs: {
+          LazyChatImagePreview: LazyImagePreview,
+          teleport: true,
+        },
+      },
+    })
+
+    const preview = wrapper.get(
+      '[data-testid="generated-image-preview-trigger"]',
+    )
+
+    await preview.trigger('click')
+    await flushPromises()
+
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="image-preview-modal"]').exists())
+      .toBe(false)
   })
 
   it('attaches the ready file for the next prompt via the shared hook', async () => {

--- a/tests/unit/composables/chat-image-preview-guard.spec.ts
+++ b/tests/unit/composables/chat-image-preview-guard.spec.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useImagePreviewGuard } from '../../../app/composables/chat-image-preview-guard'
+
+describe('useImagePreviewGuard', () => {
+  beforeEach(() => {
+    useState<number>('image-preview-guard-count', () => 0).value = 0
+  })
+
+  it('is not suppressed before anything activates it', () => {
+    const { isSuppressed } = useImagePreviewGuard()
+
+    expect(isSuppressed.value).toBe(false)
+  })
+
+  it('becomes suppressed after one activation and clears after release', () => {
+    const { isSuppressed, suppressImagePreview, releaseImagePreview }
+      = useImagePreviewGuard()
+
+    suppressImagePreview()
+
+    expect(isSuppressed.value).toBe(true)
+
+    releaseImagePreview()
+
+    expect(isSuppressed.value).toBe(false)
+  })
+
+  it('stays suppressed through an overlapping activation until every '
+    + 'release resolves', () => {
+    const { isSuppressed, suppressImagePreview, releaseImagePreview }
+      = useImagePreviewGuard()
+
+    suppressImagePreview()
+    suppressImagePreview()
+
+    expect(isSuppressed.value).toBe(true)
+
+    releaseImagePreview()
+
+    expect(isSuppressed.value).toBe(true)
+
+    releaseImagePreview()
+
+    expect(isSuppressed.value).toBe(false)
+  })
+
+  it('clamps at zero instead of going negative on an extra release', () => {
+    const { isSuppressed, releaseImagePreview } = useImagePreviewGuard()
+
+    releaseImagePreview()
+    releaseImagePreview()
+
+    expect(isSuppressed.value).toBe(false)
+
+    const { suppressImagePreview } = useImagePreviewGuard()
+
+    suppressImagePreview()
+
+    expect(isSuppressed.value).toBe(true)
+  })
+
+  it('shares the same count across independent composable calls', () => {
+    const first = useImagePreviewGuard()
+    const second = useImagePreviewGuard()
+
+    first.suppressImagePreview()
+
+    expect(second.isSuppressed.value).toBe(true)
+
+    second.releaseImagePreview()
+
+    expect(first.isSuppressed.value).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- The message bubble was exempted from the context menu's tap-to-dismiss
  gesture — a plain tap directly on the bubble (as opposed to elsewhere on
  the page) never closed the menu. That exemption existed so a tap on the
  bubble wouldn't fight with starting a text selection there.
- On mobile the bubble often spans nearly the full viewport width and can be
  taller than the viewport for long messages, so the only always-available
  dismiss target (empty space above/below the bubble) can require scrolling
  to reach. Reported by a user on both personal and shared chats.
- Fix: replace the bubble-location exemption with two synchronous checks —
  a pointer-movement gate (>8px means a drag, not a tap, mirroring the
  threshold `Message.vue` already uses for its own long-press cancellation)
  and a selection-state check (`!selection.isCollapsed`, i.e. the gesture
  actually produced a text selection). Either guard alone still protects the
  existing "second long-press/drag enters native text selection" flow; a
  plain short tap on the bubble that doesn't produce a selection now closes
  the menu exactly like a tap anywhere else outside the menu.
- No changes needed in `Message.vue` or either chat page — the text
  selection passthrough mechanism (the `select-none` CSS toggle +
  `isSelected` guards) already worked correctly and this fix is fully
  contained to `ContextMenu.client.vue`.

Design was validated against prior art (WhatsApp/iMessage/Telegram/Signal
all dismiss on any tap outside the menu, none exempt the originating
bubble), web-platform event-ordering research (mobile long-press-select
commits the selection before pointerup; desktop drag-select does not — the
implementation is deliberately synchronous, not deferred via
rAF/setTimeout, so it doesn't race the existing `preventDefault` +
"swallow next click" mechanism), and an accessibility review (WCAG 2.5.2
Pointer Cancellation is already satisfied by committing on pointerup; a
more aggressive outside-tap dismissal doesn't create new AT/switch-control
risk). Full ARIA menu semantics (`role="menu"`, focus management, an
accessible non-gesture trigger) were considered and deliberately left out
of this change — partial ARIA is worse than none, and that's a larger,
separate piece of work.

## Test plan
- [x] `pnpm run test:all` (unit 893/893, integration 246/246, e2e all
      `context-menu.spec.ts` cases green across repeated runs)
- [x] New unit tests: quick tap on the bubble now closes the menu; a tap
      that moves past the threshold does not; a tap that results in a
      non-collapsed selection does not
- [x] New e2e test: a real CDP touch long-press-then-drag gesture on the
      selected bubble does not dismiss the menu; the existing "quick tap on
      selected message" e2e test is inverted to assert dismissal
- [x] `pnpm run lint` / `pnpm run typecheck` clean