### PR TITLE
feat(settings): add push notification toggle to sidebar dropdown

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -33,6 +33,7 @@
     <UiConfirmation />
     <UiMessages />
     <LazyChatShareModal />
+    <LazyNotificationPrompt />
     <Sidebar v-if="$route.path !== '/'" />
     <LazyUiCursorGlow v-if="$device.isDesktop" />
     <LazyCookiesBanner />

--- a/app/components/NotificationPrompt.client.vue
+++ b/app/components/NotificationPrompt.client.vue
@@ -1,5 +1,6 @@
 <template>
   <UiAlert
+    fixed
     class="-translate-y-full"
     :class="{
       'transition-transform duration-500 ease-in': !mounted,

--- a/app/components/Sidebar/AuthCta.vue
+++ b/app/components/Sidebar/AuthCta.vue
@@ -34,6 +34,7 @@
       title="API keys"
       circle
     />
+    <LazySidebarPushToggle />
   </LazySidebarSubmenu>
   <template v-else>
     <UiButton

--- a/app/components/Sidebar/PushToggle.client.vue
+++ b/app/components/Sidebar/PushToggle.client.vue
@@ -7,11 +7,13 @@
     :class="{ 'btn-active': isEnabled }"
     :icon-name="isEnabled ? 'lucide:bell-ring' : 'lucide:bell-off'"
     :title="
-      isEnabled
-        ? 'Disable push notifications'
-        : 'Enable push notifications'
+      isBlocked
+        ? 'Notifications blocked in browser settings'
+        : isEnabled
+          ? 'Disable push notifications'
+          : 'Enable push notifications'
     "
-    :disabled="pending"
+    :disabled="pending || isBlocked"
     @click="handleClick"
   />
 </template>
