### PR TITLE
fix(observability): move high-variety evlog fields into an attributes map field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,8 @@ stats.html
 
 # Agents
 .claude/plans
-.pi
+.pi/*
+!.pi/mcp.json
 .herdr
 
 # Snyk Security Extension - AI Rules (auto-generated)
@@ -58,3 +59,6 @@ stats.html
 
 # CMS bucket assets (large binary files — upload to R2 instead)
 .files/
+
+# Axiom dashboards (separate repo)
+.axiom-dashboard/

--- a/.pi/mcp.json
+++ b/.pi/mcp.json
@@ -1,0 +1,12 @@
+{
+    "mcpServers": {
+        "axiom": {
+            "command": "npx",
+            "args": [
+                "-y",
+                "mcp-remote",
+                "https://mcp.axiom.co/mcp"
+            ]
+        }
+    }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,10 @@ The first bookmark whose timestamp predates the migration is **not necessarily s
   `esbuild`: a Vite 8 default-change + DaisyUI/Lightning CSS `:is()`
   specificity bug that broke the light theme in production builds only;
   when to prefer lightningcss vs esbuild, and revert criteria
+- `docs/axiom-map-fields.md` - Why `besidka-prod` hit Axiom's 256-field
+  schema limit, the `attributes` map-field convention that fixes it, the
+  `scripts/axiom-declare-map-field.mjs` rollout step that MUST run before
+  deploying, and why the fix doesn't reclaim existing schema headroom
 
 ### Tech Stack
 

--- a/docs/axiom-map-fields.md
+++ b/docs/axiom-map-fields.md
@@ -1,0 +1,169 @@
+# Axiom map fields — evlog wide-event schema limit
+
+> **Do not deploy this change until the `attributes` field has been declared
+> a map field on `besidka-prod` (and `besidka-audit-prod` /
+> `besidka-consent-prod`).** Run `scripts/axiom-declare-map-field.mjs` first
+> (see [Rollout](#rollout) below). The `besidka-prod` schema is already at
+> Axiom's 256-field cap. If the code below deploys before the map field
+> exists, `attributes.*` becomes a batch of brand-new flat fields that try to
+> push the schema past 256 and get **rejected** — turning currently-succeeding
+> log writes into failures. Declaring the map field first is what makes this
+> a fix instead of a regression.
+
+## What happened
+
+Axiom emailed that `besidka-prod` hit its 256-field-per-dataset schema limit
+and started rejecting events that would add new fields. Axiom's own fix
+recommendation is [map fields](https://axiom.co/docs/apl/data-types/map-fields).
+
+## Root cause
+
+Our evlog → Axiom drain (`server/utils/evlog-drains.ts`, `evlog/axiom`) just
+`JSON.stringify()`s each wide event and POSTs it — there's no field-limit
+awareness on our side. Axiom flattens **every nested JSON key path** in a
+plain (non-map) field into its own permanent schema field: logging
+`research: { provider, modelId }` creates two schema fields,
+`research.provider` and `research.modelId`, forever — Axiom's schema is a
+high-water mark that never shrinks on its own.
+
+With 60+ server files each calling `logger.set()` with their own
+domain-namespaced object (`chat`, `project`, `push`, `research`,
+`imageGeneration`, `fileConversion`, ...), all shipping into the *same*
+`besidka-prod` dataset, the union of distinct field paths across the whole
+app's history grew past 256. An audit of every `logger.set()` call site
+found 267 distinct nested field paths across 63 files — comfortably enough,
+combined with evlog's own reserved fields and Cloudflare request metadata, to
+explain the breach.
+
+Field **names** cause this, not field **values** — a field like
+`research.error` only ever counts once regardless of how many different
+error strings flow through it. The fix is about *which fields exist*, not
+about "unpredictable data."
+
+## The fix
+
+Added one reserved wide-event field, `attributes`, typed via evlog's
+sanctioned `declare module 'evlog'` extension point
+(`server/types/evlog.d.ts`):
+
+```ts
+declare module 'evlog' {
+  interface BaseWideEvent {
+    attributes?: Record<string, Record<string, unknown>>
+  }
+}
+```
+
+`attributes` is declared as an **Axiom map field** (see
+[Rollout](#rollout)) — once declared, anything nested under it, at any
+depth, is exempt from the field-count check, no matter how many different
+sub-keys different call sites add over time. This mirrors exactly how Axiom
+handles OpenTelemetry's `attributes.custom` field for arbitrary span
+attributes.
+
+Across 26 files, the ~55 field paths identified as high-variety and rarely
+filtered by exact value — free-form exception messages/stacks, provider ids,
+model ids, media/mime types, and error-code enums with many variants — moved
+from `<domain>.<key>` to `attributes.<domain>.<key>`. Bounded, genuinely
+useful-to-filter dimensions (entity ids, status/phase enums, counts,
+operation names) were left flat exactly where they were.
+
+Example (`server/utils/research/start.ts`):
+
+```ts
+// Before — errorCode/errorMessage are each a new permanent schema field
+input.logger.set({
+  research: {
+    phase: 'start',
+    jobId: job.id,
+    errorCode: chatError.code,
+    errorMessage: chatError.why,
+  },
+})
+
+// After — phase/jobId stay flat and queryable; errorCode/errorMessage nest
+// under the declared map field and never grow the schema
+input.logger.set({
+  research: {
+    phase: 'start',
+    jobId: job.id,
+  },
+  attributes: {
+    research: {
+      errorCode: chatError.code,
+      errorMessage: chatError.why,
+    },
+  },
+})
+```
+
+A small helper, `server/utils/evlog-attributes.ts`, DRYs up the
+`exception instanceof Error ? exception.message : String(exception)` pattern
+that was repeated at ~20 call sites:
+
+```ts
+import { exceptionMessage, exceptionStack } from '~~/server/utils/evlog-attributes'
+```
+
+## Rollout
+
+Two independent, ordered steps:
+
+1. **Before deploying this code**, declare `attributes` as a map field on
+   Axiom:
+   ```bash
+   AXIOM_API_TOKEN=xapt-... node scripts/axiom-declare-map-field.mjs
+   ```
+   This needs a **management-scoped** Axiom API token (Settings → API
+   tokens → a token with `datasets:update`), not the ingest-only token
+   already configured as `NUXT_AXIOM_TOKEN`/`NUXT_AXIOM_AUDIT_TOKEN`/
+   `NUXT_AXIOM_CONSENT_TOKEN`. Never store that management token as a Worker
+   secret — run the script locally and discard it. It targets all three
+   datasets (`besidka-prod`, `besidka-audit-prod`, `besidka-consent-prod`) by
+   default, since a request's wide event can carry `attributes` alongside an
+   `audit` or `consent` marker field and would otherwise flow through those
+   drains too.
+2. **Then deploy.** New events that nest data under `attributes` stop
+   introducing new schema fields immediately — this unblocks the events Axiom
+   is rejecting today, right away, without waiting on anything else.
+
+## What this does *not* do
+
+Declaring a map field is **prospective only**. It does not shrink
+`besidka-prod`'s existing ~256-field count — the flat fields already in the
+schema (e.g. the pre-migration `research.error`) stay there until they leave
+Axiom's retention window or are explicitly removed. Axiom's own docs are
+direct about this: converting a field to a map "affects new events"; events
+ingested before the change "retain the ordinary structure."
+
+If you need headroom back sooner than that, the options (from
+[Axiom's limits doc](https://axiom.co/docs/reference/field-restrictions)),
+independent of this code change:
+
+- **Trim + vacuum** (`POST /v1/datasets/{dataset}/trim` then
+  `POST /v2/datasets/{dataset}/vacuum`) — trim deletes old data blocks
+  (destructive to that log history), vacuum then rebuilds the schema from
+  what's left within retention. Vacuum is async (can take hours) and limited
+  to once per dataset per day.
+- **Upgrade the Axiom plan** — 256 fields is the Personal-plan limit; Axiom
+  Cloud raises it to 1,024 (itself a soft limit, raisable further on
+  request). This is the lowest-effort way to get real headroom back without
+  auditing which of this app's remaining ~212 flat fields are safe to
+  demote — that judgment call needs visibility into which fields live
+  dashboards/alerts actually query, which this audit didn't have.
+- **Fresh dataset** — starts at 0 fields; loses continuity with existing
+  history/dashboards pointed at `besidka-prod`.
+
+This PR's code change stops the schema from growing further and unblocks
+ingestion of the previously-rejected event shapes. It intentionally does not
+attempt to reclaim the existing headroom or pick a plan/trim strategy — those
+are operational/cost decisions, not code changes.
+
+## Convention going forward
+
+When adding a new `logger.set()` field, ask: is this a small, bounded
+dimension someone would actually filter or alert on (an id, a status/phase
+enum, a count, an operation name)? Keep it flat. Is it free-form text, an
+identifier that grows as the product grows (provider/model ids, mime types),
+or an error-code enum with many variants? Nest it under
+`attributes.<domain>`, using the existing domain object's name.

--- a/docs/axiom-map-fields.md
+++ b/docs/axiom-map-fields.md
@@ -61,7 +61,7 @@ sub-keys different call sites add over time. This mirrors exactly how Axiom
 handles OpenTelemetry's `attributes.custom` field for arbitrary span
 attributes.
 
-Across 26 files, the ~55 field paths identified as high-variety and rarely
+Across 28 files, the ~60 field paths identified as high-variety and rarely
 filtered by exact value — free-form exception messages/stacks, provider ids,
 model ids, media/mime types, and error-code enums with many variants — moved
 from `<domain>.<key>` to `attributes.<domain>.<key>`. Bounded, genuinely
@@ -102,7 +102,7 @@ A small helper, `server/utils/evlog-attributes.ts`, DRYs up the
 that was repeated at ~20 call sites:
 
 ```ts
-import { exceptionMessage, exceptionStack } from '~~/server/utils/evlog-attributes'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 ```
 
 ## Rollout

--- a/scripts/axiom-declare-map-field.mjs
+++ b/scripts/axiom-declare-map-field.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+/**
+ * Declares the `attributes` field as a map field on our Axiom datasets, via
+ * Axiom's Management API. See docs/axiom-map-fields.md for the full context
+ * — read that before running this.
+ *
+ * MUST run this BEFORE (or atomically with) deploying the app code that
+ * starts nesting fields under `attributes` — see the doc's deploy-ordering
+ * warning. Declaring the field is prospective only: it does not shrink the
+ * dataset's existing field count, only stops new fields from accruing under
+ * this name going forward.
+ *
+ * Requires a management-scoped Axiom API token (Settings -> API tokens ->
+ * a token with `datasets:update` — NOT the ingest-only token already used by
+ * NUXT_AXIOM_TOKEN in this app). Axiom has no per-request scoping for this
+ * call, so never store this token as a Worker secret; run this from a local
+ * shell and discard it.
+ *
+ * Usage:
+ *   AXIOM_API_TOKEN=xapt-... node scripts/axiom-declare-map-field.mjs
+ *   AXIOM_API_TOKEN=xapt-... node scripts/axiom-declare-map-field.mjs \
+ *     besidka-prod
+ */
+
+const FIELD_NAME = 'attributes'
+const DEFAULT_DATASETS = [
+  'besidka-prod',
+  'besidka-audit-prod',
+  'besidka-consent-prod',
+]
+
+const apiToken = process.env.AXIOM_API_TOKEN
+
+if (!apiToken) {
+  console.error('Missing AXIOM_API_TOKEN env var (management-scoped token).')
+  process.exit(1)
+}
+
+const datasets = process.argv.slice(2)
+const targetDatasets = datasets.length > 0 ? datasets : DEFAULT_DATASETS
+
+for (const dataset of targetDatasets) {
+  await declareMapField(dataset)
+}
+
+async function declareMapField(dataset) {
+  const existingMapFields = await listMapFields(dataset)
+
+  if (existingMapFields.includes(FIELD_NAME)) {
+    console.log(`${dataset}: "${FIELD_NAME}" is already a map field, skipping.`)
+
+    return
+  }
+
+  const response = await fetch(
+    `https://api.axiom.co/v2/datasets/${encodeURIComponent(dataset)}/mapfields`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiToken}`,
+      },
+      body: JSON.stringify({ name: FIELD_NAME }),
+    },
+  )
+
+  if (!response.ok) {
+    const body = await response.text()
+
+    console.error(
+      `${dataset}: failed to declare "${FIELD_NAME}" as a map field `
+      + `(${response.status}): ${body}`,
+    )
+    process.exitCode = 1
+
+    return
+  }
+
+  console.log(`${dataset}: "${FIELD_NAME}" declared as a map field.`)
+}
+
+async function listMapFields(dataset) {
+  const response = await fetch(
+    `https://api.axiom.co/v2/datasets/${encodeURIComponent(dataset)}/mapfields`,
+    {
+      headers: { Authorization: `Bearer ${apiToken}` },
+    },
+  )
+
+  if (!response.ok) {
+    return []
+  }
+
+  return response.json()
+}

