### PR TITLE
fix(push): stop unauthenticated push-subscribe call from erroring on reload

### DIFF
--- a/app/composables/push-notifications.ts
+++ b/app/composables/push-notifications.ts
@@ -61,6 +61,7 @@ function isApplicationServerKeyStale(
 
 export function usePushNotifications() {
   const { public: { vapidPublicKey } } = useRuntimeConfig()
+  const { loggedIn } = useAuth()
   const permission = useState<NotificationPermission>(
     'push-notifications:permission',
     () => 'default',
@@ -101,7 +102,8 @@ export function usePushNotifications() {
           vapidPublicKey,
         )
 
-      if (isStale && Notification.permission === 'granted') {
+      if (isStale && Notification.permission === 'granted'
+        && loggedIn.value) {
         try {
           await subscription.unsubscribe()
 
@@ -138,7 +140,7 @@ export function usePushNotifications() {
 
       isSubscribed.value = subscription !== null
 
-      if (subscription !== null) {
+      if (subscription !== null && loggedIn.value) {
         try {
           await $fetch('/api/v1/push/subscribe', {
             method: 'POST',

--- a/tests/unit/composables/push-notifications.spec.ts
+++ b/tests/unit/composables/push-notifications.spec.ts
@@ -6,6 +6,7 @@ import * as messagesComposable from '../../../app/composables/messages'
 const mocks = vi.hoisted(() => ({
   fetch: vi.fn(async () => undefined),
   vapidPublicKey: 'QUJDRA',
+  loggedIn: true,
 }))
 
 mockNuxtImport('useRuntimeConfig', () => {
@@ -16,6 +17,12 @@ mockNuxtImport('useRuntimeConfig', () => {
 })
 
 mockNuxtImport('$fetch', () => mocks.fetch)
+
+mockNuxtImport('useAuth', () => {
+  return () => ({
+    loggedIn: computed(() => mocks.loggedIn),
+  })
+})
 
 async function flushPromises() {
   for (let tick = 0; tick < 6; tick += 1) {
@@ -31,6 +38,7 @@ describe('usePushNotifications', () => {
   beforeEach(async () => {
     mocks.fetch.mockClear()
     mocks.vapidPublicKey = 'QUJDRA'
+    mocks.loggedIn = true
 
     useState<NotificationPermission>(
       'push-notifications:permission',
@@ -221,6 +229,28 @@ describe('usePushNotifications', () => {
     )
   })
 
+  it('does not re-post an existing subscription on load when logged out', async () => {
+    mocks.loggedIn = false
+
+    getSubscriptionMock.mockResolvedValue({
+      endpoint: 'https://push.example.com/existing',
+      getKey: (name: string) => {
+        return name === 'p256dh'
+          ? new TextEncoder().encode('p256dh-bytes').buffer
+          : new TextEncoder().encode('auth-bytes').buffer
+      },
+    })
+
+    const useErrorMessage = vi.spyOn(messagesComposable, 'useErrorMessage')
+    const composable = usePushNotifications()
+
+    await flushPromises()
+
+    expect(mocks.fetch).not.toHaveBeenCalled()
+    expect(useErrorMessage).not.toHaveBeenCalled()
+    expect(composable.isSubscribed.value).toBe(true)
+  })
+
   it('replaces a stale-key subscription on refresh when granted', async () => {
     Object.defineProperty(globalThis, 'Notification', {
       configurable: true,
@@ -302,6 +332,38 @@ describe('usePushNotifications', () => {
         },
       },
     })
+    expect(composable.isSubscribed.value).toBe(true)
+  })
+
+  it('does not replace a stale-key subscription when logged out', async () => {
+    mocks.loggedIn = false
+
+    Object.defineProperty(globalThis, 'Notification', {
+      configurable: true,
+      value: {
+        permission: 'granted',
+        requestPermission: requestPermissionMock,
+      },
+    })
+
+    const unsubscribeMock = vi.fn(async () => true)
+
+    getSubscriptionMock.mockResolvedValue({
+      endpoint: 'https://push.example.com/stale',
+      options: {
+        applicationServerKey: new TextEncoder().encode('stale-key').buffer,
+      },
+      getKey: () => new TextEncoder().encode('key-bytes').buffer,
+      unsubscribe: unsubscribeMock,
+    })
+
+    const composable = usePushNotifications()
+
+    await flushPromises()
+
+    expect(unsubscribeMock).not.toHaveBeenCalled()
+    expect(subscribeMock).not.toHaveBeenCalled()
+    expect(mocks.fetch).not.toHaveBeenCalled()
     expect(composable.isSubscribed.value).toBe(true)
   })
 


### PR DESCRIPTION
## Summary
- `usePushNotifications()` auto-reconciles the browser's push subscription with the server on the first client mount of every page (added in #304). It fired unconditionally, including for signed-out users who still hold a granted Notification permission + subscription from before signing out.
- The resulting `401` from `/api/v1/push/subscribe` surfaced as a raw "You don't have access to this resource. Try to sign out and sign in again." toast on every reload after sign-out — reproducible every time because sign-out itself does a full `reloadNuxtApp`, and visible on `/signin` because `NotificationPrompt.client.vue` mounts globally in `app.vue`.
- Gates both `/api/v1/push/subscribe` reconciliation call sites in `refreshState()` on `useAuth().loggedIn.value`, captured synchronously in the composable body to avoid async-context loss.

## Test plan
- [x] `pnpm run format` — clean
- [x] `pnpm run typecheck` — 0 errors
- [x] `pnpm vitest run tests/unit/composables/push-notifications.spec.ts` — 14/14 passing, including 2 new logged-out regression cases (normal + stale-VAPID-key branches)
- [x] Full unit suite (1079 tests) and pre-push affected-test sweep (unit + integration, 123 tests) — all passing
- [ ] Manual verification on preview: sign out with push notifications enabled, confirm no toast on the resulting reload