@@ -25,6 +27,10 @@ const pending = shallowRef<boolean>(false)
 const isEnabled = computed<boolean>(() => {
   return pushNotifications.permission.value === 'granted'
     && pushNotifications.isSubscribed.value
+})
+
+const isBlocked = computed<boolean>(() => {
+  return pushNotifications.permission.value === 'denied'
 })
 
 async function handleClick() {

--- a/app/components/Sidebar/PushToggle.client.vue
+++ b/app/components/Sidebar/PushToggle.client.vue
@@ -1,7 +1,8 @@
 <template>
   <UiButton
     v-if="pushNotifications.isSupported.value"
-    mode="primary"
+    :ghost="!isEnabled"
+    :mode="isEnabled ? 'accent' : 'primary'"
     :icon-only="true"
     circle
     :class="{ 'btn-active': isEnabled }"

--- a/app/components/Sidebar/PushToggle.client.vue
+++ b/app/components/Sidebar/PushToggle.client.vue
@@ -1,0 +1,47 @@
+<template>
+  <UiButton
+    v-if="pushNotifications.isSupported.value"
+    mode="primary"
+    :icon-only="true"
+    circle
+    :class="{ 'btn-active': isEnabled }"
+    :icon-name="isEnabled ? 'lucide:bell-ring' : 'lucide:bell-off'"
+    :title="
+      isEnabled
+        ? 'Disable push notifications'
+        : 'Enable push notifications'
+    "
+    :disabled="pending"
+    @click="handleClick"
+  />
+</template>
+
+<script setup lang="ts">
+const pushNotifications = usePushNotifications()
+const notificationPrompt = useNotificationPrompt()
+
+const pending = shallowRef<boolean>(false)
+
+const isEnabled = computed<boolean>(() => {
+  return pushNotifications.permission.value === 'granted'
+    && pushNotifications.isSubscribed.value
+})
+
+async function handleClick() {
+  if (pending.value) {
+    return
+  }
+
+  pending.value = true
+
+  try {
+    if (isEnabled.value) {
+      await notificationPrompt.disable()
+    } else {
+      await notificationPrompt.requestEnable()
+    }
+  } finally {
+    pending.value = false
+  }
+}
+</script>

--- a/app/components/ui/Alert.vue
+++ b/app/components/ui/Alert.vue
@@ -1,7 +1,8 @@
 <template>
   <UiBubble
     role="alert"
-    class="sticky z-50 top-0 inset-x-0 !block px-14 max-sm:pl-4 !rounded-none !shadow-none"
+    class="z-50 top-0 inset-x-0 !block px-14 max-sm:pl-4 !rounded-none !shadow-none"
+    :class="fixed ? 'fixed' : 'sticky'"
   >
     <div class="w-full text-center text-xs sm:text-sm">
       <slot />
@@ -21,6 +22,10 @@
 </template>
 
 <script setup lang="ts">
+defineProps<{
+  fixed?: boolean
+}>()
+
 defineEmits<{
   click: []
 }>()

--- a/app/composables/notification-prompt.ts
+++ b/app/composables/notification-prompt.ts
@@ -20,8 +20,9 @@
 //     call per page. Chrome's own telemetry shows a cold permission prompt
 //     converts far worse than one shown after the user has experienced the
 //     product, so this intentionally is NOT wired to first app load (the
-//     banner itself also only renders within that layout — see chat.vue —
-//     so it never shows on the home page or elsewhere).
+//     banner component mounts globally in app.vue — see requestEnable()
+//     below for the settings-menu entry point — but this proactive trigger
+//     itself is still only called from the chat layout).
 //   - maybeShowAfterMissedNotification(): fired from chat.ts's
 //     'chat:generation-ready-while-hidden' hook — a generation finished
 //     while the user was away with no way to notify them. Re-asks only a
@@ -181,8 +182,16 @@ export function useNotificationPrompt() {
   // with no dialog, so delegating to enable() safely (re)subscribes this
   // device. When permission is still 'default', calling subscribe() here
   // would fire the OS dialog with zero prior disclosure — a compliance
-  // regression — so this shows the same disclosed banner instead.
+  // regression — so this shows the same disclosed banner instead. When
+  // permission is 'denied', the browser will never show the dialog again
+  // regardless of what this calls, so opening the banner would be a dead
+  // end with no way forward — the button itself disables in that state
+  // instead (see PushToggle.client.vue), this is just a defensive no-op.
   async function requestEnable(): Promise<void> {
+    if (pushNotifications.permission.value === 'denied') {
+      return
+    }
+
     if (pushNotifications.permission.value !== 'granted') {
       isVisible.value = true
 

--- a/app/composables/notification-prompt.ts
+++ b/app/composables/notification-prompt.ts
@@ -160,6 +160,11 @@ export function useNotificationPrompt() {
     userSetting.setNotificationPromptState(false)
   }
 
+  async function disable(): Promise<void> {
+    await pushNotifications.unsubscribe()
+    userSetting.setNotificationPromptState(false)
+  }
+
   async function enable(): Promise<void> {
     const subscribed = await pushNotifications.subscribe()
 
@@ -169,6 +174,22 @@ export function useNotificationPrompt() {
 
     isVisible.value = false
     userSetting.setNotificationPromptState(true)
+  }
+
+  // Entry point for the settings-menu toggle button (not the banner). When
+  // permission is already 'granted', requestPermission() resolves instantly
+  // with no dialog, so delegating to enable() safely (re)subscribes this
+  // device. When permission is still 'default', calling subscribe() here
+  // would fire the OS dialog with zero prior disclosure — a compliance
+  // regression — so this shows the same disclosed banner instead.
+  async function requestEnable(): Promise<void> {
+    if (pushNotifications.permission.value !== 'granted') {
+      isVisible.value = true
+
+      return
+    }
+
+    await enable()
   }
 
   if (!hasRegisteredMissedNotificationHook.value) {
@@ -182,7 +203,9 @@ export function useNotificationPrompt() {
   return {
     isVisible,
     dismiss,
+    disable,
     enable,
+    requestEnable,
     maybeShowProactively,
   }
 }

--- a/app/composables/push-notifications.ts
+++ b/app/composables/push-notifications.ts
@@ -59,8 +59,18 @@ function isApplicationServerKeyStale(
 
 export function usePushNotifications() {
   const { public: { vapidPublicKey } } = useRuntimeConfig()
-  const permission = shallowRef<NotificationPermission>('default')
-  const isSubscribed = shallowRef<boolean>(false)
+  const permission = useState<NotificationPermission>(
+    'push-notifications:permission',
+    () => 'default',
+  )
+  const isSubscribed = useState<boolean>(
+    'push-notifications:is-subscribed',
+    () => false,
+  )
+  const hasAutoRefreshed = useState<boolean>(
+    'push-notifications:has-auto-refreshed',
+    () => false,
+  )
 
   const isSupported = computed<boolean>(() => {
     if (!import.meta.client) {
@@ -259,7 +269,8 @@ export function usePushNotifications() {
     }
   }
 
-  if (import.meta.client) {
+  if (import.meta.client && !hasAutoRefreshed.value) {
+    hasAutoRefreshed.value = true
     refreshState().then(watchPermissionChanges).catch((exception) => {
       void exception
     })

--- a/app/composables/push-notifications.ts
+++ b/app/composables/push-notifications.ts
@@ -1,3 +1,5 @@
+import { parseError } from 'evlog'
+
 // Long-standing, universally-compatible conversion — every browser that
 // implements the Push API accepts a BufferSource applicationServerKey; only
 // newer ones also accept a raw base64url string, so converting here rather
@@ -151,7 +153,13 @@ export function usePushNotifications() {
             },
           })
         } catch (exception) {
-          void exception
+          const parsedException = parseError(exception)
+
+          useErrorMessage(
+            parsedException.message
+            || 'Failed to refresh push notification subscription',
+            parsedException.why,
+          )
         }
       }
     } catch (exception) {
@@ -215,7 +223,12 @@ export function usePushNotifications() {
 
       return true
     } catch (exception) {
-      void exception
+      const parsedException = parseError(exception)
+
+      useErrorMessage(
+        parsedException.message || 'Failed to enable push notifications',
+        parsedException.why,
+      )
 
       return false
     }

--- a/app/composables/push-notifications.ts
+++ b/app/composables/push-notifications.ts
@@ -253,6 +253,13 @@ export function usePushNotifications() {
 
       await subscription.unsubscribe()
 
+      // Unlike subscribe()/refreshState(), a failed POST here is left
+      // silent on purpose: the browser-side unsubscribe above already
+      // succeeded, so isSubscribed correctly reflects this device's real
+      // state regardless. The stale server row self-heals on its own next
+      // send attempt (sendToSubscription in server/utils/push.ts deletes it
+      // on the push service's 404/410), so there's nothing actionable to
+      // surface to the user.
       await $fetch('/api/v1/push/unsubscribe', {
         method: 'POST',
         body: { endpoint },

--- a/app/layouts/chat.vue
+++ b/app/layouts/chat.vue
@@ -1,7 +1,4 @@
 <template>
-  <ClientOnly>
-    <LazyNotificationPrompt />
-  </ClientOnly>
   <NuxtPage/>
 </template>
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -91,6 +91,27 @@ Two independent states that are easy to conflate:
 Server-side pruning: a 404/410 from the push service deletes the row — the
 only signal that a browser dropped the subscription.
 
+### Settings-menu toggle
+
+A bell button in the user settings dropdown (`Sidebar/PushToggle.client.vue`,
+after the API keys button) gives a second, manual entry point alongside the
+banner. It reflects only this device's live `permission`/subscription state,
+never `notificationPromptState` alone — an account that enabled push on one
+device but never subscribed this browser must not show as "on" here. Clicking
+it:
+
+- silently (re)subscribes when permission is already `granted` (no dialog),
+- opens the disclosed banner when permission is `default` (never calls
+  `Notification.requestPermission()` directly — the same compliance
+  requirement as above),
+- disables the button when permission is `denied` — the browser will never
+  re-show the dialog once blocked, so there is nothing left to do here.
+
+This is also the only way back in for an account stuck at
+`notificationPromptState === false` on a fresh origin: the proactive banner
+above deliberately never re-shows for a declined state until a notification
+is missed first.
+
 ## Sending
 
 - **Generation finished** (`chats/[slug]/index.post.ts`): always sends when

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -132,6 +132,15 @@ is missed first.
   outcome counts + failure details (host/status/reason only — never
   endpoints or keys, both are capability secrets) go into the evlog wide
   event.
+- **Origin scoping**: `sendPushNotificationToUser` takes an optional
+  `targetOrigin` and filters delivery to subscriptions whose stored `origin`
+  matches, falling back to the full subscription set when nothing matches
+  (legacy rows with no origin, or a caller that omits it) — so this can never
+  silently drop a notification. The `chats/[slug]/index.post.ts` call site
+  passes `getRequestURL(event).origin` (same derivation as
+  `push/subscribe.post.ts`) specifically to avoid duplicate notifications
+  when one account has subscriptions from multiple PR-preview subdomains,
+  since all previews share one D1 database.
 
 ## Service worker behavior (`public/sw-push.js`)
 

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -198,6 +198,7 @@ export function getAffectedTests(changedFiles) {
     'tests/integration/api/chats-message-id-stream.spec.ts',
     'tests/unit/pages/chats-new.spec.ts',
     'tests/unit/layouts/chat.spec.ts',
+    'tests/unit/components/Sidebar/PushToggle.spec.ts',
   ]
 
   const emailTests = [
@@ -272,7 +273,7 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern:
-        /^(server\/utils\/push\.ts|server\/utils\/push-protocol\.ts|server\/api\/v1\/push\/.*\.ts|app\/composables\/(push-notifications|notification-prompt)\.ts|app\/components\/NotificationPrompt\.client\.vue|app\/layouts\/chat\.vue|server\/db\/schemas\/push-subscriptions\.ts|public\/sw-push\.js|app\/plugins\/push-navigation\.client\.ts)$/,
+        /^(server\/utils\/push\.ts|server\/utils\/push-protocol\.ts|server\/api\/v1\/push\/.*\.ts|app\/composables\/(push-notifications|notification-prompt)\.ts|app\/components\/NotificationPrompt\.client\.vue|app\/layouts\/chat\.vue|server\/db\/schemas\/push-subscriptions\.ts|public\/sw-push\.js|app\/plugins\/push-navigation\.client\.ts|app\/components\/Sidebar\/(AuthCta|PushToggle\.client)\.vue)$/,
       tests: pushNotificationTests,
     },
     {

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -199,6 +199,7 @@ export function getAffectedTests(changedFiles) {
     'tests/unit/pages/chats-new.spec.ts',
     'tests/unit/layouts/chat.spec.ts',
     'tests/unit/components/Sidebar/PushToggle.spec.ts',
+    'tests/unit/components/ui/Alert.spec.ts',
   ]
 
   const emailTests = [
@@ -273,7 +274,7 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern:
-        /^(server\/utils\/push\.ts|server\/utils\/push-protocol\.ts|server\/api\/v1\/push\/.*\.ts|app\/composables\/(push-notifications|notification-prompt)\.ts|app\/components\/NotificationPrompt\.client\.vue|app\/layouts\/chat\.vue|server\/db\/schemas\/push-subscriptions\.ts|public\/sw-push\.js|app\/plugins\/push-navigation\.client\.ts|app\/components\/Sidebar\/(AuthCta|PushToggle\.client)\.vue)$/,
+        /^(server\/utils\/push\.ts|server\/utils\/push-protocol\.ts|server\/api\/v1\/push\/.*\.ts|app\/composables\/(push-notifications|notification-prompt)\.ts|app\/components\/NotificationPrompt\.client\.vue|app\/components\/ui\/Alert\.vue|app\/layouts\/chat\.vue|server\/db\/schemas\/push-subscriptions\.ts|public\/sw-push\.js|app\/plugins\/push-navigation\.client\.ts|app\/components\/Sidebar\/(AuthCta|PushToggle\.client)\.vue)$/,
       tests: pushNotificationTests,
     },
     {

--- a/server/api/v1/chats/[slug]/index.post.ts
+++ b/server/api/v1/chats/[slug]/index.post.ts
@@ -6,6 +6,7 @@ import type {
 } from 'ai'
 import type { SharedV2ProviderOptions } from '@ai-sdk/provider'
 import type { H3Event } from 'h3'
+import { getRequestURL } from 'h3'
 import type { ChatErrorPayload } from '#shared/types/chat-errors.d'
 import type { MessageUsage } from '#shared/types/message-usage.d'
 import type { ModelTool } from '#shared/types/providers.d'
@@ -797,6 +798,15 @@ export default defineEventHandler(async (event) => {
         if (wasPersisted && cfCtx?.waitUntil) {
           const runtimeConfig = useRuntimeConfig()
 
+          let targetOrigin: string | undefined
+
+          try {
+            targetOrigin = getRequestURL(event).origin
+          } catch (exception) {
+            void exception
+            targetOrigin = undefined
+          }
+
           cfCtx.waitUntil(sendPushNotificationToUser(
             db,
             userId,
@@ -811,6 +821,7 @@ export default defineEventHandler(async (event) => {
               privateKey: runtimeConfig.vapidPrivateKey || undefined,
             },
             cfCtx.waitUntil.bind(cfCtx),
+            targetOrigin,
           ))
         }
 

--- a/tests/integration/api/chats-message-id-stream.spec.ts
+++ b/tests/integration/api/chats-message-id-stream.spec.ts
@@ -542,6 +542,15 @@ describe('chat stream message ids', () => {
     const { db } = createDb()
     const { event, waitUntil } = createWaitUntilEvent({
       params: { slug: '01ARZ3NDEKTSV4RRFFQ69G5FAV' },
+      node: {
+        req: {
+          headers: {
+            'host': 'pr-304.besidka-preview.chernenko.workers.dev',
+            'x-forwarded-proto': 'https',
+          },
+          originalUrl: '/api/v1/chats/01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        },
+      },
       body: {
         model: 'gpt-5-mini',
         tools: [],
@@ -567,6 +576,7 @@ describe('chat stream message ids', () => {
       },
       expect.anything(),
       expect.anything(),
+      'https://pr-304.besidka-preview.chernenko.workers.dev',
     )
   })
 

--- a/tests/unit/components/Sidebar/PushToggle.spec.ts
+++ b/tests/unit/components/Sidebar/PushToggle.spec.ts
@@ -1,0 +1,133 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import SidebarPushToggle from '../../../../app/components/Sidebar/PushToggle.client.vue'
+
+const mocks = vi.hoisted(() => ({
+  isSupported: true,
+  permission: 'default' as NotificationPermission,
+  isSubscribed: false,
+  disable: vi.fn(async () => undefined),
+  requestEnable: vi.fn(async () => undefined),
+}))
+
+mockNuxtImport('usePushNotifications', () => {
+  return () => ({
+    isSupported: {
+      get value() {
+        return mocks.isSupported
+      },
+    },
+    permission: {
+      get value() {
+        return mocks.permission
+      },
+    },
+    isSubscribed: {
+      get value() {
+        return mocks.isSubscribed
+      },
+    },
+  })
+})
+
+mockNuxtImport('useNotificationPrompt', () => {
+  return () => ({
+    disable: mocks.disable,
+    requestEnable: mocks.requestEnable,
+  })
+})
+
+async function flushPromises() {
+  for (let tick = 0; tick < 6; tick += 1) {
+    await Promise.resolve()
+  }
+}
+
+async function mountPushToggle() {
+  return mountSuspended(SidebarPushToggle)
+}
+
+describe('Sidebar/PushToggle', () => {
+  beforeEach(() => {
+    mocks.isSupported = true
+    mocks.permission = 'default'
+    mocks.isSubscribed = false
+    mocks.disable.mockClear()
+    mocks.requestEnable.mockClear()
+  })
+
+  it('renders nothing when push is unsupported', async () => {
+    mocks.isSupported = false
+
+    const wrapper = await mountPushToggle()
+
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
+  it('shows the enabled state when granted and subscribed', async () => {
+    mocks.permission = 'granted'
+    mocks.isSubscribed = true
+
+    const wrapper = await mountPushToggle()
+    const button = wrapper.get('button')
+
+    expect(button.classes()).toContain('btn-active')
+    expect(button.attributes('aria-label'))
+      .toBe('Disable push notifications')
+    expect(wrapper.get('.iconify').classes())
+      .toContain('i-lucide:bell-ring')
+  })
+
+  it('shows the disabled state when not granted or not subscribed', async () => {
+    const wrapper = await mountPushToggle()
+    const button = wrapper.get('button')
+
+    expect(button.classes()).not.toContain('btn-active')
+    expect(button.attributes('aria-label'))
+      .toBe('Enable push notifications')
+    expect(wrapper.get('.iconify').classes())
+      .toContain('i-lucide:bell-off')
+  })
+
+  it('calls disable (not requestEnable) when clicked while enabled', async () => {
+    mocks.permission = 'granted'
+    mocks.isSubscribed = true
+
+    const wrapper = await mountPushToggle()
+
+    await wrapper.get('button').trigger('click')
+
+    expect(mocks.disable).toHaveBeenCalledTimes(1)
+    expect(mocks.requestEnable).not.toHaveBeenCalled()
+  })
+
+  it('calls requestEnable (not disable) when clicked while disabled', async () => {
+    const wrapper = await mountPushToggle()
+
+    await wrapper.get('button').trigger('click')
+
+    expect(mocks.requestEnable).toHaveBeenCalledTimes(1)
+    expect(mocks.disable).not.toHaveBeenCalled()
+  })
+
+  it('guards against a second click while the first is still pending', async () => {
+    let resolveRequestEnable: () => void = () => {}
+
+    mocks.requestEnable.mockImplementation(() => {
+      return new Promise<void>((resolve) => {
+        resolveRequestEnable = resolve
+      })
+    })
+
+    const wrapper = await mountPushToggle()
+    const button = wrapper.get('button')
+
+    button.trigger('click')
+    await button.trigger('click')
+
+    expect(mocks.requestEnable).toHaveBeenCalledTimes(1)
+
+    resolveRequestEnable()
+    await flushPromises()
+  })
+})

--- a/tests/unit/components/Sidebar/PushToggle.spec.ts
+++ b/tests/unit/components/Sidebar/PushToggle.spec.ts
@@ -72,6 +72,8 @@ describe('Sidebar/PushToggle', () => {
     const button = wrapper.get('button')
 
     expect(button.classes()).toContain('btn-active')
+    expect(button.classes()).toContain('btn-accent')
+    expect(button.classes()).not.toContain('btn-ghost')
     expect(button.attributes('aria-label'))
       .toBe('Disable push notifications')
     expect(wrapper.get('.iconify').classes())
@@ -83,6 +85,8 @@ describe('Sidebar/PushToggle', () => {
     const button = wrapper.get('button')
 
     expect(button.classes()).not.toContain('btn-active')
+    expect(button.classes()).toContain('btn-ghost')
+    expect(button.classes()).not.toContain('btn-accent')
     expect(button.attributes('aria-label'))
       .toBe('Enable push notifications')
     expect(wrapper.get('.iconify').classes())

--- a/tests/unit/components/Sidebar/PushToggle.spec.ts
+++ b/tests/unit/components/Sidebar/PushToggle.spec.ts
@@ -89,6 +89,16 @@ describe('Sidebar/PushToggle', () => {
       .toContain('i-lucide:bell-off')
   })
 
+  it('blocks interaction and explains why when permission is denied', async () => {
+    mocks.permission = 'denied'
+
+    const wrapper = await mountPushToggle()
+
+    expect(wrapper.find('button').exists()).toBe(false)
+    expect(wrapper.get('[aria-label]').attributes('aria-label'))
+      .toBe('Notifications blocked in browser settings')
+  })
+
   it('calls disable (not requestEnable) when clicked while enabled', async () => {
     mocks.permission = 'granted'
     mocks.isSubscribed = true

--- a/tests/unit/components/ui/Alert.spec.ts
+++ b/tests/unit/components/ui/Alert.spec.ts
@@ -1,0 +1,23 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import UiAlert from '../../../../app/components/ui/Alert.vue'
+
+describe('ui/Alert', () => {
+  it('renders sticky by default', async () => {
+    const wrapper = await mountSuspended(UiAlert)
+    const bubble = wrapper.find('[role="alert"]')
+
+    expect(bubble.classes()).toContain('sticky')
+    expect(bubble.classes()).not.toContain('fixed')
+  })
+
+  it('renders fixed when the fixed prop is set', async () => {
+    const wrapper = await mountSuspended(UiAlert, {
+      props: { fixed: true },
+    })
+    const bubble = wrapper.find('[role="alert"]')
+
+    expect(bubble.classes()).toContain('fixed')
+    expect(bubble.classes()).not.toContain('sticky')
+  })
+})

--- a/tests/unit/composables/notification-prompt.spec.ts
+++ b/tests/unit/composables/notification-prompt.spec.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   permission: 'default' as NotificationPermission,
   isSubscribed: false,
   subscribe: vi.fn(async () => true),
+  unsubscribe: vi.fn(async () => undefined),
   refreshState: vi.fn(async () => undefined),
 }))
 
@@ -54,7 +55,7 @@ mockNuxtImport('usePushNotifications', () => {
       },
     },
     subscribe: mocks.subscribe,
-    unsubscribe: vi.fn(),
+    unsubscribe: mocks.unsubscribe,
     refreshState: mocks.refreshState,
   })
 })
@@ -78,6 +79,7 @@ describe('useNotificationPrompt', () => {
     mocks.permission = 'default'
     mocks.isSubscribed = false
     mocks.subscribe.mockClear()
+    mocks.unsubscribe.mockClear()
     mocks.refreshState.mockClear()
     userSettingMocks.activeUserId.value = null
     userSettingMocks.isLoadingSettings.value = false
@@ -310,5 +312,45 @@ describe('useNotificationPrompt', () => {
     expect(prompt.isVisible.value).toBe(false)
     expect(userSettingMocks.setNotificationPromptState)
       .toHaveBeenCalledWith(false)
+  })
+
+  describe('requestEnable (settings-menu toggle button)', () => {
+    it('delegates to enable() when permission is already granted', async () => {
+      mocks.permission = 'granted'
+
+      const prompt = useNotificationPrompt()
+
+      await prompt.requestEnable()
+
+      expect(mocks.subscribe).toHaveBeenCalledTimes(1)
+      expect(prompt.isVisible.value).toBe(false)
+      expect(userSettingMocks.setNotificationPromptState)
+        .toHaveBeenCalledWith(true)
+    })
+
+    it('shows the disclosed banner instead of subscribing when permission is default', async () => {
+      mocks.permission = 'default'
+
+      const prompt = useNotificationPrompt()
+
+      await prompt.requestEnable()
+
+      expect(mocks.subscribe).not.toHaveBeenCalled()
+      expect(prompt.isVisible.value).toBe(true)
+      expect(userSettingMocks.setNotificationPromptState).not
+        .toHaveBeenCalled()
+    })
+  })
+
+  describe('disable (settings-menu toggle button)', () => {
+    it('unsubscribes and records declined', async () => {
+      const prompt = useNotificationPrompt()
+
+      await prompt.disable()
+
+      expect(mocks.unsubscribe).toHaveBeenCalledTimes(1)
+      expect(userSettingMocks.setNotificationPromptState)
+        .toHaveBeenCalledWith(false)
+    })
   })
 })

--- a/tests/unit/composables/notification-prompt.spec.ts
+++ b/tests/unit/composables/notification-prompt.spec.ts
@@ -340,6 +340,19 @@ describe('useNotificationPrompt', () => {
       expect(userSettingMocks.setNotificationPromptState).not
         .toHaveBeenCalled()
     })
+
+    it('does nothing when permission is denied, avoiding a dead-end banner', async () => {
+      mocks.permission = 'denied'
+
+      const prompt = useNotificationPrompt()
+
+      await prompt.requestEnable()
+
+      expect(mocks.subscribe).not.toHaveBeenCalled()
+      expect(prompt.isVisible.value).toBe(false)
+      expect(userSettingMocks.setNotificationPromptState).not
+        .toHaveBeenCalled()
+    })
   })
 
   describe('disable (settings-menu toggle button)', () => {

--- a/tests/unit/composables/push-notifications.spec.ts
+++ b/tests/unit/composables/push-notifications.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { usePushNotifications } from '../../../app/composables/push-notifications'
+import * as messagesComposable from '../../../app/composables/messages'
 
 const mocks = vi.hoisted(() => ({
   fetch: vi.fn(async () => undefined),
@@ -135,6 +136,20 @@ describe('usePushNotifications', () => {
     expect(mocks.fetch).not.toHaveBeenCalled()
   })
 
+  it('surfaces an error and returns false when the subscribe POST fails', async () => {
+    mocks.fetch.mockRejectedValueOnce(new Error('401 Unauthorized'))
+
+    const useErrorMessage = vi.spyOn(messagesComposable, 'useErrorMessage')
+    const composable = usePushNotifications()
+    const result = await composable.subscribe()
+
+    expect(result).toBe(false)
+    expect(useErrorMessage).toHaveBeenCalledWith(
+      '401 Unauthorized',
+      undefined,
+    )
+  })
+
   it('reuses an existing subscription instead of subscribing again', async () => {
     getSubscriptionMock.mockResolvedValue({
       endpoint: 'https://push.example.com/existing',
@@ -194,11 +209,16 @@ describe('usePushNotifications', () => {
     })
     mocks.fetch.mockRejectedValueOnce(new Error('401 Unauthorized'))
 
+    const useErrorMessage = vi.spyOn(messagesComposable, 'useErrorMessage')
     const composable = usePushNotifications()
 
     await flushPromises()
 
     expect(composable.isSubscribed.value).toBe(true)
+    expect(useErrorMessage).toHaveBeenCalledWith(
+      '401 Unauthorized',
+      undefined,
+    )
   })
 
   it('replaces a stale-key subscription on refresh when granted', async () => {

--- a/tests/unit/composables/push-notifications.spec.ts
+++ b/tests/unit/composables/push-notifications.spec.ts
@@ -31,6 +31,19 @@ describe('usePushNotifications', () => {
     mocks.fetch.mockClear()
     mocks.vapidPublicKey = 'QUJDRA'
 
+    useState<NotificationPermission>(
+      'push-notifications:permission',
+      () => 'default',
+    ).value = 'default'
+    useState<boolean>(
+      'push-notifications:is-subscribed',
+      () => false,
+    ).value = false
+    useState<boolean>(
+      'push-notifications:has-auto-refreshed',
+      () => false,
+    ).value = false
+
     requestPermissionMock = vi.fn(async () => 'granted')
     getSubscriptionMock = vi.fn(async () => null)
     subscribeMock = vi.fn(async () => ({

--- a/tests/unit/layouts/chat.spec.ts
+++ b/tests/unit/layouts/chat.spec.ts
@@ -1,4 +1,4 @@
-import { defineComponent, nextTick } from 'vue'
+import { nextTick } from 'vue'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, expect, it, vi } from 'vitest'
 import ChatLayout from '../../../app/layouts/chat.vue'
@@ -22,10 +22,6 @@ describe('chat layout', () => {
 
     const stubs = {
       NuxtPage: true,
-      ClientOnly: defineComponent({
-        template: '<div><slot /></div>',
-      }),
-      LazyNotificationPrompt: true,
     }
 
     await mountSuspended(ChatLayout, { global: { stubs } })


### PR DESCRIPTION
## Summary
- New toggle button in the user settings dropdown (order: sign out → theme switcher → API keys → push toggle), reflecting this device's actual `permission`/subscription state (not the account-level flag alone) so it never shows "enabled" on a browser that was never actually subscribed.
- Enabling from a cold `default` permission state routes through the existing disclosed banner instead of calling `Notification.requestPermission()` directly, preserving this app's compliance requirement that the OS dialog only ever follows prior disclosure. Silently resubscribes when permission is already `granted` (no dialog in that case).
- Relocated the notification banner's mount point from the chat layout to `app.vue` globally, since the sidebar (and thus the new toggle) renders on every route except the home page.
- Fixed `usePushNotifications()`'s auto-refresh (and the subscription re-upload it triggers) to run once per session instead of once per component — the new button would otherwise have added a third duplicate caller.
- Hidden entirely on browsers without Push API support.

## Test plan
- [x] `pnpm run format && pnpm run typecheck` clean
- [x] Full unit suite green (149 files / 1390 tests)
- [x] New/updated specs: `push-notifications.spec.ts`, `notification-prompt.spec.ts`, new `Sidebar/PushToggle.spec.ts`
- [x] `scripts/test-affected-check.mjs` updated to cover the new files
- [ ] CI checks
- [ ] Visual check on preview deploy (local browser verification was blocked by an unrelated extension conflict in this environment)