### PR TITLE
fix(chats): stop hiding deep research cost from chat totals

### DIFF
--- a/app/components/Chat/ContextMenu.client.vue
+++ b/app/components/Chat/ContextMenu.client.vue
@@ -85,7 +85,7 @@
               class="flex flex-col gap-1"
             >
               <span class="text-xs font-normal text-base-content/50">
-                Cost
+                {{ hasEstimatedCost ? 'Cost (estimated)' : 'Cost' }}
               </span>
               <div
                 v-if="info.cost !== undefined"
@@ -96,7 +96,7 @@
                   Current message
                 </span>
                 <span class="min-w-0 truncate font-normal text-base-content">
-                  {{ formatMessageCost(info.cost) }}
+                  {{ formatMessageCost(info.cost, info.costIsEstimated) }}
                 </span>
               </div>
               <div
@@ -108,7 +108,12 @@
                   Up to this message
                 </span>
                 <span class="min-w-0 truncate font-normal text-base-content">
-                  {{ formatMessageCost(info.costToMessage) }}
+                  {{
+                    formatMessageCost(
+                      info.costToMessage,
+                      info.costToMessageIsEstimated,
+                    )
+                  }}
                 </span>
               </div>
               <div
@@ -120,7 +125,12 @@
                   Chat total
                 </span>
                 <span class="min-w-0 truncate font-normal text-base-content">
-                  {{ formatMessageCost(info.chatTotalCost) }}
+                  {{
+                    formatMessageCost(
+                      info.chatTotalCost,
+                      info.chatTotalCostIsEstimated,
+                    )
+                  }}
                 </span>
               </div>
             </div>
@@ -285,6 +295,14 @@ const hasCostInfo = computed<boolean>(() => {
     props.info?.cost !== undefined
     || props.info?.costToMessage !== undefined
     || props.info?.chatTotalCost !== undefined
+  )
+})
+
+const hasEstimatedCost = computed<boolean>(() => {
+  return (
+    !!props.info?.costIsEstimated
+    || !!props.info?.costToMessageIsEstimated
+    || !!props.info?.chatTotalCostIsEstimated
   )
 })
 

--- a/server/utils/ai/message-usage.ts
+++ b/server/utils/ai/message-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelUsage } from 'ai'
 import type { MessageUsage } from '#shared/types/message-usage.d'
+import { getModel } from '#shared/utils/model'
+import { getModelResearch } from '#shared/utils/research'
+import { hasUnknownTokenSplit } from '#shared/utils/message-metadata'
 import { getModelCostMap } from '~~/server/utils/ai/cost-map'
 
 /**
@@ -69,5 +72,68 @@ export function addImageGenerationCostToUsage(
   return {
     ...usage,
     outputCost: (usage.outputCost ?? 0) + imageGenerationCost,
+  }
+}
+
+function parseResearchCostEstimate(costEstimate: string): number | undefined {
+  const matches = costEstimate.match(/[0-9]+(?:[.,][0-9]+)*/g)
+
+  if (!matches?.length) {
+    return undefined
+  }
+
+  const values = matches.map(match => Number(match.replace(/,/g, '')))
+  const total = values.reduce((sum, value) => sum + value, 0)
+
+  return total / values.length
+}
+
+function hasNoTrustworthyCost(usage: MessageUsage): boolean {
+  const costUnknown = usage.inputCost === undefined
+    && usage.outputCost === undefined
+
+  return costUnknown || hasUnknownTokenSplit(usage)
+}
+
+/**
+ * Falls back to a flat per-task dollar estimate for deep research messages
+ * whose real cost can't be computed from tokens. Google's Deep Research API
+ * reports only a total token count (no input/output split) and has no
+ * published per-token rate, so buildMessageUsage() correctly leaves cost
+ * fields unset rather than fabricate a number from a defaulted-zero split.
+ * Left as-is, sumMessageCosts() in message-metadata.ts silently drops that
+ * message from any total it contributes to — the research job's real
+ * spend disappears from "Chat total" while an unrelated message's cost is
+ * shown as if it were the whole chat's cost (this is the bug being fixed).
+ * OpenAI's deep research models already carry real published per-token
+ * prices, so they already produce a trustworthy cost and this never
+ * overwrites them. The `costEstimated` flag this sets tells the UI to
+ * render the fallback with a "~" instead of as an exact figure. Only
+ * `outputCost` is set — a message's displayed cost is always driven by
+ * `outputCost` alone (see `getPerMessageCost` in message-metadata.ts), so
+ * `inputCost` is left untouched by design.
+ */
+export function addResearchCostEstimateToUsage(
+  usage: MessageUsage | undefined,
+  modelId: string,
+): MessageUsage | undefined {
+  if (!usage || !hasNoTrustworthyCost(usage)) {
+    return usage
+  }
+
+  const { model } = getModel(modelId)
+  const research = getModelResearch(model)
+  const costEstimate = research
+    ? parseResearchCostEstimate(research.costEstimate)
+    : undefined
+
+  if (costEstimate === undefined) {
+    return usage
+  }
+
+  return {
+    ...usage,
+    outputCost: costEstimate,
+    costEstimated: true,
   }
 }