--- a/server/api/v1/chats/[slug]/index.post.ts
+++ b/server/api/v1/chats/[slug]/index.post.ts
@@ -52,6 +52,7 @@ import {
 } from '~~/server/utils/files/assistant-files'
 import { createImageGenerationTool } from '~~/server/utils/ai/image-generation'
 import { buildProjectSystemPrompt } from '~~/server/utils/projects/instructions'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 export default defineEventHandler(async (event) => {
   const logger = useLogger(event)
@@ -604,9 +605,11 @@ export default defineEventHandler(async (event) => {
         logger.set({
           generationGuard: {
             operation: 'put',
-            error: exception instanceof Error
-              ? exception.message
-              : String(exception),
+          },
+          attributes: {
+            generationGuard: {
+              error: exceptionMessage(exception),
+            },
           },
         })
       }
@@ -855,9 +858,11 @@ export default defineEventHandler(async (event) => {
           logger.set({
             generationGuard: {
               operation: 'delete',
-              error: exception instanceof Error
-                ? exception.message
-                : String(exception),
+            },
+            attributes: {
+              generationGuard: {
+                error: exceptionMessage(exception),
+              },
             },
           })
         }
@@ -1107,10 +1112,10 @@ async function persistAssistantMessageFromStream(input: {
       usage = addImageGenerationCostToUsage(baseUsage, imageGenerationCost)
     } catch (exception) {
       input.logger.set({
-        usageCapture: {
-          error: exception instanceof Error
-            ? exception.message
-            : String(exception),
+        attributes: {
+          usageCapture: {
+            error: exceptionMessage(exception),
+          },
         },
       })
     }

--- a/server/api/v1/chats/[slug]/project.patch.ts
+++ b/server/api/v1/chats/[slug]/project.patch.ts
@@ -6,6 +6,7 @@ import {
   markProjectsMemoryStale,
   refreshProjectMemory,
 } from '~~/server/utils/projects/memory'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 export default defineEventHandler(async (event) => {
   const logger = useLogger(event)
@@ -20,9 +21,11 @@ export default defineEventHandler(async (event) => {
       logger.set({
         projectMemoryRefreshError: {
           projectId,
-          message: exception instanceof Error
-            ? exception.message
-            : String(exception),
+        },
+        attributes: {
+          projectMemoryRefreshError: {
+            message: exceptionMessage(exception),
+          },
         },
       })
     }

--- a/server/api/v1/chats/[slug]/research/cancel.post.ts
+++ b/server/api/v1/chats/[slug]/research/cancel.post.ts
@@ -89,7 +89,11 @@ export default defineEventHandler(async (event) => {
             phase: 'cancel',
             jobId: job.id,
             errorStatus: exceptionDetails.status,
-            error: exceptionDetails.message,
+          },
+          attributes: {
+            research: {
+              error: exceptionDetails.message,
+            },
           },
         })
       }

--- a/server/api/v1/chats/[slug]/research/index.get.ts
+++ b/server/api/v1/chats/[slug]/research/index.get.ts
@@ -6,6 +6,7 @@ import { useLogger, createError } from 'evlog'
 import * as schema from '~~/server/db/schema'
 import { finalizeResearchJob } from '~~/server/utils/research/finalize'
 import { toResearchJobView } from '~~/server/utils/research/job-view'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 type WaitUntilCtx = {
   cloudflare?: {
@@ -98,9 +99,11 @@ export default defineEventHandler(async (event) => {
       research: {
         phase: 'finalize',
         jobId: job.id,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        research: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }

--- a/server/api/v1/chats/client-errors.post.ts
+++ b/server/api/v1/chats/client-errors.post.ts
@@ -22,13 +22,17 @@ export default defineEventHandler(async (event) => {
     requestId: body.requestId,
     transportRequestId: body.transportRequestId,
     chatId: body.chatId,
-    modelId: body.modelId,
-    providerId: body.providerId,
     userId: session ? Number(session.user.id) : undefined,
     status: body.status,
-    errorCode: body.code,
     stage: 'client-transport',
     why: body.reason,
+    attributes: {
+      clientError: {
+        modelId: body.modelId,
+        providerId: body.providerId,
+        errorCode: body.code,
+      },
+    },
   })
 
   setResponseStatus(event, 204)

--- a/server/api/v1/chats/history/project/bulk.post.ts
+++ b/server/api/v1/chats/history/project/bulk.post.ts
@@ -6,6 +6,7 @@ import {
   markProjectsMemoryStale,
   refreshProjectMemory,
 } from '~~/server/utils/projects/memory'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 export default defineEventHandler(async (event) => {
   const logger = useLogger(event)
@@ -46,9 +47,11 @@ export default defineEventHandler(async (event) => {
         logger.set({
           projectMemoryRefreshError: {
             projectId,
-            message: exception instanceof Error
-              ? exception.message
-              : String(exception),
+          },
+          attributes: {
+            projectMemoryRefreshError: {
+              message: exceptionMessage(exception),
+            },
           },
         })
       }

--- a/server/api/v1/chats/new/index.put.ts
+++ b/server/api/v1/chats/new/index.put.ts
@@ -164,8 +164,12 @@ export default defineEventHandler(async (event) => {
       logger.set({
         research: {
           phase: 'start',
-          errorCode: researchFailure.code,
           errorStatus: researchFailure.status,
+        },
+        attributes: {
+          research: {
+            errorCode: researchFailure.code,
+          },
         },
       })
 

--- a/server/api/v1/chats/research/clarify.post.ts
+++ b/server/api/v1/chats/research/clarify.post.ts
@@ -63,9 +63,13 @@ export default defineEventHandler(async (event) => {
 
   logger.set({
     userId,
-    providerId: provider.id,
-    model: body.data.model,
     operation: 'research-clarify',
+    attributes: {
+      research: {
+        providerId: provider.id,
+        model: body.data.model,
+      },
+    },
   })
 
   const runtimeConfig = useRuntimeConfig()
@@ -105,9 +109,13 @@ export default defineEventHandler(async (event) => {
 
     logger.set({
       stage: 'generate-clarifications',
-      errorCode: chatError.code,
       providerStatus: chatError.status,
       providerRequestId: chatError.providerRequestId,
+      attributes: {
+        research: {
+          errorCode: chatError.code,
+        },
+      },
     })
 
     throw createError({ ...chatError })

--- a/server/api/v1/chats/shares/[slug]/handoff.post.ts
+++ b/server/api/v1/chats/shares/[slug]/handoff.post.ts
@@ -144,8 +144,12 @@ export default defineEventHandler(async (event) => {
   }
 
   const sent = outcomes.sent > 0
+  const { failures, ...outcomeCounts } = outcomes
 
-  logger.set({ handoff: { sent, outcomes } })
+  logger.set({
+    handoff: { sent, outcomes: outcomeCounts },
+    attributes: { handoff: { failures } },
+  })
 
   if (!sent) {
     return {

--- a/server/api/v1/files/[id]/index.delete.ts
+++ b/server/api/v1/files/[id]/index.delete.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { and, eq } from 'drizzle-orm'
 import * as schema from '~~/server/db/schema'
 import { invalidateStorageCache } from '~~/server/api/v1/storage/index.get'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 const paramsSchema = z.object({
   id: z.string().min(1),
@@ -55,9 +56,11 @@ export default defineEventHandler(async (event) => {
         operation: 'delete',
         fileId: id,
         key: file.storageKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        storage: {
+          error: exceptionMessage(exception),
+        },
       },
     })
 
@@ -75,9 +78,11 @@ export default defineEventHandler(async (event) => {
         operation: 'invalidate',
         fileId: id,
         key: file.storageKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        cache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }

--- a/server/api/v1/files/create.post.ts
+++ b/server/api/v1/files/create.post.ts
@@ -7,6 +7,7 @@ import {
   reserveImageTransformSlots,
 } from '~~/server/utils/files/file-governance'
 import { persistFile } from '~~/server/utils/files/persist-file'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 /**
  * @example
@@ -70,10 +71,14 @@ export default defineEventHandler(async (event) => {
     logger.set({
       upload: {
         operation: 'size-mismatch',
-        fileName,
-        fileType,
         headerFileSize,
         actualFileSize: parsedFileSize,
+      },
+      attributes: {
+        upload: {
+          fileName,
+          fileType,
+        },
       },
     })
   }
@@ -148,12 +153,14 @@ export default defineEventHandler(async (event) => {
         logger.set({
           upload: {
             operation: 'transform-fallback',
-            fileName,
-            fileType,
             fileSize: parsedFileSize,
-            error: exception instanceof Error
-              ? exception.message
-              : String(exception),
+          },
+          attributes: {
+            upload: {
+              fileName,
+              fileType,
+              error: exceptionMessage(exception),
+            },
           },
         })
       }
@@ -161,10 +168,14 @@ export default defineEventHandler(async (event) => {
       logger.set({
         upload: {
           operation: 'transform-skipped',
-          fileName,
-          fileType,
           fileSize: parsedFileSize,
           reason: reservation.reason,
+        },
+        attributes: {
+          upload: {
+            fileName,
+            fileType,
+          },
         },
       })
     }

--- a/server/api/v1/files/delete/bulk.post.ts
+++ b/server/api/v1/files/delete/bulk.post.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { and, eq } from 'drizzle-orm'
 import * as schema from '~~/server/db/schema'
 import { invalidateStorageCache } from '~~/server/api/v1/storage/index.get'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 const bodySchema = z.object({
   ids: z.array(z.string().min(1)).min(1).max(100),
@@ -57,9 +58,11 @@ export default defineEventHandler(async (event) => {
           operation: 'delete',
           fileId: id,
           key: file.storageKey,
-          error: exception instanceof Error
-            ? exception.message
-            : String(exception),
+        },
+        attributes: {
+          storage: {
+            error: exceptionMessage(exception),
+          },
         },
       })
 
@@ -75,9 +78,11 @@ export default defineEventHandler(async (event) => {
           operation: 'invalidate',
           fileId: id,
           key: file.storageKey,
-          error: exception instanceof Error
-            ? exception.message
-            : String(exception),
+        },
+        attributes: {
+          cache: {
+            error: exceptionMessage(exception),
+          },
         },
       })
     }

--- a/server/api/v1/files/policy.get.ts
+++ b/server/api/v1/files/policy.get.ts
@@ -4,6 +4,7 @@ import {
   getEffectiveUserFilePolicy,
   getGlobalMonthlyTransformStats,
 } from '~~/server/utils/files/file-governance'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 const CACHE_TTL_SECONDS = 60
 
@@ -36,9 +37,11 @@ export default defineEventHandler(async (
       cache: {
         operation: 'read',
         key: cacheKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        cache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }
@@ -62,9 +65,11 @@ export default defineEventHandler(async (
       cache: {
         operation: 'write',
         key: cacheKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        cache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }

--- a/server/api/v1/files/upload.put.ts
+++ b/server/api/v1/files/upload.put.ts
@@ -7,6 +7,7 @@ import {
   reserveImageTransformSlots,
 } from '~~/server/utils/files/file-governance'
 import { persistFile } from '~~/server/utils/files/persist-file'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 /**
  * @example
@@ -70,10 +71,14 @@ export default defineEventHandler(async (event) => {
     logger.set({
       upload: {
         operation: 'size-mismatch',
-        fileName,
-        fileType,
         headerFileSize,
         actualFileSize: parsedFileSize,
+      },
+      attributes: {
+        upload: {
+          fileName,
+          fileType,
+        },
       },
     })
   }
@@ -150,12 +155,14 @@ export default defineEventHandler(async (event) => {
         logger.set({
           upload: {
             operation: 'transform-fallback',
-            fileName,
-            fileType,
             fileSize: parsedFileSize,
-            error: exception instanceof Error
-              ? exception.message
-              : String(exception),
+          },
+          attributes: {
+            upload: {
+              fileName,
+              fileType,
+              error: exceptionMessage(exception),
+            },
           },
         })
       }
@@ -163,10 +170,14 @@ export default defineEventHandler(async (event) => {
       logger.set({
         upload: {
           operation: 'transform-skipped',
-          fileName,
-          fileType,
           fileSize: parsedFileSize,
           reason: reservation.reason,
+        },
+        attributes: {
+          upload: {
+            fileName,
+            fileType,
+          },
         },
       })
     }

--- a/server/api/v1/storage/index.get.ts
+++ b/server/api/v1/storage/index.get.ts
@@ -10,6 +10,7 @@ import {
 } from '~~/server/utils/files/logger'
 import type { LoggerLike } from '~~/server/utils/files/logger'
 import { getFilePolicyCacheKey } from '~~/server/api/v1/files/policy.get'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 const CACHE_TTL_SECONDS = 60
 
@@ -40,9 +41,11 @@ export default defineEventHandler(async (event): Promise<StorageStats> => {
       cache: {
         operation: 'read',
         key: cacheKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        cache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }
@@ -79,9 +82,11 @@ export default defineEventHandler(async (event): Promise<StorageStats> => {
       cache: {
         operation: 'write',
         key: cacheKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        cache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }
@@ -105,9 +110,11 @@ export async function invalidateStorageCache(
       cache: {
         operation: 'invalidate',
         key: `${storageCacheKey},${filePolicyCacheKey}`,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        cache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
 
@@ -121,9 +128,11 @@ export async function invalidateStorageCache(
       cache: {
         operation: 'invalidate',
         key: storageCacheKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        cache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }
@@ -135,9 +144,11 @@ export async function invalidateStorageCache(
       cache: {
         operation: 'invalidate',
         key: filePolicyCacheKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        cache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }

--- a/server/plugins/file-retention-cleanup.ts
+++ b/server/plugins/file-retention-cleanup.ts
@@ -1,4 +1,5 @@
 import { createRequestLogger } from 'evlog'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 import { cleanupExpiredFiles } from '~~/server/utils/files/cleanup-expired-files'
 
 const ERROR_STACK_MAX_LENGTH = 2000
@@ -101,10 +102,12 @@ export async function runFileRetentionCleanupJob(
     logger.set({
       retentionCleanupError: {
         phase: 'cleanup-run',
-        message: exception instanceof Error
-          ? exception.message
-          : String(exception),
-        stack: getSafeErrorStack(exception),
+      },
+      attributes: {
+        retentionCleanupError: {
+          message: exceptionMessage(exception),
+          stack: getSafeErrorStack(exception),
+        },
       },
     })
   }

--- a/server/plugins/landing-cache-refresh.ts
+++ b/server/plugins/landing-cache-refresh.ts
@@ -5,6 +5,7 @@ import {
 } from '~~/server/utils/landing/stats'
 import { cachedGithubStars } from '~~/server/utils/landing/github-stars'
 import { shipWideEventToAxiom } from '~~/server/utils/evlog-drains'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 const REFRESH_UTC_HOUR = 3
 const LANDING_CACHE_REFRESH_CRON = '0 * * * *'
@@ -94,18 +95,10 @@ export async function runLandingCacheRefreshJob(
     attributes: {
       stats: statsResult.status === 'fulfilled'
         ? {}
-        : {
-          error: statsResult.reason instanceof Error
-            ? statsResult.reason.message
-            : String(statsResult.reason),
-        },
+        : { error: exceptionMessage(statsResult.reason) },
       githubStars: githubStarsResult.status === 'fulfilled'
         ? {}
-        : {
-          error: githubStarsResult.reason instanceof Error
-            ? githubStarsResult.reason.message
-            : String(githubStarsResult.reason),
-        },
+        : { error: exceptionMessage(githubStarsResult.reason) },
     },
   })
 

--- a/server/plugins/landing-cache-refresh.ts
+++ b/server/plugins/landing-cache-refresh.ts
@@ -87,18 +87,26 @@ export async function runLandingCacheRefreshJob(
         uploadedFiles: statsResult.value.uploadedFiles,
         generatedImages: statsResult.value.generatedImages,
       }
-      : {
-        error: statsResult.reason instanceof Error
-          ? statsResult.reason.message
-          : String(statsResult.reason),
-      },
+      : {},
     githubStars: githubStarsResult.status === 'fulfilled'
       ? { updatedAt: githubStarsResult.value.updatedAt }
-      : {
-        error: githubStarsResult.reason instanceof Error
-          ? githubStarsResult.reason.message
-          : String(githubStarsResult.reason),
-      },
+      : {},
+    attributes: {
+      stats: statsResult.status === 'fulfilled'
+        ? {}
+        : {
+          error: statsResult.reason instanceof Error
+            ? statsResult.reason.message
+            : String(statsResult.reason),
+        },
+      githubStars: githubStarsResult.status === 'fulfilled'
+        ? {}
+        : {
+          error: githubStarsResult.reason instanceof Error
+            ? githubStarsResult.reason.message
+            : String(githubStarsResult.reason),
+        },
+    },
   })
 
   const status = statsResult.status === 'fulfilled'

--- a/server/plugins/research-job-sweep.ts
+++ b/server/plugins/research-job-sweep.ts
@@ -1,5 +1,6 @@
 import { createRequestLogger } from 'evlog'
 import type { VapidKeys } from '~~/server/utils/push'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 import { sweepResearchJobs } from '~~/server/utils/research/sweep'
 
 const ERROR_STACK_MAX_LENGTH = 2000
@@ -107,10 +108,12 @@ export async function runResearchJobSweepJob(
     logger.set({
       researchSweepError: {
         phase: 'sweep-run',
-        message: exception instanceof Error
-          ? exception.message
-          : String(exception),
-        stack: getSafeErrorStack(exception),
+      },
+      attributes: {
+        researchSweepError: {
+          message: exceptionMessage(exception),
+          stack: getSafeErrorStack(exception),
+        },
       },
     })
   }

--- a/server/types/evlog.d.ts
+++ b/server/types/evlog.d.ts
@@ -1,0 +1,16 @@
+declare module 'evlog' {
+  interface BaseWideEvent {
+    /**
+     * High-variety, low-query-value context (free-form exception messages
+     * and stacks, provider/model ids, media types, error-code enums, etc.),
+     * namespaced by domain. Declared as an Axiom map field so nesting new
+     * attributes here never grows the dataset's schema field count — unlike
+     * every other top-level field, which Axiom flattens into its own
+     * dotted-path schema entry. See docs/axiom-map-fields.md before adding
+     * a new top-level field to a wide event.
+     */
+    attributes?: Record<string, Record<string, unknown>>
+  }
+}
+
+export {}

--- a/server/utils/ai/image-generation.ts
+++ b/server/utils/ai/image-generation.ts
@@ -132,13 +132,17 @@ export function createImageGenerationTool(
         input.logger.set({
           imageGeneration: {
             status: 'ready',
-            provider: input.provider,
-            model: input.model,
             durationMs: Date.now() - startedAt,
             size: persistedFile.size,
-            mediaType: persistedFile.type,
             warnings: result.warnings.length,
-            usage: result.usage,
+          },
+          attributes: {
+            imageGeneration: {
+              provider: input.provider,
+              model: input.model,
+              mediaType: persistedFile.type,
+              usage: result.usage,
+            },
           },
         })
 
@@ -168,13 +172,17 @@ export function createImageGenerationTool(
         input.logger.set({
           imageGeneration: {
             status: 'failed',
-            provider: input.provider,
-            model: input.model,
             durationMs: Date.now() - startedAt,
-            errorCode: safeError.code,
             providerStatus: safeError.providerStatus,
             providerRequestId: safeError.providerRequestId,
             requestId: input.requestId,
+          },
+          attributes: {
+            imageGeneration: {
+              provider: input.provider,
+              model: input.model,
+              errorCode: safeError.code,
+            },
           },
         })
 

--- a/server/utils/consents-db.ts
+++ b/server/utils/consents-db.ts
@@ -7,6 +7,7 @@ import type { RequestLogger } from 'evlog'
 import { consentReceipts } from '~~/server/db/consent/schema'
 import type { ConsentDecision } from '~~/server/utils/consents'
 import { DrizzleQueryLogger } from '~~/server/utils/drizzle-logger'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 export interface ConsentReceiptRecord {
   id: string
@@ -64,10 +65,10 @@ export async function insertConsentReceipt(
     logger.set({ consentDb: { stored: true } })
   } catch (exception) {
     logger.set({
-      consentDb: {
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      attributes: {
+        consentDb: {
+          error: exceptionMessage(exception),
+        },
       },
     })
 

--- a/server/utils/evlog-attributes.ts
+++ b/server/utils/evlog-attributes.ts
@@ -1,0 +1,7 @@
+export function exceptionMessage(exception: unknown): string {
+  return exception instanceof Error ? exception.message : String(exception)
+}
+
+export function exceptionStack(exception: unknown): string | undefined {
+  return exception instanceof Error ? exception.stack : undefined
+}

--- a/server/utils/evlog-attributes.ts
+++ b/server/utils/evlog-attributes.ts
@@ -1,7 +1,3 @@
 export function exceptionMessage(exception: unknown): string {
   return exception instanceof Error ? exception.message : String(exception)
 }
-
-export function exceptionStack(exception: unknown): string | undefined {
-  return exception instanceof Error ? exception.stack : undefined
-}

--- a/server/utils/files/assistant-files.ts
+++ b/server/utils/files/assistant-files.ts
@@ -180,8 +180,12 @@ export async function normalizeAssistantMessagePartsForPersistence(
         : 'skipped-feature-disabled',
       count: assistantFileParts.length,
       chatId: input.chatId,
-      providerId: input.providerId,
       userId: input.userId,
+    },
+    attributes: {
+      assistantFiles: {
+        providerId: input.providerId,
+      },
     },
   })
 

--- a/server/utils/files/cleanup-expired-files.ts
+++ b/server/utils/files/cleanup-expired-files.ts
@@ -3,6 +3,7 @@ import * as schema from '~~/server/db/schema'
 import { invalidateStorageCache } from '~~/server/api/v1/storage/index.get'
 import { invalidateFileCache } from '~~/server/utils/files/convert-files-for-ai'
 import type { LoggerLike } from '~~/server/utils/files/logger'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 export interface CleanupExpiredFilesInput {
   now?: Date
@@ -71,9 +72,11 @@ export async function cleanupExpiredFiles(
           storageKey: file.storageKey,
           userId: file.userId,
           expiresAt,
-          error: exception instanceof Error
-            ? exception.message
-            : String(exception),
+        },
+        attributes: {
+          retentionCleanup: {
+            error: exceptionMessage(exception),
+          },
         },
       })
       continue
@@ -89,9 +92,11 @@ export async function cleanupExpiredFiles(
           storageKey: file.storageKey,
           userId: file.userId,
           expiresAt,
-          error: exception instanceof Error
-            ? exception.message
-            : String(exception),
+        },
+        attributes: {
+          retentionCleanup: {
+            error: exceptionMessage(exception),
+          },
         },
       })
     }
@@ -112,9 +117,11 @@ export async function cleanupExpiredFiles(
           storageKey: file.storageKey,
           userId: file.userId,
           expiresAt,
-          error: exception instanceof Error
-            ? exception.message
-            : String(exception),
+        },
+        attributes: {
+          retentionCleanup: {
+            error: exceptionMessage(exception),
+          },
         },
       })
 
@@ -133,9 +140,11 @@ export async function cleanupExpiredFiles(
         retentionCleanup: {
           phase: 'storage-cache-invalidate',
           userId,
-          error: exception instanceof Error
-            ? exception.message
-            : String(exception),
+        },
+        attributes: {
+          retentionCleanup: {
+            error: exceptionMessage(exception),
+          },
         },
       })
     }

--- a/server/utils/files/convert-files-for-ai.ts
+++ b/server/utils/files/convert-files-for-ai.ts
@@ -9,6 +9,7 @@ import {
   resolveServerLogger,
 } from '~~/server/utils/files/logger'
 import type { LoggerLike } from '~~/server/utils/files/logger'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 export interface MissingFile {
   storageKey: string
@@ -87,7 +88,11 @@ export async function convertFilesForAI(
         logger.set({
           fileConversion: {
             reason: 'invalid-url',
-            url: part.url,
+          },
+          attributes: {
+            fileConversion: {
+              url: part.url,
+            },
           },
         })
         convertedParts.push(part)
@@ -138,9 +143,11 @@ export async function convertFilesForAI(
             fileConversion: {
               operation: 'inline-text',
               storageKey,
-              error: exception instanceof Error
-                ? exception.message
-                : String(exception),
+            },
+            attributes: {
+              fileConversion: {
+                error: exceptionMessage(exception),
+              },
             },
           })
           missingFiles.push({
@@ -190,9 +197,11 @@ export async function convertFilesForAI(
           fileConversion: {
             operation: 'convert',
             storageKey,
-            error: exception instanceof Error
-              ? exception.message
-              : String(exception),
+          },
+          attributes: {
+            fileConversion: {
+              error: exceptionMessage(exception),
+            },
           },
         })
         missingFiles.push({
@@ -229,9 +238,11 @@ async function getCachedFileDataUrl(
       fileCache: {
         operation: 'read',
         key: getCacheKey(storageKey),
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        fileCache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
 
@@ -256,9 +267,11 @@ async function cacheFileDataUrl(
       fileCache: {
         operation: 'write',
         key: getCacheKey(storageKey),
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        fileCache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }
@@ -286,9 +299,11 @@ async function readStorageFileAsText(
       fileStorage: {
         operation: 'read-text',
         storageKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        fileStorage: {
+          error: exceptionMessage(exception),
+        },
       },
     })
 
@@ -370,9 +385,11 @@ async function convertStorageFileToDataUrl(
       fileStorage: {
         operation: 'read',
         storageKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        fileStorage: {
+          error: exceptionMessage(exception),
+        },
       },
     })
 
@@ -396,9 +413,11 @@ export async function invalidateFileCache(
       fileCache: {
         operation: 'invalidate',
         key: getCacheKey(storageKey),
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        fileCache: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }

--- a/server/utils/files/persist-file.ts
+++ b/server/utils/files/persist-file.ts
@@ -8,6 +8,7 @@ import {
 import { useLogger } from 'evlog'
 import * as schema from '~~/server/db/schema'
 import { invalidateStorageCache } from '~~/server/api/v1/storage/index.get'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 import {
   getEffectiveUserFilePolicy,
   getUserStorageUsageBytes,
@@ -95,13 +96,15 @@ export async function persistFile(
     logger.set({
       filePersistence: {
         operation: 'r2-put',
-        fileName: input.fileName,
-        mediaType: input.mediaType,
         fileSize,
         source,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        filePersistence: {
+          fileName: input.fileName,
+          mediaType: input.mediaType,
+          error: exceptionMessage(exception),
+        },
       },
     })
 
@@ -150,13 +153,15 @@ export async function persistFile(
     logger.set({
       filePersistence: {
         operation: 'db-insert',
-        fileName: input.fileName,
-        mediaType: input.mediaType,
         fileSize,
         source,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        filePersistence: {
+          fileName: input.fileName,
+          mediaType: input.mediaType,
+          error: exceptionMessage(exception),
+        },
       },
     })
 
@@ -166,14 +171,16 @@ export async function persistFile(
       logger.set({
         filePersistence: {
           operation: 'r2-rollback',
-          fileName: input.fileName,
-          mediaType: input.mediaType,
           fileSize,
           source,
           key: response.key,
-          error: rollbackException instanceof Error
-            ? rollbackException.message
-            : String(rollbackException),
+        },
+        attributes: {
+          filePersistence: {
+            fileName: input.fileName,
+            mediaType: input.mediaType,
+            error: exceptionMessage(rollbackException),
+          },
         },
       })
     }
@@ -246,14 +253,16 @@ async function rollbackPersistedFile(
     input.logger.set({
       filePersistence: {
         operation: 'quota-db-rollback',
-        fileName: input.fileName,
-        mediaType: input.mediaType,
         fileSize: input.fileSize,
         source: input.source,
         key: input.storageKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        filePersistence: {
+          fileName: input.fileName,
+          mediaType: input.mediaType,
+          error: exceptionMessage(exception),
+        },
       },
     })
 
@@ -269,14 +278,16 @@ async function rollbackPersistedFile(
     input.logger.set({
       filePersistence: {
         operation: 'quota-r2-rollback',
-        fileName: input.fileName,
-        mediaType: input.mediaType,
         fileSize: input.fileSize,
         source: input.source,
         key: input.storageKey,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        filePersistence: {
+          fileName: input.fileName,
+          mediaType: input.mediaType,
+          error: exceptionMessage(exception),
+        },
       },
     })
   }

--- a/server/utils/landing/analytics-events.ts
+++ b/server/utils/landing/analytics-events.ts
@@ -1,6 +1,7 @@
 import { useLogger } from 'evlog'
 import type { H3Event } from 'h3'
 import type { LandingEventName, LandingEventData } from '#shared/types/analytics.d'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 
 const BOT_PATTERN
   = /bot|crawler|spider|scraper|curl|wget|python|java(?!script)|headless|phantom/i
@@ -68,10 +69,12 @@ export function trackLandingEvent(
 
     logger.set({
       analytics: {
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
         event: name,
+      },
+      attributes: {
+        analytics: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }

--- a/server/utils/push.ts
+++ b/server/utils/push.ts
@@ -308,13 +308,20 @@ export async function sendPushNotificationToUser(
     waitUntil,
   })
 
+  const { failures, ...outcomeCounts } = outcomes
+
   logger.set({
     push: {
       operation: 'send',
       userId,
       subscriptionCount: subscriptionsToNotify.length,
       totalSubscriptionCount: subscriptions.length,
-      ...outcomes,
+      ...outcomeCounts,
+    },
+    attributes: {
+      push: {
+        failures,
+      },
     },
   })
 

--- a/server/utils/research/finalize.ts
+++ b/server/utils/research/finalize.ts
@@ -19,6 +19,7 @@ import {
   normalizeChatError,
 } from '~~/server/utils/chats/errors'
 import { insertMessageWithPublicId } from '~~/server/utils/chats/insert-message'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 import { getResearchAdapter } from '~~/server/utils/research/adapters'
 import { mockResearchAdapter } from '~~/server/utils/research/adapters/mock'
 import { describeResearchAdapterException } from '~~/server/utils/research/adapter-error'
@@ -97,7 +98,11 @@ export async function finalizeResearchJob(
         phase: 'poll',
         jobId: job.id,
         errorStatus: exceptionDetails.status,
-        error: exceptionDetails.message,
+      },
+      attributes: {
+        research: {
+          error: exceptionDetails.message,
+        },
       },
     })
 
@@ -151,7 +156,11 @@ export async function finalizeResearchJob(
             phase: 'timeout-cancel',
             jobId: job.id,
             errorStatus: exceptionDetails.status,
-            error: exceptionDetails.message,
+          },
+          attributes: {
+            research: {
+              error: exceptionDetails.message,
+            },
           },
         })
       }
@@ -200,7 +209,11 @@ export async function finalizeResearchJob(
         phase: 'result',
         jobId: job.id,
         errorStatus: exceptionDetails.status,
-        error: exceptionDetails.message,
+      },
+      attributes: {
+        research: {
+          error: exceptionDetails.message,
+        },
       },
     })
 
@@ -289,9 +302,11 @@ export async function finalizeResearchJob(
       research: {
         phase: 'finalize-persist',
         jobId: job.id,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        research: {
+          error: exceptionMessage(exception),
+        },
       },
     })
 

--- a/server/utils/research/start.ts
+++ b/server/utils/research/start.ts
@@ -15,6 +15,7 @@ import { and, count, eq, inArray } from 'drizzle-orm'
 import { getRequestURL } from 'h3'
 import * as schema from '~~/server/db/schema'
 import { mapResearchProviderError, normalizeChatError } from '~~/server/utils/chats/errors'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 import { buildResearchAssistModelInstance } from '~~/server/utils/research/assist-model'
 import { getResearchAdapter } from '~~/server/utils/research/adapters'
 import { mockResearchAdapter } from '~~/server/utils/research/adapters/mock'
@@ -236,8 +237,12 @@ export async function startResearchJobForChat(
           phase: 'start',
           jobId: job.id,
           status: currentJob.status,
-          note: 'job left the active state before the provider job'
-            + ' could be stored',
+        },
+        attributes: {
+          research: {
+            note: 'job left the active state before the provider job'
+              + ' could be stored',
+          },
         },
       })
 
@@ -248,10 +253,14 @@ export async function startResearchJobForChat(
       research: {
         phase: 'start',
         jobId: job.id,
-        provider: supportedProviderId,
         level: research.tier,
-        modelId: model.id,
         status: started.status,
+      },
+      attributes: {
+        research: {
+          provider: supportedProviderId,
+          modelId: model.id,
+        },
       },
     })
 
@@ -292,8 +301,12 @@ export async function startResearchJobForChat(
       research: {
         phase: 'start',
         jobId: job.id,
-        errorCode: chatError.code,
-        errorMessage: chatError.why,
+      },
+      attributes: {
+        research: {
+          errorCode: chatError.code,
+          errorMessage: chatError.why,
+        },
       },
     })
 
@@ -314,9 +327,11 @@ async function cancelStartedProviderJobBestEffort(
       research: {
         phase: 'start-cancel',
         providerJobId,
-        error: exception instanceof Error
-          ? exception.message
-          : String(exception),
+      },
+      attributes: {
+        research: {
+          error: exceptionMessage(exception),
+        },
       },
     })
   }

--- a/server/utils/research/sweep.ts
+++ b/server/utils/research/sweep.ts
@@ -1,4 +1,5 @@
 import type { VapidKeys } from '~~/server/utils/push'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
 import { finalizeResearchJob } from '~~/server/utils/research/finalize'
 
 export interface SweepResearchJobsInput {
@@ -66,9 +67,11 @@ export async function sweepResearchJobs(
         researchSweep: {
           phase: 'finalize',
           jobId: job.id,
-          error: exception instanceof Error
-            ? exception.message
-            : String(exception),
+        },
+        attributes: {
+          researchSweep: {
+            error: exceptionMessage(exception),
+          },
         },
       })
     }

--- a/tests/integration/server/assistant-files.spec.ts
+++ b/tests/integration/server/assistant-files.spec.ts
@@ -346,8 +346,12 @@ describe('assistant files scaffolding', () => {
         action: 'skipped-feature-disabled',
         count: 1,
         chatId: 'chat-1',
-        providerId: 'openai',
         userId: 1,
+      },
+      attributes: {
+        assistantFiles: {
+          providerId: 'openai',
+        },
       },
     })
   })

--- a/tests/integration/server/file-retention-cleanup-plugin.spec.ts
+++ b/tests/integration/server/file-retention-cleanup-plugin.spec.ts
@@ -100,7 +100,11 @@ describe('file-retention cleanup plugin', () => {
     expect(loggerSet).toHaveBeenCalledWith(expect.objectContaining({
       retentionCleanupError: expect.objectContaining({
         phase: 'cleanup-run',
-        message: 'cleanup failed',
+      }),
+      attributes: expect.objectContaining({
+        retentionCleanupError: expect.objectContaining({
+          message: 'cleanup failed',
+        }),
       }),
     }))
     expect(loggerEmit).toHaveBeenCalledWith({ status: 500 })

--- a/tests/integration/server/landing-cache-refresh.spec.ts
+++ b/tests/integration/server/landing-cache-refresh.spec.ts
@@ -83,6 +83,10 @@ describe('landing cache refresh job', () => {
         githubStars: {
           updatedAt: '2026-07-15T03:00:00.000Z',
         },
+        attributes: {
+          stats: {},
+          githubStars: {},
+        },
       })
       expect(logger.emit).toHaveBeenCalledWith({ status: 200 })
       expect(shipWideEvent).toHaveBeenCalledWith(wideEvent)

--- a/tests/integration/server/research-job-sweep-plugin.spec.ts
+++ b/tests/integration/server/research-job-sweep-plugin.spec.ts
@@ -127,7 +127,11 @@ describe('research job sweep plugin', () => {
     expect(loggerSet).toHaveBeenCalledWith(expect.objectContaining({
       researchSweepError: expect.objectContaining({
         phase: 'sweep-run',
-        message: 'sweep failed',
+      }),
+      attributes: expect.objectContaining({
+        researchSweepError: expect.objectContaining({
+          message: 'sweep failed',
+        }),
       }),
     }))
     expect(loggerEmit).toHaveBeenCalledWith({ status: 500 })

--- a/tests/unit/utils/research/sweep.spec.ts
+++ b/tests/unit/utils/research/sweep.spec.ts
@@ -87,7 +87,11 @@ describe('sweepResearchJobs', () => {
     expect(logger.set).toHaveBeenCalledWith(expect.objectContaining({
       researchSweep: expect.objectContaining({
         jobId: 'job-1',
-        error: 'boom',
+      }),
+      attributes: expect.objectContaining({
+        researchSweep: expect.objectContaining({
+          error: 'boom',
+        }),
       }),
     }))
   })


### PR DESCRIPTION
## Summary

`besidka-prod` hit Axiom's 256-field dataset schema limit and started rejecting events. Axiom's own recommendation (per their email and docs) is to use map fields.

- Axiom's `evlog` drain just `JSON.stringify()`s each wide event — no field-limit awareness on our side.
- Axiom flattens every nested JSON key path into a permanent schema field; 60+ `logger.set()` call sites, each contributing their own domain-namespaced fields into one dataset, pushed the union of distinct paths past 256. Field **names** cause this, not field **values**.
- Fix: a reserved `attributes` wide-event field (typed via evlog's `declare module` extension point), declared as an Axiom map field, holds the ~55 high-variety/rarely-exact-filtered fields (free-text exception messages/stacks, provider/model ids, media types, error-code enums) that were spread across 26 files. Bounded/queryable dimensions (ids, status, phase, operation, counts) stay flat.
- A small helper (`server/utils/evlog-attributes.ts`) DRYs up the `exception instanceof Error ? exception.message : String(exception)` pattern repeated at ~20 call sites.

## ⚠️ Required rollout step — read before deploying

**Do not deploy this PR until `attributes` is declared a map field on `besidka-prod`** (and the audit/consent datasets). The schema is already at the 256 cap; deploying first turns `attributes.*` into new flat fields that get rejected — a regression, not a fix.

```bash
AXIOM_API_TOKEN=xapt-... node scripts/axiom-declare-map-field.mjs
```

Needs a management-scoped Axiom API token (`datasets:update`), not the ingest token already configured. Full context, the "what this does NOT do" caveat (it doesn't reclaim existing schema headroom — that needs trim+vacuum or a plan upgrade), and the ongoing convention are in `docs/axiom-map-fields.md`.

## Test plan

- [x] `pnpm run format && pnpm run typecheck` — clean
- [x] `pnpm run test:unit` — 1079/1079 passed
- [x] `pnpm run test:integration` — 331/331 passed (4 pre-existing assertions on the old flat field shape updated to match the new `attributes` nesting)
- [x] `pnpm run test:e2e` — 72 passed, 1 pre-existing skip