--- a/server/utils/research/finalize.ts
+++ b/server/utils/research/finalize.ts
@@ -10,7 +10,10 @@ import type {
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { ulid } from 'ulid'
 import * as schema from '~~/server/db/schema'
-import { buildMessageUsage } from '~~/server/utils/ai/message-usage'
+import {
+  addResearchCostEstimateToUsage,
+  buildMessageUsage,
+} from '~~/server/utils/ai/message-usage'
 import {
   mapResearchProviderError,
   normalizeChatError,
@@ -232,10 +235,13 @@ export async function finalizeResearchJob(
   }
 
   const parts = buildResearchAssistantParts({ result, job, durationMs })
-  const messageUsage = buildMessageUsage(
-    toLanguageModelUsage(result.usage),
+  const messageUsage = addResearchCostEstimateToUsage(
+    buildMessageUsage(
+      toLanguageModelUsage(result.usage),
+      job.modelId,
+      job.provider,
+    ),
     job.modelId,
-    job.provider,
   )
 
   try {

--- a/shared/types/message-usage.d.ts
+++ b/shared/types/message-usage.d.ts
@@ -8,6 +8,10 @@ export type MessageUsage = {
   totalTokens: number
   inputCost?: number
   outputCost?: number
+  // Set when outputCost is a flat per-task estimate, not measured from
+  // tokens (see addResearchCostEstimateToUsage in
+  // server/utils/ai/message-usage.ts).
+  costEstimated?: boolean
 }
 
 export type ChatMessageMetadata = {

--- a/shared/utils/message-format.ts
+++ b/shared/utils/message-format.ts
@@ -46,27 +46,32 @@ export function formatTokenCount(
  *   always keeping at least 2 decimals.
  * - Smaller positive values render with up to 6 decimals.
  * - In both cases, trailing zeros beyond the minimum are trimmed.
+ * - When `isEstimated` is `true`, the result is prefixed with `~` to mark
+ *   it as a flat per-task estimate rather than a measured, exact figure.
  */
 export function formatMessageCost(
   cost: number | undefined | null,
+  isEstimated = false,
 ): string {
   if (cost === undefined || cost === null) {
     return '—'
   }
 
+  const prefix = isEstimated ? '~' : ''
+
   if (cost === 0) {
-    return '$0.00'
+    return `${prefix}$0.00`
   }
 
   if (cost > 0 && cost < 0.0001) {
-    return '< $0.0001'
+    return `${prefix}< $0.0001`
   }
 
   const formatter = cost >= 0.01
     ? COST_ABOVE_CENT_FORMATTER
     : COST_BELOW_CENT_FORMATTER
 
-  return `$${formatter.format(cost)}`
+  return `${prefix}$${formatter.format(cost)}`
 }
 
 export function formatMessageDateTime(

--- a/shared/utils/message-metadata.ts
+++ b/shared/utils/message-metadata.ts
@@ -14,8 +14,16 @@ export type MessageMenuInfo = {
   tokens?: number
   reasoningTokens?: number
   cost?: number
+  costIsEstimated?: boolean
   costToMessage?: number
+  costToMessageIsEstimated?: boolean
   chatTotalCost?: number
+  chatTotalCostIsEstimated?: boolean
+}
+
+type DisplayCost = {
+  amount: number
+  isEstimated: boolean
 }
 
 type MenuMessage = {
@@ -77,7 +85,7 @@ export function hydrateMessageUsage<
 // split was never reported — so it's a reliable signal to fall back to the
 // total instead of displaying a misleading "0", and to treat any cost
 // computed from that zeroed split as unknown rather than a real $0.00.
-function hasUnknownTokenSplit(usage: MessageUsage): boolean {
+export function hasUnknownTokenSplit(usage: MessageUsage): boolean {
   return usage.inputTokens === 0
     && usage.outputTokens === 0
     && usage.totalTokens > 0
@@ -97,12 +105,16 @@ function resolveDisplayTokens(
 function resolveDisplayCost(
   usage: MessageUsage | undefined,
   cost: number | undefined,
-): number | undefined {
-  if (usage && hasUnknownTokenSplit(usage)) {
+): DisplayCost | undefined {
+  if (cost === undefined) {
     return undefined
   }
 
-  return cost
+  if (usage && hasUnknownTokenSplit(usage) && !usage.costEstimated) {
+    return undefined
+  }
+
+  return { amount: cost, isEstimated: !!usage?.costEstimated }
 }
 
 export function getMessageUsedTools(
@@ -171,7 +183,7 @@ function getFollowingAssistantUsage(
 function getPerMessageCost(
   messages: MenuMessage[],
   messageIndex: number,
-): number | undefined {
+): DisplayCost | undefined {
   const message = messages[messageIndex]
 
   if (!message) {
@@ -196,9 +208,10 @@ function getPerMessageCost(
 function sumMessageCosts(
   messages: MenuMessage[],
   endIndex: number,
-): number | undefined {
+): DisplayCost | undefined {
   let total = 0
   let hasCost = false
+  let isEstimated = false
 
   for (let index = 0; index <= endIndex; index += 1) {
     const cost = getPerMessageCost(messages, index)
@@ -208,10 +221,11 @@ function sumMessageCosts(
     }
 
     hasCost = true
-    total += cost
+    total += cost.amount
+    isEstimated = isEstimated || cost.isEstimated
   }
 
-  return hasCost ? total : undefined
+  return hasCost ? { amount: total, isEstimated } : undefined
 }
 
 export function resolveMessageMenuInfo(
@@ -248,9 +262,12 @@ export function resolveMessageMenuInfo(
       reasoning: message.reasoning,
       tokens: resolveDisplayTokens(usage, usage?.outputTokens),
       reasoningTokens: usage?.reasoningTokens,
-      cost,
-      costToMessage,
-      chatTotalCost,
+      cost: cost?.amount,
+      costIsEstimated: cost?.isEstimated || undefined,
+      costToMessage: costToMessage?.amount,
+      costToMessageIsEstimated: costToMessage?.isEstimated || undefined,
+      chatTotalCost: chatTotalCost?.amount,
+      chatTotalCostIsEstimated: chatTotalCost?.isEstimated || undefined,
     }
   }
 
@@ -260,8 +277,11 @@ export function resolveMessageMenuInfo(
     role: 'user',
     createdAt: metadata.createdAt,
     tokens: resolveDisplayTokens(followingUsage, followingUsage?.inputTokens),
-    cost,
-    costToMessage,
-    chatTotalCost,
+    cost: cost?.amount,
+    costIsEstimated: cost?.isEstimated || undefined,
+    costToMessage: costToMessage?.amount,
+    costToMessageIsEstimated: costToMessage?.isEstimated || undefined,
+    chatTotalCost: chatTotalCost?.amount,
+    chatTotalCostIsEstimated: chatTotalCost?.isEstimated || undefined,
   }
 }

--- a/tests/unit/components/Chat/ContextMenu.client.spec.ts
+++ b/tests/unit/components/Chat/ContextMenu.client.spec.ts
@@ -1000,6 +1000,65 @@ describe('Chat/ContextMenu.client', () => {
       ).toContain('Web search')
     })
 
+    it('prefixes estimated costs with a tilde', async () => {
+      const info: MessageMenuInfo = {
+        role: 'assistant',
+        createdAt: '2026-01-15T10:30:00.000Z',
+        cost: 2,
+        costIsEstimated: true,
+        costToMessage: 2,
+        costToMessageIsEstimated: true,
+        chatTotalCost: 2,
+        chatTotalCostIsEstimated: true,
+      }
+
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: {
+          messageId: 'm1',
+          anchorEl,
+          info,
+        },
+        attachTo: document.body,
+      })
+
+      expect(
+        wrapper.find('[data-testid="message-menu-cost-current"]').text(),
+      ).toContain('~$2.00')
+      expect(
+        wrapper.find('[data-testid="message-menu-cost-to-message"]').text(),
+      ).toContain('~$2.00')
+      expect(
+        wrapper.find('[data-testid="message-menu-cost-chat-total"]').text(),
+      ).toContain('~$2.00')
+      expect(
+        wrapper.find('[data-testid="message-menu-info"]').text(),
+      ).toContain('Cost (estimated)')
+    })
+
+    it('labels the cost section plainly when nothing is estimated', async () => {
+      const info: MessageMenuInfo = {
+        role: 'assistant',
+        createdAt: '2026-01-15T10:30:00.000Z',
+        cost: 0.0177,
+        costToMessage: 0.0177,
+        chatTotalCost: 0.0177,
+      }
+
+      const wrapper = await mountSuspended(ContextMenu, {
+        props: {
+          messageId: 'm1',
+          anchorEl,
+          info,
+        },
+        attachTo: document.body,
+      })
+
+      const infoText = wrapper.find('[data-testid="message-menu-info"]').text()
+
+      expect(infoText).toContain('Cost')
+      expect(infoText).not.toContain('Cost (estimated)')
+    })
+
     it('shows only the cost sub-rows that have a value', async () => {
       const info: MessageMenuInfo = {
         role: 'assistant',

--- a/tests/unit/utils/message-format.spec.ts
+++ b/tests/unit/utils/message-format.spec.ts
@@ -45,6 +45,19 @@ describe('formatMessageCost', () => {
   it('pads whole-cent costs to 2 decimals', () => {
     expect(formatMessageCost(2.5)).toBe('$2.50')
   })
+
+  it('prefixes an estimated cost with a tilde', () => {
+    expect(formatMessageCost(2, true)).toBe('~$2.00')
+  })
+
+  it('does not prefix a non-estimated cost', () => {
+    expect(formatMessageCost(2, false)).toBe('$2.00')
+    expect(formatMessageCost(2)).toBe('$2.00')
+  })
+
+  it('prefixes the near-zero lower bound when estimated', () => {
+    expect(formatMessageCost(0.00005, true)).toBe('~< $0.0001')
+  })
 })
 
 describe('formatMessageDateTime', () => {

--- a/tests/unit/utils/message-metadata.spec.ts
+++ b/tests/unit/utils/message-metadata.spec.ts
@@ -371,6 +371,85 @@ describe('resolveMessageMenuInfo', () => {
     expect(info?.chatTotalCost).toBeUndefined()
   })
 
+  it('marks an estimated deep-research cost with the isEstimated flags', () => {
+    const researchUsage = {
+      model: 'deep-research-preview-04-2026',
+      provider: 'google',
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 1130546,
+      outputCost: 2,
+      costEstimated: true,
+    }
+    const messages = [{
+      id: 'a1',
+      role: 'assistant',
+      metadata: { usage: researchUsage, createdAt: 'when' },
+      parts: [
+        { type: 'data-research', data: { provider: 'google' } },
+      ],
+    }]
+
+    expect(resolveMessageMenuInfo(messages, 'a1')).toEqual({
+      role: 'assistant',
+      createdAt: 'when',
+      model: 'deep-research-preview-04-2026',
+      usedTools: ['deep_research'],
+      tokens: 1130546,
+      reasoningTokens: undefined,
+      cost: 2,
+      costIsEstimated: true,
+      costToMessage: 2,
+      costToMessageIsEstimated: true,
+      chatTotalCost: 2,
+      chatTotalCostIsEstimated: true,
+    })
+  })
+
+  it('mixes an estimated research cost into a real chat total and still flags it as estimated', () => {
+    const researchUsage = {
+      model: 'deep-research-preview-04-2026',
+      provider: 'google',
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 1130546,
+      outputCost: 2,
+      costEstimated: true,
+    }
+    const followUpUsage = {
+      model: 'gemini-2.5-flash-lite',
+      provider: 'google',
+      inputTokens: 5000,
+      outputTokens: 3000,
+      totalTokens: 8000,
+      inputCost: 0.0012251,
+      outputCost: 0.0079328,
+    }
+    const messages = [
+      { id: 'a1', role: 'assistant', metadata: { usage: researchUsage } },
+      { id: 'u1', role: 'user', metadata: { createdAt: 'follow-up' } },
+      { id: 'a2', role: 'assistant', metadata: { usage: followUpUsage } },
+    ]
+
+    const info = resolveMessageMenuInfo(messages, 'a2')
+
+    expect(info?.chatTotalCost).toBeCloseTo(2 + 0.0012251 + 0.0079328)
+    expect(info?.chatTotalCostIsEstimated).toBe(true)
+  })
+
+  it('does not mark chatTotalCost as estimated for a chat with only real costs', () => {
+    const messages = [{
+      id: 'a1',
+      role: 'assistant',
+      metadata: { usage: assistantUsage, createdAt: 'when' },
+    }]
+
+    const info = resolveMessageMenuInfo(messages, 'a1')
+
+    expect(info?.chatTotalCost).toBe(0.0177)
+    expect(info?.chatTotalCostIsEstimated).toBeFalsy()
+  })
+
   it('still reports a genuine zero-token assistant reply without a fallback', () => {
     const usage = {
       model: 'gpt-5.4',

--- a/tests/unit/utils/message-usage.spec.ts
+++ b/tests/unit/utils/message-usage.spec.ts
@@ -2,6 +2,7 @@ import type { LanguageModelUsage } from 'ai'
 import { describe, expect, it } from 'vitest'
 import {
   addImageGenerationCostToUsage,
+  addResearchCostEstimateToUsage,
   buildMessageUsage,
 } from '../../../server/utils/ai/message-usage'
 
@@ -185,6 +186,90 @@ describe('addImageGenerationCostToUsage', () => {
 
   it('returns undefined unchanged when usage itself is undefined', () => {
     const result = addImageGenerationCostToUsage(undefined, 0.067)
+
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('addResearchCostEstimateToUsage', () => {
+  it('fills in the midpoint task estimate for a Google deep research usage with totals-only tokens', () => {
+    const usage = buildMessageUsage(
+      createUsage({ totalTokens: 1130546 }),
+      'deep-research-preview-04-2026',
+      'google',
+    )
+
+    const result = addResearchCostEstimateToUsage(
+      usage,
+      'deep-research-preview-04-2026',
+    )
+
+    expect(result?.outputCost).toBe(2)
+    expect(result?.costEstimated).toBe(true)
+  })
+
+  it('leaves an OpenAI deep research usage with a real computed cost unchanged', () => {
+    const usage = buildMessageUsage(
+      createUsage({
+        inputTokens: 49052,
+        outputTokens: 35610,
+        totalTokens: 84662,
+      }),
+      'o4-mini-deep-research',
+      'openai',
+    )
+
+    const result = addResearchCostEstimateToUsage(
+      usage,
+      'o4-mini-deep-research',
+    )
+
+    expect(result).toEqual(usage)
+  })
+
+  it('is a no-op for a regular non-research model', () => {
+    const usage = buildMessageUsage(
+      createUsage({
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+      }),
+      PRICED_MODEL_ID,
+      PRICED_PROVIDER_ID,
+    )
+
+    const result = addResearchCostEstimateToUsage(usage, PRICED_MODEL_ID)
+
+    expect(result).toEqual(usage)
+  })
+
+  it('overwrites a fake $0 caused by an unknown split on a priced research model', () => {
+    const usage = buildMessageUsage(
+      createUsage({
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 1000,
+      }),
+      'o4-mini-deep-research',
+      'openai',
+    )
+
+    expect(usage?.outputCost).toBe(0)
+
+    const result = addResearchCostEstimateToUsage(
+      usage,
+      'o4-mini-deep-research',
+    )
+
+    expect(result?.outputCost).toBe(1)
+    expect(result?.costEstimated).toBe(true)
+  })
+
+  it('returns undefined unchanged when usage itself is undefined', () => {
+    const result = addResearchCostEstimateToUsage(
+      undefined,
+      'deep-research-preview-04-2026',
+    )
 
     expect(result).toBeUndefined()
   })

--- a/tests/unit/utils/research/finalize.spec.ts
+++ b/tests/unit/utils/research/finalize.spec.ts
@@ -635,7 +635,7 @@ describe('finalizeResearchJob', () => {
     )
   })
 
-  it('persists tokens without cost for a Google deep research report', async () => {
+  it('persists a flat cost estimate for a Google deep research report with totals-only tokens', async () => {
     mocks.getResearchAdapter.mockReturnValue({
       status: vi.fn(async () => ({ status: 'completed' })),
       result: vi.fn(async () => ({
@@ -673,6 +673,8 @@ describe('finalizeResearchJob', () => {
       inputTokens: 0,
       outputTokens: 0,
       totalTokens: 500,
+      outputCost: 2,
+      costEstimated: true,
     })
   })
 


### PR DESCRIPTION
## Summary

Google's Gemini Deep Research messages (`deep-research-preview-04-2026`, `deep-research-max-preview-04-2026`) end up with no computable per-token cost — correctly, since Google bills these per task (not per token) and its Interactions API only returns a total token count, never an input/output split. `sumMessageCosts()` then silently dropped these costless messages from any running total, so a chat containing a deep research job displayed a small, precise-looking "Chat total" that quietly omitted the research job's real spend (verified against a real production chat: displayed cost was `$0.009158`, actual provider billing was `$1.93` — the displayed number was entirely the cost of one small unrelated follow-up message later in the same chat).

Verified along the way that this can't be fixed by reading a real cost from the AI SDK, evlog, or the provider APIs directly — none of them carry a billed-dollar field for these jobs (evlog's own `cost` option is a caller-supplied static price map; neither OpenAI's Responses API nor Google's Interactions API return cost in their `usage` object). OpenAI's deep research models are unaffected today since they already have real published per-token prices.

## Fix

- Fall back to a flat per-task dollar estimate (midpoint of the model's own published `research.costEstimate`, e.g. midpoint of "$1–3 / task" → $2, within ~4% of the real $1.93 billed) whenever a research message has no trustworthy per-token cost.
- Mark it `costEstimated: true` so it's never presented as an exact figure: totals that include an estimated-cost message render with a `~` prefix, and the context menu's "Cost" section label switches to "Cost (estimated)" whenever any of its rows is.
- The `hasUnknownTokenSplit` $0-fabrication guard is now gated strictly on the usage's own `costEstimated` flag rather than "is this a research message" — a research message with a real, token-derived, unmarked cost that happens to hit a zeroed split still gets suppressed exactly as before.
- Side task: double-checked image generation costs for the same failure mode — they use flat numeric constants (not string-parsed prices) and are always paired with a real token split, so neither bug applies there. No code change needed.

## Test plan

- [x] `pnpm run format && pnpm run typecheck` — clean
- [x] `pnpm vitest run` (full unit suite) — 148 files, 1393 tests passing, plus 1 new test = 1394
- [x] `pnpm run test:unit` + `pnpm run test:integration` — 1063 + 331 tests passing
- [x] `pnpm run test:e2e` — 69 passing, 1 pre-existing local-only flake (`signin.spec.ts`, documented Vite 8 HMR worker-contention issue unrelated to this diff — reproduces-pass in isolation with `--workers=1`)
- [x] Code review pass (0 critical/warning findings, 3 style/hardening suggestions applied)
- [x] `providers/openai.ts`, `providers/google.ts`, `server/utils/ai/cost-map.ts` left untouched