### PR TITLE
perf: reduce p95 latency on slow endpoints

### DIFF
--- a/.drizzle/migrations/20260723161132_unknown_overlord/migration.sql
+++ b/.drizzle/migrations/20260723161132_unknown_overlord/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_files_user_id` ON `files` (`user_id`);

--- a/.drizzle/migrations/20260723161132_unknown_overlord/snapshot.json
+++ b/.drizzle/migrations/20260723161132_unknown_overlord/snapshot.json
@@ -1,0 +1,2582 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "091e9f38-701d-4fea-a7b8-c479014d0a9a",
+  "prevIds": [
+    "ad291021-1c49-4a15-81a5-512e0b753b45"
+  ],
+  "ddl": [
+    {
+      "name": "accounts",
+      "entityType": "tables"
+    },
+    {
+      "name": "sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "users",
+      "entityType": "tables"
+    },
+    {
+      "name": "verifications",
+      "entityType": "tables"
+    },
+    {
+      "name": "user_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "projects",
+      "entityType": "tables"
+    },
+    {
+      "name": "chats",
+      "entityType": "tables"
+    },
+    {
+      "name": "messages",
+      "entityType": "tables"
+    },
+    {
+      "name": "keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "files",
+      "entityType": "tables"
+    },
+    {
+      "name": "chat_share_files",
+      "entityType": "tables"
+    },
+    {
+      "name": "chat_shares",
+      "entityType": "tables"
+    },
+    {
+      "name": "storages",
+      "entityType": "tables"
+    },
+    {
+      "name": "image_transform_usage_monthly",
+      "entityType": "tables"
+    },
+    {
+      "name": "image_generation_locks",
+      "entityType": "tables"
+    },
+    {
+      "name": "push_subscriptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "research_jobs",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_login_method",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "reasoning_expanded",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "reasoning_auto_hide",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "allow_external_links",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "notification_prompt_state",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sidebar_pinned",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "instructions",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'idle'",
+      "generated": null,
+      "name": "memory_status",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_updated_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_dirty_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_provider",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_model",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_error",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pinned_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activity_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "''",
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shared",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branched_from_share_slug",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pinned_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_memory_summary",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_memory_summary_updated_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activity_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "parts",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "tools",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'off'",
+      "generated": null,
+      "name": "reasoning",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "usage",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "api_key",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_key",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "size",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_message_id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_provider",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_model",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generation_cost",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_share_id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "revoked",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "indexable",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "show_files",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "show_metadata",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "show_author_avatar",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "allow_branch",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "20971520",
+      "generated": null,
+      "name": "storage",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'free'",
+      "generated": null,
+      "name": "tier",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "10",
+      "generated": null,
+      "name": "max_files_per_message",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1048576000",
+      "generated": null,
+      "name": "max_message_files_bytes",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "30",
+      "generated": null,
+      "name": "file_retention_days",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "image_transform_limit_total",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "image_transform_used_total",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "month_key",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "transforms_used",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1000",
+      "generated": null,
+      "name": "transforms_limit",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "endpoint",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "p256dh_key",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "auth_key",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_message_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "level",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_job_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "answers",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "usage",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "result_message_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "accounts_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "accounts"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sessions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "user_settings_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "user_settings"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "projects_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chats_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "projects",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "chats_project_id_projects_id_fk",
+      "entityType": "fks",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "messages_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "messages"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "keys_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "files_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "files"
+    },
+    {
+      "columns": [
+        "origin_message_id"
+      ],
+      "tableTo": "messages",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "files_origin_message_id_messages_id_fk",
+      "entityType": "fks",
+      "table": "files"
+    },
+    {
+      "columns": [
+        "chat_share_id"
+      ],
+      "tableTo": "chat_shares",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_share_files_chat_share_id_chat_shares_id_fk",
+      "entityType": "fks",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        "file_id"
+      ],
+      "tableTo": "files",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_share_files_file_id_files_id_fk",
+      "entityType": "fks",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_shares_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "storages_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "storages"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "push_subscriptions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_research_jobs_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pk",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pk",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pk",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pk",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_settings_pk",
+      "table": "user_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pk",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chats_pk",
+      "table": "chats",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "messages_pk",
+      "table": "messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "keys_pk",
+      "table": "keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "files_pk",
+      "table": "files",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chat_share_files_pk",
+      "table": "chat_share_files",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chat_shares_pk",
+      "table": "chat_shares",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "storages_pk",
+      "table": "storages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "month_key"
+      ],
+      "nameExplicit": false,
+      "name": "image_transform_usage_monthly_pk",
+      "table": "image_transform_usage_monthly",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "image_generation_locks_pk",
+      "table": "image_generation_locks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "push_subscriptions_pk",
+      "table": "push_subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "research_jobs_pk",
+      "table": "research_jobs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "table": "accounts"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "table": "verifications"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_user_settings_user",
+      "entityType": "indexes",
+      "table": "user_settings"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_project_user",
+      "entityType": "indexes",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        {
+          "value": "activity_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_projects_activity_at",
+      "entityType": "indexes",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_user",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_slug",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "activity_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_chats_activity_at",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "chat_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_message_chat",
+      "entityType": "indexes",
+      "table": "messages"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_key_user",
+      "entityType": "indexes",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_key_user_provider",
+      "entityType": "indexes",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_file_user",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "storage_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_file_storageKey",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_files_expires_at",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_files_user_id",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_share_id",
+          "isExpression": false
+        },
+        {
+          "value": "file_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_file",
+      "entityType": "indexes",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_chat",
+      "entityType": "indexes",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_slug",
+      "entityType": "indexes",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_chat_id",
+      "entityType": "indexes",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_storage_user",
+      "entityType": "indexes",
+      "table": "storages"
+    },
+    {
+      "columns": [
+        {
+          "value": "endpoint",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_push_subscriptions_endpoint",
+      "entityType": "indexes",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_push_subscriptions_user_id",
+      "entityType": "indexes",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "status in ('pending', 'running')",
+      "origin": "manual",
+      "name": "uq_research_jobs_chat_active",
+      "entityType": "indexes",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_research_jobs_status_created",
+      "entityType": "indexes",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_research_jobs_user",
+      "entityType": "indexes",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        "token"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_token_unique",
+      "entityType": "uniques",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "email"
+      ],
+      "nameExplicit": false,
+      "name": "users_email_unique",
+      "entityType": "uniques",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "chats_slug_unique",
+      "entityType": "uniques",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "public_id"
+      ],
+      "nameExplicit": false,
+      "name": "messages_public_id_unique",
+      "entityType": "uniques",
+      "table": "messages"
+    }
+  ],
+  "renames": []
+}

--- a/docs/p95-endpoint-optimization.md
+++ b/docs/p95-endpoint-optimization.md
@@ -285,22 +285,43 @@ substitute for, the round-trip elimination.
     `401` (session correctly invalidated, no stale-context leak across the
     sign-out boundary).
 
-## Rolling out the migration
+## Rolling out the migration — this is NOT a manual step
 
-The migration (`.drizzle/migrations/20260723161132_unknown_overlord/`) has
-only been applied to this worktree's local D1 for benchmarking and smoke
-testing. Per this repo's D1 migration safety rules, applying it to
-`chat-preview` and then production `chat` is a separate, explicit step:
+Unlike a typical schema change in this repo, applying this migration is
+**not** something anyone needs to remember to run by hand — CI does it
+automatically, with no approval gate in between:
+
+- `.github/workflows/preview-deploy.yml` runs automatically once "Preview
+  Build" succeeds for this PR, and its deploy job runs
+  `wrangler d1 migrations apply DB --remote` against `chat-preview`
+  unattended.
+- `.github/workflows/production.yml` triggers on every push to `main`, and
+  its deploy job runs `wrangler d1 migrations apply DB --remote --env
+  production` against the production `chat` database unattended.
+
+So: merging this PR is what applies `idx_files_user_id` to production — not
+a follow-up command someone runs later. There is no Time Travel bookmark
+step anywhere in either workflow; this repo's D1 safety checklist's "take a
+bookmark first" step is not automated and is on whoever merges to do it
+manually if they want that safety net:
 
 ```bash
 npx wrangler d1 time-travel info chat-preview
-pnpm run db:migrate:preview
-# verify, then:
 npx wrangler d1 time-travel info chat
-pnpm run db:migrate:prod
 ```
 
 This migration is additive-only (`CREATE INDEX`, no `DROP TABLE`) and does
 not touch any cascade-dependent table, so it carries none of the rebuild risk
-this repo's checklist warns about — but the checklist's "take a Time Travel
-bookmark first" step is still cheap insurance and should not be skipped.
+this repo's checklist warns about — but given CI applies it to production
+with no human gate, taking the bookmark before merging is still cheap
+insurance worth doing.
+
+**Important asymmetry to expect post-merge**: the session-dedup, read-first,
+dedup-threading, parallelization, and KV-cache fixes all go live simply by
+deploying the new code — no migration involved. The index is the one fix
+with hard, measured, algorithmic proof (see the benchmark above) but it only
+takes effect once the migration actually runs against `chat`/`chat-preview`
+via the deploy pipelines above. If you check production p95 right after
+merge and the `files.userId`-scan-related improvement seems absent, confirm
+the production deploy job actually completed its migration step before
+concluding anything is wrong.

--- a/docs/p95-endpoint-optimization.md
+++ b/docs/p95-endpoint-optimization.md
@@ -1,0 +1,306 @@
+# P95 slow-endpoint optimization (2026-07)
+
+Axiom's "Slowest endpoints — p95" panel flagged nine paths. This document
+records what was actually found (by reading the real code, not guessing),
+what was fixed, what was deliberately left alone and why, and how the fixes
+were verified without access to production traffic.
+
+| Path | p95 (Axiom) | Disposition |
+|---|---|---|
+| `/api/auth/callback/google` | 3220ms (also 1530ms) | Floor-bound — not fixed |
+| `/api/v1/files/upload` | 2480ms | Partially floor-bound — dedup fixed, ~300ms not expected |
+| `/api/v1/storage` | 1640ms | Fixed — ~300ms plausible |
+| `/api/v1/consents` | 1170ms | Fixed (exclusion), but win is likely near-zero |
+| `/api/auth/sign-out` | 1070ms | Platform-tail-bound — dedup helps a little, no further lever |
+| `/api/auth/sign-in/email` | 1050ms | Floor-bound — not fixed |
+| `/api/v1/chats/new` | 971ms | Platform-tail-bound — dedup helps a little, no further lever |
+| `/api/v1/files/policy` | 905ms | Fixed — ~300ms plausible |
+| `/api/v1/push/subscribe` | 747ms | Platform-tail-bound — dedup helps a little, no further lever |
+
+## What was actually wrong
+
+### 1. Every request resolved its Better Auth session twice
+
+`server/middleware/evlog-auth.ts` runs on every request (except an exclude
+list) purely to attribute logs, and called `createAuthMiddleware(...)` from
+the `evlog` package. That helper resolves the session itself
+(`auth.api.getSession()`) internally and never exposed the result — it
+returns only a boolean. Separately, `server/utils/session.ts`'s
+`useUserSession()` — called independently by nearly every protected handler
+(`files/upload`, `storage`, `files/policy`, `chats/new`, `push/subscribe`) —
+resolved the session again from scratch. Most protected requests paid for
+two full Better Auth session resolutions.
+
+On a `cookieCache` hit (5-minute TTL HMAC check) the second resolution is
+cheap CPU only. On a miss it costs a KV read and potentially a D1 read —
+this is a tail-latency trim, not a guaranteed p95 halving. Worth noting:
+server-side `getSession()` calls can't refresh the cookie cache (no
+`Set-Cookie` propagation), so misses are more common in practice than the
+5-minute TTL suggests.
+
+**Fix**: `evlog-auth.ts` now passes an `onIdentify` callback to
+`createAuthMiddleware` that stashes the resolved session on
+`event.context.authSession` (typed via `server/types/h3-context.d.ts`).
+`useUserSession()` checks that context field first and only falls back to
+its own `getSession()` call when nothing is cached.
+
+Only **positive** (successfully identified) results are cached — `onIdentify`
+only fires when a session actually resolved. Anonymous and error paths are
+never cached, so a transient KV/D1 hiccup can't turn into a spurious 401 for
+a request whose own retry would have succeeded. No auth-mutating route
+(sign-in, sign-out, OAuth callback, password reset) sits outside
+`/api/auth/**`, which stays fully excluded from this middleware and never
+calls `useUserSession()` — so there's no route where a stale cached session
+could be read after a same-request mutation.
+
+`/api/v1/consents` was also added to the exclude list: its handler never
+calls `useUserSession()` at all (it's fully anonymous), so it was paying for
+a session resolution with no consumer. In practice this endpoint's cost is
+dominated by cold-isolate overhead on the separate `CONSENT_DB` binding and
+by the fact that consent POSTs correlate with new visitors' first requests —
+don't expect this specific change to move its p95 much.
+
+### 2. `files.userId` had no usable index
+
+`getUserStorageUsageBytes()` (`server/utils/files/file-governance.ts`) runs
+`SELECT COALESCE(SUM(size),0) FROM files WHERE userId = ?` — called from the
+hot path of `/api/v1/files/upload` and `/api/v1/storage`. The `files` table
+had a unique index on `(id, userId)`, but `id` (the table's own primary key)
+is the leading column, making it useless for a plain `userId = ?` predicate.
+SQLite fell back to a full table scan across every user's files, growing
+worse as the table grows.
+
+**Fix**: added `index('idx_files_user_id').on(table.userId)` to
+`server/db/schemas/files.ts`. The generated migration
+(`.drizzle/migrations/20260723161132_unknown_overlord/migration.sql`)
+contains exactly one statement:
+
+```sql
+CREATE INDEX `idx_files_user_id` ON `files` (`user_id`);
+```
+
+No `DROP TABLE`, no table rebuild — this is the one migration shape this
+repo's D1 safety checklist calls unconditionally safe (see `CLAUDE.md`).
+
+### 3. Two helper functions wrote to D1 on every call, even in steady state
+
+This was the single biggest lever found — bigger than the missing index.
+
+`getOrCreateStoragePolicyRow()` always ran `INSERT ... ON CONFLICT DO
+NOTHING` followed by a `SELECT`, even when the row already existed (which is
+true almost always, after a user's first-ever call). D1 writes serialize at
+the primary and have a materially higher latency floor than reads. This
+function backs `getEffectiveUserFilePolicy()`, called from `/api/v1/storage`,
+`/api/v1/files/policy`, `/api/v1/files/upload`, and
+`reserveImageTransformSlots` — nearly every hot read path in this subsystem.
+
+`getGlobalMonthlyTransformStats()` was worse: `INSERT ... ON CONFLICT DO
+NOTHING`, then an **unconditional** `UPDATE` (two writes), then a `SELECT` —
+on every call, including every `/files/policy` request and every `/storage`
+cache miss — just to sync `transformsLimit` from a runtime-config value that
+essentially never changes between deploys.
+
+**Fix**: both functions now read first. `getOrCreateStoragePolicyRow` only
+inserts (via `.returning()`, avoiding a third round trip) when the row is
+actually missing. `getGlobalMonthlyTransformStats` only writes when the row
+is missing or its stored `transformsLimit` differs from the computed limit.
+Steady state for both: a single `SELECT`, zero writes. The concurrent-miss
+race (two requests both seeing "row missing") is exactly as safe as before —
+`ON CONFLICT DO NOTHING` already handled that.
+
+`reserveGlobalTransformSlot`'s/`reserveUserTransformSlot`'s atomic
+`UPDATE ... WHERE used < limit` reservation logic was deliberately left
+untouched — that conditional update *is* the actual slot reservation, not
+wasted work.
+
+### 4. Policy and usage were fetched 2-3x per upload for no reason
+
+For one image upload: `upload.put.ts` fetched policy + usage as a pre-check,
+`reserveImageTransformSlots` fetched policy again internally just to read one
+field, and `persistFile()` fetched both again to redo the exact same
+pre-check (nothing D1-relevant changed in between — the only thing that
+happened is a Cloudflare Images transform call, which doesn't touch D1).
+
+**Fix**: `reserveImageTransformSlots(userId, policy?)` and
+`persistFile(input)` (`policy`/`totalFilesSize` optional fields) now accept
+already-fetched values and skip their internal fetch when supplied,
+defaulting to fetching internally otherwise (so other callers of
+`persistFile` elsewhere in the codebase are unaffected). `upload.put.ts`
+fetches policy and usage once and threads them through.
+
+`persistFile`'s **post-insert** re-check of `getUserStorageUsageBytes` — the
+authoritative, race-safe check that catches a concurrent second upload
+landing in the gap — was left completely untouched. It has to re-query fresh
+every time; only the redundant *pre*-check fetches were deduplicated.
+
+Non-negotiable invariant: these optional pre-fetched parameters are only ever
+populated from `upload.put.ts`'s own same-request calls, never from anything
+client-supplied. `reserveUserTransformSlot` branches its enforcement path on
+`policy.imageTransformLimitTotal` (unguarded increment when `null`, `WHERE
+... <` guarded otherwise), so a wrong policy here would matter for
+enforcement if it could come from outside — it can't.
+
+### 5. Independent D1 calls were awaited sequentially
+
+`storage/index.get.ts` (policy + usage + global stats), `policy.get.ts`
+(policy + global stats), and `upload.put.ts`'s pre-check (policy + usage) each
+awaited 2-3 independent calls one at a time. None of them depend on each
+other's results. All three now use `Promise.all([...])`.
+
+### 6. `/api/v1/files/policy` had no cache; `/api/v1/storage` already did
+
+`storage/index.get.ts` already KV-caches its response for 60 seconds.
+`policy.get.ts` computed nearly the same underlying data fresh on every call.
+
+**Fix**: added the same 60-second TTL KV-cache pattern to `policy.get.ts`
+(`file-policy:{userId}` key). `invalidateStorageCache` (called from
+`persist-file.ts` after a successful upload) now deletes both cache keys, so
+the two caches can't silently drift out of sync with each other.
+
+## What was deliberately NOT changed, and why
+
+**`/api/auth/callback/google` (3220/1530ms)** — the OAuth callback makes two
+*sequential* external calls to Google (authorization-code→token exchange,
+then userinfo — inherently sequential, since userinfo needs the access token
+from the first call), plus roughly 5-8 sequential D1/KV operations
+(verification-state consume, user/account upsert, a `lastLoginMethod` write,
+session create to both D1 and KV, rate-limit KV read+write). This floor
+cannot be pushed below Google's own round-trip time. **Not fixed.**
+
+The gap between the two observed samples (3220ms vs 1530ms) is plausibly
+explained by Better Auth's `oAuthProxy({ productionURL })` plugin: its
+`checkSkipProxy` logic forces the entire OAuth exchange onto
+`productionURL`'s origin (`https://www.besidka.com`) with an extra redirect
+round-trip whenever the request's current origin differs — e.g. a sign-in
+starting on the bare apex domain or a preview URL. This is **unverified** —
+it requires checking which origins the slow samples in Axiom actually came
+from, which needs Axiom access this work didn't have. **Investigate before
+touching** — don't change `baseURL`/proxy config on this hypothesis alone.
+
+**`/api/auth/sign-in/email` (1050ms)** — Better Auth's default password KDF
+is scrypt, deliberately CPU-expensive for security, and Workers CPU is
+comparatively scarce vs. a typical VM. Weakening the KDF trades security for
+speed. **Not fixed, and shouldn't be.**
+
+**`/api/v1/files/upload` (2480ms)** — the redundant-fetch fixes above (items
+3 and 4) reduce the server-side D1 cost, but the measured duration starts at
+request receipt: `readRawBody()` waits for the entire request body to arrive
+from the client. For multi-megabyte files over residential/mobile uplinks,
+that transfer time dominates the 2480ms figure, on top of a genuine
+Cloudflare Images transform round trip and an R2 put. **~300ms is not
+achievable here by definition** — this endpoint should be excluded from the
+300ms target the same way the OAuth callback is.
+
+**`/api/auth/sign-out`, `/api/v1/push/subscribe`, `/api/v1/chats/new`
+(non-research path)** — each does very little real work (1-3 already-indexed
+D1 operations). The session-resolution dedup (fix 1) removes one of their two
+session resolutions, which helps some, but their p95 is dominated by
+platform tail latency: cold Worker isolates paying the full Better Auth
+instance construction cost on first use, Cloudflare Smart Placement variance,
+and D1/KV round-trip latency — not application logic. There is no further
+code-level lever here.
+
+One considered-and-declined option: collapsing `push/subscribe`'s
+find-then-update/insert pair into a single `INSERT ... ON CONFLICT(endpoint)
+DO UPDATE` would save one round trip, but the handler deliberately logs
+whether a subscription was new vs. reassigned/resubscribed, and the single
+upsert would lose that attribution. Declined as not worth the trade.
+
+**Cloudflare Smart Placement** (`wrangler.jsonc`, `"placement": {"mode":
+"smart"}`) and the **oAuthProxy origin-mismatch theory** above are both
+investigate-only. Flipping Smart Placement without production A/B data would
+itself be a guess — for a D1-coupled app, Smart Placement typically converges
+execution toward the D1 primary, which *helps* the D1-RTT-dominated
+endpoints; blindly disabling it could make things worse.
+
+**Statistical caveat**: `sign-in`, `sign-out`, `callback/google`, and
+`consents` are comparatively low-volume endpoints. Their p95 over an Axiom
+dashboard window may be computed from a small number of samples — check
+per-path sample counts and p50 in Axiom before treating these specific p95
+figures as stable facts to re-measure against later.
+
+## Benchmark: proving the index change, not guessing it
+
+Local `wrangler dev`/miniflare D1 has near-zero network latency and no cold
+starts — it can never reproduce Axiom's production p95 numbers, and no
+number in this document claims to. What *is* provable locally and
+deterministically is the algorithmic shift SQLite's query planner makes for
+this exact predicate: a full table `SCAN` becomes an indexed `SEARCH`, and
+that shift's cost scales with row count regardless of what machine runs it.
+
+`scripts/bench/files-user-id-index.mjs` (run via `pnpm run bench:files-index`)
+builds a throwaway SQLite database (never the checked-in local D1 state)
+matching the real `files` table DDL, seeds it with a power-law-skewed
+`user_id` distribution and realistic file sizes, times the query before and
+after applying the exact migration SQL, and prints `EXPLAIN QUERY PLAN` plus
+mean/median/p95 over 1000 timed iterations. It accepts `--rows`, `--users`,
+`--iterations`, `--seed` for re-running at different scales.
+
+Results at three scales (all runs reproduced independently, not
+cherry-picked):
+
+| Rows | Distinct users | Before plan | Before mean/median/p95 | After plan | After mean/median/p95 |
+|---|---|---|---|---|---|
+| 100,000 | 1,000 | `SCAN files` | 3.66 / 3.52 / 4.05 ms | `SEARCH ... USING INDEX` | 0.026 / 0.009 / 0.061 ms |
+| 120,000 | 1,499 | `SCAN files` | 4.20 / 4.14 / 4.57 ms | `SEARCH ... USING INDEX` | 0.021 / 0.008 / 0.051 ms |
+| 300,000 | 3,000 | `SCAN files` | 16.74 / 16.60 / 18.03 ms | `SEARCH ... USING INDEX` | 0.041 / 0.016 / 0.126 ms |
+
+The pattern that matters: full-scan cost grows with row count (3.66ms →
+4.20ms → 16.74ms as rows went 100k → 120k → 300k) while the indexed-seek cost
+stays essentially flat regardless of table size. That's the proof this task
+needed — treat the specific "Nx faster" multipliers (roughly two orders of
+magnitude) as directional, not precise; sub-0.1ms figures approach timer
+resolution.
+
+**The honest way to think about the production win**: it's round-trips
+eliminated (and writes eliminated) × real D1/KV round-trip time, not a local
+millisecond figure. Fixes 1, 3, 4, and 5 above are what move production
+wall-clock p95 today — they remove actual round trips and writes from the
+request path. The index (fix 2) is what keeps `getUserStorageUsageBytes`
+cheap as the `files` table keeps growing; it's complementary to, not a
+substitute for, the round-trip elimination.
+
+## Verification performed
+
+- `pnpm run format && pnpm run typecheck` clean on the full combined change
+  set (no errors; only a pre-existing unrelated `no-console` warning).
+- Full test suite: 151 files / 1414 tests passing, including a new
+  `tests/integration/server/session.spec.ts` (cached-context fast path,
+  fallback path, and the existing issue-#235 diagnostic still firing) and a
+  new assertion in `tests/integration/server/cache-invalidation.spec.ts`
+  confirming both cache keys get invalidated together.
+- **Real dev-server smoke test**, because the integration tests above mock
+  `useUserSession`/`useServerAuth` — i.e. they mock the exact chain this
+  change touches, so green mocked tests alone don't prove the real Nitro
+  middleware → handler flow works. Against a live `pnpm run dev` with the
+  index migration applied locally:
+  - Signed up via email/password (dev auto-signs-in) → `200`.
+  - `GET /api/v1/storage` and `GET /api/v1/files/policy` with the real
+    session cookie → `200` with correct data, second `/files/policy` call
+    served from the new KV cache.
+  - Same endpoints with no cookie → `401`.
+  - `POST /api/v1/consents` with no cookie → succeeds (no session resolution
+    at all, confirming the exclude works).
+  - Signed out, then re-hit `/api/v1/storage` with the same cookie jar →
+    `401` (session correctly invalidated, no stale-context leak across the
+    sign-out boundary).
+
+## Rolling out the migration
+
+The migration (`.drizzle/migrations/20260723161132_unknown_overlord/`) has
+only been applied to this worktree's local D1 for benchmarking and smoke
+testing. Per this repo's D1 migration safety rules, applying it to
+`chat-preview` and then production `chat` is a separate, explicit step:
+
+```bash
+npx wrangler d1 time-travel info chat-preview
+pnpm run db:migrate:preview
+# verify, then:
+npx wrangler d1 time-travel info chat
+pnpm run db:migrate:prod
+```
+
+This migration is additive-only (`CREATE INDEX`, no `DROP TABLE`) and does
+not touch any cascade-dependent table, so it carries none of the rebuild risk
+this repo's checklist warns about — but the checklist's "take a Time Travel
+bookmark first" step is still cheap insurance and should not be skipped.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
 		"test:cookie-consent": "pnpm --filter @besidka/nuxt-cookie-consent test:run",
 		"landing:video": "node scripts/landing-demo-video.mjs",
 		"cms:files:upload": "node scripts/cms-bucket-manager.mjs upload",
-		"cms:files:download": "node scripts/cms-bucket-manager.mjs download"
+		"cms:files:download": "node scripts/cms-bucket-manager.mjs download",
+		"bench:files-index": "node scripts/bench/files-user-id-index.mjs"
 	},
 	"dependencies": {
 		"@ai-sdk/google": "^4.0.21",

--- a/scripts/bench/files-user-id-index.mjs
+++ b/scripts/bench/files-user-id-index.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+/**
+ * Benchmarks `idx_files_user_id` against the `files` table's own hot-path
+ * query: `SELECT COALESCE(SUM(size),0) FROM files WHERE user_id = ?`, used by
+ * `getUserStorageUsageBytes()` in `server/utils/files/file-governance.ts`.
+ *
+ * This does NOT reproduce production latency (network hops, cold starts, and
+ * D1's HTTP-based access pattern have zero equivalent on a local SQLite
+ * file). What it DOES prove, deterministically, is the algorithmic shift
+ * SQLite's query planner makes for this exact predicate once the index
+ * exists: a full table `SCAN` becomes an indexed `SEARCH`, and how that
+ * shows up as wall-clock time on a realistically sized, realistically skewed
+ * dataset.
+ *
+ * The script builds a throwaway SQLite database (never the checked-in local
+ * D1 state under `.wrangler/state/v3/d1`) under the OS temp directory,
+ * recreates the `files` table DDL as Drizzle currently generates it (minus
+ * foreign keys, which are irrelevant to this table's own index behavior),
+ * seeds it with a power-law-skewed distribution of `user_id` values, times
+ * the query before and after creating the index, and deletes the throwaway
+ * database when done.
+ *
+ * Usage:
+ *   pnpm run bench:files-index
+ *   pnpm run bench:files-index -- --rows 250000 --users 3000
+ *   pnpm run bench:files-index -- --iterations 2000 --seed 42
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Database from 'better-sqlite3'
+
+const DEFAULT_ROW_COUNT = 120_000
+const DEFAULT_USER_COUNT = 1_500
+const DEFAULT_ITERATION_COUNT = 1_000
+const WARMUP_ITERATION_COUNT = 50
+const DEFAULT_SEED = 20260723
+
+const USER_DISTRIBUTION_SKEW_EXPONENT = 1.1
+const MIN_FILE_SIZE_BYTES = 1024
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024
+
+const CREATE_TABLE_SQL = `
+  CREATE TABLE files (
+    id integer PRIMARY KEY NOT NULL,
+    created_at integer NOT NULL,
+    updated_at integer NOT NULL,
+    user_id integer NOT NULL,
+    storage_key text NOT NULL,
+    name text NOT NULL,
+    size integer NOT NULL,
+    type text NOT NULL,
+    source text DEFAULT 'upload' NOT NULL,
+    expires_at integer,
+    origin_message_id integer,
+    origin_provider text,
+    origin_model text,
+    generation_cost real
+  );
+  CREATE UNIQUE INDEX uq_file_user ON files (id, user_id);
+  CREATE UNIQUE INDEX \`uq_file_storageKey\` ON files (storage_key);
+  CREATE INDEX idx_files_expires_at ON files (expires_at);
+`
+
+const CREATE_INDEX_SQL
+  = 'CREATE INDEX `idx_files_user_id` ON `files` (`user_id`);'
+
+const BENCHMARK_QUERY_SQL
+  = 'SELECT COALESCE(SUM(size), 0) AS total FROM files WHERE user_id = ?'
+
+const EXPLAIN_QUERY_PLAN_SQL = `EXPLAIN QUERY PLAN ${BENCHMARK_QUERY_SQL}`
+
+function parseArgs(argv) {
+  const args = {}
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+
+    if (!value.startsWith('--')) {
+      continue
+    }
+
+    const key = value.slice(2)
+    const next = argv[index + 1]
+
+    if (!next || next.startsWith('--')) {
+      args[key] = true
+
+      continue
+    }
+
+    args[key] = next
+    index += 1
+  }
+
+  return args
+}
+
+function createSeededRandom(seed) {
+  let state = seed >>> 0
+
+  return function random() {
+    state = (state + 0x6d2b79f5) >>> 0
+
+    let value = state
+
+    value = Math.imul(value ^ (value >>> 15), value | 1)
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61)
+
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function buildUserIdCumulativeWeights(userCount) {
+  const weights = Array.from({ length: userCount }, (_, index) => {
+    return 1 / ((index + 1) ** USER_DISTRIBUTION_SKEW_EXPONENT)
+  })
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0)
+  const cumulativeWeights = []
+  let runningTotal = 0
+
+  for (const weight of weights) {
+    runningTotal += weight / totalWeight
+    cumulativeWeights.push(runningTotal)
+  }
+
+  return cumulativeWeights
+}
+
+function sampleUserId(cumulativeWeights, random) {
+  const target = random()
+  let low = 0
+  let high = cumulativeWeights.length - 1
+
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2)
+
+    if (cumulativeWeights[middle] < target) {
+      low = middle + 1
+    } else {
+      high = middle
+    }
+  }
+
+  return low + 1
+}
+
+function sampleFileSizeBytes(random) {
+  const minExponent = Math.log2(MIN_FILE_SIZE_BYTES)
+  const maxExponent = Math.log2(MAX_FILE_SIZE_BYTES)
+  const exponent = minExponent + (random() * (maxExponent - minExponent))
+
+  return Math.round(2 ** exponent)
+}
+
+function createThrowawayDatabase() {
+  const directory = mkdtempSync(
+    join(tmpdir(), 'besidka-files-index-bench-'),
+  )
+  const path = join(directory, 'bench.sqlite')
+  const db = new Database(path)
+
+  db.pragma('journal_mode = WAL')
+  db.pragma('foreign_keys = OFF')
+  db.exec(CREATE_TABLE_SQL)
+
+  return { db, directory, path }
+}
+
+function seedFiles(db, rowCount, userCount, seed) {
+  const random = createSeededRandom(seed)
+  const cumulativeWeights = buildUserIdCumulativeWeights(userCount)
+  const insert = db.prepare(`
+    INSERT INTO files (
+      id, created_at, updated_at, user_id, storage_key, name, size, type
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+  const insertAll = db.transaction((count) => {
+    const now = Math.floor(Date.now() / 1000)
+
+    for (let index = 1; index <= count; index += 1) {
+      const userId = sampleUserId(cumulativeWeights, random)
+      const size = sampleFileSizeBytes(random)
+
+      insert.run(
+        index,
+        now,
+        now,
+        userId,
+        `bench/${index}`,
+        `file-${index}.bin`,
+        size,
+        'application/octet-stream',
+      )
+    }
+  })
+
+  insertAll(rowCount)
+}
+
+function readDistinctUserIds(db) {
+  const rows = db.prepare('SELECT DISTINCT user_id FROM files').all()
+
+  return rows.map(row => row.user_id)
+}
+
+function sampleBenchmarkUserIds(distinctUserIds, iterationCount, seed) {
+  const random = createSeededRandom(seed + 1)
+  const sampledUserIds = []
+
+  for (let index = 0; index < iterationCount; index += 1) {
+    const randomIndex = Math.floor(random() * distinctUserIds.length)
+
+    sampledUserIds.push(distinctUserIds[randomIndex])
+  }
+
+  return sampledUserIds
+}
+
+function explainQueryPlan(db, userId) {
+  const rows = db.prepare(EXPLAIN_QUERY_PLAN_SQL).all(userId)
+
+  return rows.map(row => row.detail).join(' | ')
+}
+
+function benchmarkQuery(db, userIds) {
+  const statement = db.prepare(BENCHMARK_QUERY_SQL)
+
+  for (let index = 0; index < WARMUP_ITERATION_COUNT; index += 1) {
+    statement.get(userIds[index % userIds.length])
+  }
+
+  const durationsInMilliseconds = []
+
+  for (const userId of userIds) {
+    const startedAt = process.hrtime.bigint()
+
+    statement.get(userId)
+
+    const finishedAt = process.hrtime.bigint()
+    const durationInMilliseconds
+      = Number(finishedAt - startedAt) / 1_000_000
+
+    durationsInMilliseconds.push(durationInMilliseconds)
+  }
+
+  return durationsInMilliseconds
+}
+
+function computePercentile(sortedValues, percentile) {
+  const rank = Math.ceil(percentile * sortedValues.length) - 1
+  const index = Math.min(Math.max(rank, 0), sortedValues.length - 1)
+
+  return sortedValues[index]
+}
+
+function computeStatistics(durationsInMilliseconds) {
+  const sortedValues = [...durationsInMilliseconds].sort((left, right) => {
+    return left - right
+  })
+  const sum = sortedValues.reduce((total, value) => total + value, 0)
+  const mean = sum / sortedValues.length
+  const median = computePercentile(sortedValues, 0.5)
+  const p95 = computePercentile(sortedValues, 0.95)
+
+  return { mean, median, p95 }
+}
+
+function formatMilliseconds(value) {
+  return `${value.toFixed(4)}ms`
+}
+
+function printSummary(summary) {
+  const {
+    rowCount,
+    userCount,
+    iterationCount,
+    beforePlan,
+    afterPlan,
+    beforeStatistics,
+    afterStatistics,
+  } = summary
+
+  console.log('')
+  console.log('=== files.user_id index benchmark ===')
+  console.log(`Rows seeded:          ${rowCount}`)
+  console.log(`Distinct user_ids:    ${userCount}`)
+  console.log(`Timed iterations:     ${iterationCount}`)
+  console.log('')
+  console.log('Before (no index on user_id):')
+  console.log(`  Query plan:  ${beforePlan}`)
+  console.log(`  Mean:        ${formatMilliseconds(beforeStatistics.mean)}`)
+  console.log(`  Median:      ${formatMilliseconds(beforeStatistics.median)}`)
+  console.log(`  p95:         ${formatMilliseconds(beforeStatistics.p95)}`)
+  console.log('')
+  console.log('After (idx_files_user_id created):')
+  console.log(`  Query plan:  ${afterPlan}`)
+  console.log(`  Mean:        ${formatMilliseconds(afterStatistics.mean)}`)
+  console.log(`  Median:      ${formatMilliseconds(afterStatistics.median)}`)
+  console.log(`  p95:         ${formatMilliseconds(afterStatistics.p95)}`)
+  console.log('')
+
+  const meanSpeedup = beforeStatistics.mean / afterStatistics.mean
+  const p95Speedup = beforeStatistics.p95 / afterStatistics.p95
+
+  console.log(`Mean speedup: ${meanSpeedup.toFixed(2)}x`)
+  console.log(`p95 speedup:  ${p95Speedup.toFixed(2)}x`)
+  console.log('')
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const rowCount = Number(args.rows || DEFAULT_ROW_COUNT)
+  const userCount = Number(args.users || DEFAULT_USER_COUNT)
+  const iterationCount = Number(args.iterations || DEFAULT_ITERATION_COUNT)
+  const seed = Number(args.seed || DEFAULT_SEED)
+
+  const { db, directory } = createThrowawayDatabase()
+
+  try {
+    console.log(
+      `Seeding ${rowCount} rows across ${userCount} distinct `
+      + 'user_id values (power-law skewed)...',
+    )
+    seedFiles(db, rowCount, userCount, seed)
+
+    const distinctUserIds = readDistinctUserIds(db)
+    const sampledUserIds = sampleBenchmarkUserIds(
+      distinctUserIds,
+      iterationCount,
+      seed,
+    )
+
+    console.log('Running "before" benchmark (full table scan expected)...')
+    const beforePlan = explainQueryPlan(db, sampledUserIds[0])
+    const beforeStatistics = computeStatistics(
+      benchmarkQuery(db, sampledUserIds),
+    )
+
+    console.log(`Applying migration SQL: ${CREATE_INDEX_SQL}`)
+    db.exec(CREATE_INDEX_SQL)
+
+    console.log('Running "after" benchmark (index seek expected)...')
+    const afterPlan = explainQueryPlan(db, sampledUserIds[0])
+    const afterStatistics = computeStatistics(
+      benchmarkQuery(db, sampledUserIds),
+    )
+
+    printSummary({
+      rowCount,
+      userCount: distinctUserIds.length,
+      iterationCount,
+      beforePlan,
+      afterPlan,
+      beforeStatistics,
+      afterStatistics,
+    })
+  } finally {
+    db.close()
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+await main()

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -561,6 +561,7 @@ export function getAffectedTests(changedFiles) {
     {
       pattern: /^server\/utils\/session\.ts$/,
       tests: [
+        'tests/integration/server/session.spec.ts',
         'tests/integration/api/chats-new.spec.ts',
         'tests/integration/api/projects.spec.ts',
         'tests/integration/api/chats-branch.spec.ts',

--- a/server/api/v1/files/policy.get.ts
+++ b/server/api/v1/files/policy.get.ts
@@ -1,10 +1,20 @@
 import type { FilePolicyResponse } from '#shared/types/files.d'
+import { useLogger } from 'evlog'
 import {
   getEffectiveUserFilePolicy,
   getGlobalMonthlyTransformStats,
 } from '~~/server/utils/files/file-governance'
 
-export default defineEventHandler(async (): Promise<FilePolicyResponse> => {
+const CACHE_TTL_SECONDS = 60
+
+export function getFilePolicyCacheKey(userId: number): string {
+  return `file-policy:${userId}`
+}
+
+export default defineEventHandler(async (
+  event,
+): Promise<FilePolicyResponse> => {
+  const logger = useLogger(event)
   const session = await useUserSession()
 
   if (!session) {
@@ -12,11 +22,52 @@ export default defineEventHandler(async (): Promise<FilePolicyResponse> => {
   }
 
   const userId = parseInt(session.user.id)
-  const policy = await getEffectiveUserFilePolicy(userId)
-  const globalTransformStats = await getGlobalMonthlyTransformStats()
+  const kv = useKV()
+  const cacheKey = getFilePolicyCacheKey(userId)
 
-  return {
+  try {
+    const cached = await kv.get<FilePolicyResponse>(cacheKey, 'json')
+
+    if (cached) {
+      return cached
+    }
+  } catch (exception) {
+    logger.set({
+      cache: {
+        operation: 'read',
+        key: cacheKey,
+        error: exception instanceof Error
+          ? exception.message
+          : String(exception),
+      },
+    })
+  }
+
+  const [policy, globalTransformStats] = await Promise.all([
+    getEffectiveUserFilePolicy(userId),
+    getGlobalMonthlyTransformStats(),
+  ])
+
+  const response: FilePolicyResponse = {
     policy,
     globalTransformRemainingMonth: globalTransformStats.remaining,
   }
+
+  try {
+    await kv.put(cacheKey, JSON.stringify(response), {
+      expirationTtl: CACHE_TTL_SECONDS,
+    })
+  } catch (exception) {
+    logger.set({
+      cache: {
+        operation: 'write',
+        key: cacheKey,
+        error: exception instanceof Error
+          ? exception.message
+          : String(exception),
+      },
+    })
+  }
+
+  return response
 })

--- a/server/api/v1/files/upload.put.ts
+++ b/server/api/v1/files/upload.put.ts
@@ -90,8 +90,10 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const policy = await getEffectiveUserFilePolicy(userId)
-  const totalFilesSize = await getUserStorageUsageBytes(userId)
+  const [policy, totalFilesSize] = await Promise.all([
+    getEffectiveUserFilePolicy(userId),
+    getUserStorageUsageBytes(userId),
+  ])
   const wouldExceed = totalFilesSize + parsedFileSize > policy.maxStorageBytes
 
   if (wouldExceed) {
@@ -112,7 +114,7 @@ export default defineEventHandler(async (event) => {
   let hasReservedTransformSlots = false
 
   if (isFileImage) {
-    const reservation = await reserveImageTransformSlots(userId)
+    const reservation = await reserveImageTransformSlots(userId, policy)
 
     if (reservation.reserved) {
       hasReservedTransformSlots = true
@@ -185,6 +187,8 @@ export default defineEventHandler(async (event) => {
       quotaSizeBytes: parsedFileSize,
       source: 'upload',
       logger,
+      policy,
+      totalFilesSize,
     })
   } catch (exception) {
     if (!transformed && hasReservedTransformSlots) {

--- a/server/api/v1/storage/index.get.ts
+++ b/server/api/v1/storage/index.get.ts
@@ -94,9 +94,25 @@ export async function invalidateStorageCache(
   logger?: LoggerLike,
 ): Promise<void> {
   const activeLogger = resolveServerLogger(logger)
-  const kv = useKV()
   const storageCacheKey = getStorageCacheKey(userId)
   const filePolicyCacheKey = getFilePolicyCacheKey(userId)
+  let kv: ReturnType<typeof useKV>
+
+  try {
+    kv = useKV()
+  } catch (exception) {
+    activeLogger.set({
+      cache: {
+        operation: 'invalidate',
+        key: `${storageCacheKey},${filePolicyCacheKey}`,
+        error: exception instanceof Error
+          ? exception.message
+          : String(exception),
+      },
+    })
+
+    return
+  }
 
   try {
     await kv.delete(storageCacheKey)

--- a/server/api/v1/storage/index.get.ts
+++ b/server/api/v1/storage/index.get.ts
@@ -9,6 +9,7 @@ import {
   resolveServerLogger,
 } from '~~/server/utils/files/logger'
 import type { LoggerLike } from '~~/server/utils/files/logger'
+import { getFilePolicyCacheKey } from '~~/server/api/v1/files/policy.get'
 
 const CACHE_TTL_SECONDS = 60
 
@@ -46,9 +47,11 @@ export default defineEventHandler(async (event): Promise<StorageStats> => {
     })
   }
 
-  const policy = await getEffectiveUserFilePolicy(userId)
-  const used = await getUserStorageUsageBytes(userId)
-  const globalTransformStats = await getGlobalMonthlyTransformStats()
+  const [policy, used, globalTransformStats] = await Promise.all([
+    getEffectiveUserFilePolicy(userId),
+    getUserStorageUsageBytes(userId),
+    getGlobalMonthlyTransformStats(),
+  ])
   const total = policy.maxStorageBytes
 
   const percentage = total > 0 ? Math.round((used / total) * 100) : 0
@@ -91,17 +94,31 @@ export async function invalidateStorageCache(
   logger?: LoggerLike,
 ): Promise<void> {
   const activeLogger = resolveServerLogger(logger)
-  const cacheKey = getStorageCacheKey(userId)
+  const kv = useKV()
+  const storageCacheKey = getStorageCacheKey(userId)
+  const filePolicyCacheKey = getFilePolicyCacheKey(userId)
 
   try {
-    const kv = useKV()
-
-    await kv.delete(cacheKey)
+    await kv.delete(storageCacheKey)
   } catch (exception) {
     activeLogger.set({
       cache: {
         operation: 'invalidate',
-        key: cacheKey,
+        key: storageCacheKey,
+        error: exception instanceof Error
+          ? exception.message
+          : String(exception),
+      },
+    })
+  }
+
+  try {
+    await kv.delete(filePolicyCacheKey)
+  } catch (exception) {
+    activeLogger.set({
+      cache: {
+        operation: 'invalidate',
+        key: filePolicyCacheKey,
         error: exception instanceof Error
           ? exception.message
           : String(exception),

--- a/server/db/schemas/files.ts
+++ b/server/db/schemas/files.ts
@@ -30,5 +30,6 @@ export const files = snakeCase.table(
     uniqueIndex('uq_file_user').on(table.id, table.userId),
     uniqueIndex('uq_file_storageKey').on(table.storageKey),
     index('idx_files_expires_at').on(table.expiresAt),
+    index('idx_files_user_id').on(table.userId),
   ],
 )

--- a/server/middleware/evlog-auth.ts
+++ b/server/middleware/evlog-auth.ts
@@ -1,6 +1,7 @@
 import { useLogger } from 'evlog'
 import { createAuthMiddleware } from 'evlog/better-auth'
 import type { BetterAuthInstance } from 'evlog/better-auth'
+import type { AuthSession } from '~~/server/types/h3-context'
 
 type Identify = ReturnType<typeof createAuthMiddleware>
 
@@ -20,10 +21,14 @@ function getIdentify(): Identify {
         '/api/_evlog/**',
         '/api/_nuxt_icon/**',
         '/api/v1/stats*',
+        '/api/v1/consents',
         '/_nuxt/**',
         '/health',
       ],
       maskEmail: true,
+      onIdentify: (_logger, session) => {
+        useEvent().context.authSession = session as AuthSession
+      },
       onAnonymous: (logger) => {
         logger.set({ anonymous: true })
       },

--- a/server/middleware/evlog-auth.ts
+++ b/server/middleware/evlog-auth.ts
@@ -21,7 +21,7 @@ function getIdentify(): Identify {
         '/api/_evlog/**',
         '/api/_nuxt_icon/**',
         '/api/v1/stats*',
-        '/api/v1/consents',
+        '/api/v1/consents*',
         '/_nuxt/**',
         '/health',
       ],

--- a/server/types/h3-context.d.ts
+++ b/server/types/h3-context.d.ts
@@ -1,0 +1,11 @@
+export type AuthSession = NonNullable<
+  Awaited<
+    ReturnType<ReturnType<typeof useServerAuth>['api']['getSession']>
+  >
+>
+
+declare module 'h3' {
+  interface H3EventContext {
+    authSession?: AuthSession
+  }
+}

--- a/server/utils/files/file-governance.ts
+++ b/server/utils/files/file-governance.ts
@@ -33,6 +33,21 @@ interface StoragePolicyRow {
   imageTransformUsedTotal: number
 }
 
+type TransformSlotPolicy = Pick<
+  StoragePolicyRow,
+  'imageTransformLimitTotal' | 'imageTransformUsedTotal'
+>
+
+const storagePolicyRowColumns = {
+  tier: true,
+  storage: true,
+  maxFilesPerMessage: true,
+  maxMessageFilesBytes: true,
+  fileRetentionDays: true,
+  imageTransformLimitTotal: true,
+  imageTransformUsedTotal: true,
+} as const
+
 interface TransformSlotReservation {
   reserved: boolean
   used: number
@@ -64,13 +79,22 @@ export async function getOrCreateStoragePolicyRow(
   userId: number,
 ): Promise<StoragePolicyRow> {
   const db = useDb()
+  const existingRow = await db.query.storages.findFirst({
+    where: { userId },
+    columns: storagePolicyRowColumns,
+  })
+
+  if (existingRow) {
+    return existingRow
+  }
+
   const config = useRuntimeConfig().public
   const defaultMaxFilesPerMessage = config.maxFilesPerMessage
     || DEFAULT_MAX_FILES_PER_MESSAGE
   const defaultMaxMessageFilesBytes = config.maxMessageFilesBytes
     || DEFAULT_MAX_MESSAGE_FILES_BYTES
 
-  await db
+  const insertedRow = await db
     .insert(schema.storages)
     .values({
       userId,
@@ -83,29 +107,34 @@ export async function getOrCreateStoragePolicyRow(
       imageTransformUsedTotal: 0,
     })
     .onConflictDoNothing()
-    .run()
+    .returning({
+      tier: schema.storages.tier,
+      storage: schema.storages.storage,
+      maxFilesPerMessage: schema.storages.maxFilesPerMessage,
+      maxMessageFilesBytes: schema.storages.maxMessageFilesBytes,
+      fileRetentionDays: schema.storages.fileRetentionDays,
+      imageTransformLimitTotal: schema.storages.imageTransformLimitTotal,
+      imageTransformUsedTotal: schema.storages.imageTransformUsedTotal,
+    })
+    .get()
 
-  const row = await db.query.storages.findFirst({
+  if (insertedRow) {
+    return insertedRow
+  }
+
+  const raceWinnerRow = await db.query.storages.findFirst({
     where: { userId },
-    columns: {
-      tier: true,
-      storage: true,
-      maxFilesPerMessage: true,
-      maxMessageFilesBytes: true,
-      fileRetentionDays: true,
-      imageTransformLimitTotal: true,
-      imageTransformUsedTotal: true,
-    },
+    columns: storagePolicyRowColumns,
   })
 
-  if (!row) {
+  if (!raceWinnerRow) {
     throw createError({
       statusCode: 500,
       statusMessage: 'Failed to initialize user storage policy',
     })
   }
 
-  return row
+  return raceWinnerRow
 }
 
 export function getEffectiveFilePolicy(
@@ -280,6 +309,26 @@ export async function getGlobalMonthlyTransformStats(
   const db = useDb()
   const monthKey = getCurrentMonthKey()
   const limit = getGlobalMonthlyTransformLimit()
+  const existingRow = await db.query.imageTransformUsageMonthly.findFirst({
+    where: { monthKey },
+    columns: {
+      monthKey: true,
+      transformsUsed: true,
+      transformsLimit: true,
+    },
+  })
+
+  if (existingRow && existingRow.transformsLimit === limit) {
+    return {
+      monthKey: existingRow.monthKey,
+      used: existingRow.transformsUsed,
+      limit: existingRow.transformsLimit,
+      remaining: Math.max(
+        existingRow.transformsLimit - existingRow.transformsUsed,
+        0,
+      ),
+    }
+  }
 
   await db
     .insert(schema.imageTransformUsageMonthly)
@@ -326,22 +375,27 @@ export async function getGlobalMonthlyTransformStats(
 
 export async function reserveImageTransformSlots(
   userId: number,
+  policy?: TransformSlotPolicy,
 ): Promise<TransformSlotReservation> {
-  const policy = await getOrCreateStoragePolicyRow(userId)
+  const effectivePolicy = policy
+    || await getOrCreateStoragePolicyRow(userId)
 
   if (
-    policy.imageTransformLimitTotal !== null
-    && policy.imageTransformLimitTotal <= 0
+    effectivePolicy.imageTransformLimitTotal !== null
+    && effectivePolicy.imageTransformLimitTotal <= 0
   ) {
     return {
       reserved: false,
-      used: policy.imageTransformUsedTotal,
-      limit: policy.imageTransformLimitTotal,
+      used: effectivePolicy.imageTransformUsedTotal,
+      limit: effectivePolicy.imageTransformLimitTotal,
       reason: 'disabled',
     }
   }
 
-  const userReservation = await reserveUserTransformSlot(userId, policy)
+  const userReservation = await reserveUserTransformSlot(
+    userId,
+    effectivePolicy,
+  )
 
   if (!userReservation.reserved) {
     return userReservation
@@ -503,7 +557,7 @@ export async function getOwnedGeneratedImageFilesByStorageKeys(
 
 async function reserveUserTransformSlot(
   userId: number,
-  policy: StoragePolicyRow,
+  policy: TransformSlotPolicy,
 ): Promise<TransformSlotReservation> {
   const db = useDb()
   const userLimit = policy.imageTransformLimitTotal

--- a/server/utils/files/persist-file.ts
+++ b/server/utils/files/persist-file.ts
@@ -1,4 +1,4 @@
-import type { FileMetadata, FileSource } from '#shared/types/files.d'
+import type { FileMetadata, FilePolicy, FileSource } from '#shared/types/files.d'
 import type { LoggerLike } from '~~/server/utils/files/logger'
 import { and, eq } from 'drizzle-orm'
 import {
@@ -29,6 +29,8 @@ export interface PersistFileInput {
   originModel?: string | null
   generationCost?: number | null
   logger?: LoggerLike
+  policy?: FilePolicy
+  totalFilesSize?: number
 }
 
 export type PersistedFile = Pick<
@@ -58,8 +60,10 @@ export async function persistFile(
     })
   }
 
-  const policy = await getEffectiveUserFilePolicy(input.userId)
-  const totalFilesSize = await getUserStorageUsageBytes(input.userId)
+  const policy = input.policy
+    ?? await getEffectiveUserFilePolicy(input.userId)
+  const totalFilesSize = input.totalFilesSize
+    ?? await getUserStorageUsageBytes(input.userId)
   const wouldExceed = totalFilesSize + quotaSizeBytes > policy.maxStorageBytes
   const expiresAt = getExpiresAtByRetentionDays(policy.fileRetentionDays)
 

--- a/server/utils/session.ts
+++ b/server/utils/session.ts
@@ -15,6 +15,11 @@ const SESSION_TOKEN_COOKIE
 
 export async function useUserSession() {
   const event = useEvent()
+
+  if (event.context.authSession) {
+    return event.context.authSession
+  }
+
   const session = await useServerAuth().api.getSession({
     // @ts-ignore
     headers: getHeaders(event),

--- a/tests/integration/server/cache-invalidation.spec.ts
+++ b/tests/integration/server/cache-invalidation.spec.ts
@@ -73,6 +73,19 @@ describe('cache invalidation helpers', () => {
     expect(loggerSet).toHaveBeenCalledTimes(1)
   })
 
+  it('deletes both the storage-stats and file-policy cache keys', async () => {
+    const invalidateStorageCache = await getInvalidateStorageCache()
+
+    vi.stubGlobal('useEvent', () => {
+      throw new Error('Request event is unavailable')
+    })
+
+    await expect(invalidateStorageCache(12)).resolves.toBeUndefined()
+
+    expect(mocks.kvDelete).toHaveBeenCalledWith('storage-stats:12')
+    expect(mocks.kvDelete).toHaveBeenCalledWith('file-policy:12')
+  })
+
   it('falls back to no-op logger when event is unavailable', async () => {
     const invalidateFileCache = await getInvalidateFileCache()
     const invalidateStorageCache = await getInvalidateStorageCache()

--- a/tests/integration/server/session.spec.ts
+++ b/tests/integration/server/session.spec.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  loggerSet: vi.fn(),
+  getSession: vi.fn(),
+}))
+
+vi.mock('evlog', () => ({
+  useLogger: () => ({
+    set: mocks.loggerSet,
+  }),
+}))
+
+async function getUseUserSession() {
+  const module = await import('../../../server/utils/session')
+
+  return module.useUserSession
+}
+
+describe('useUserSession', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    vi.stubGlobal('useServerAuth', vi.fn(() => ({
+      api: { getSession: mocks.getSession },
+    })))
+    vi.stubGlobal('getHeaders', vi.fn(() => ({})))
+    vi.stubGlobal('getHeader', vi.fn(() => ''))
+  })
+
+  it('returns the middleware-cached session without calling getSession',
+    async () => {
+      const cachedSession = {
+        user: { id: 'user-1' },
+        session: { id: 'session-1' },
+      }
+
+      vi.stubGlobal('useEvent', () => ({
+        context: { authSession: cachedSession },
+      }))
+
+      const useUserSession = await getUseUserSession()
+      const session = await useUserSession()
+
+      expect(session).toBe(cachedSession)
+      expect(mocks.getSession).not.toHaveBeenCalled()
+    })
+
+  it('falls back to resolving a session when none is cached', async () => {
+    const resolvedSession = {
+      user: { id: 'user-2' },
+      session: { id: 'session-2' },
+    }
+
+    mocks.getSession.mockResolvedValue(resolvedSession)
+    vi.stubGlobal('useEvent', () => ({ context: {} }))
+
+    const useUserSession = await getUseUserSession()
+    const session = await useUserSession()
+
+    expect(session).toBe(resolvedSession)
+    expect(mocks.getSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs the issue #235 diagnostic when no session is cached and '
+    + 'getSession resolves to null', async () => {
+    mocks.getSession.mockResolvedValue(null)
+    vi.stubGlobal('useEvent', () => ({ context: {} }))
+    vi.stubGlobal('getHeader', vi.fn(() => 'better-auth.session_token=abc'))
+
+    const useUserSession = await getUseUserSession()
+    const session = await useUserSession()
+
+    expect(session).toBeNull()
+    expect(mocks.loggerSet).toHaveBeenCalledWith({
+      sessionCheck: {
+        resolved: false,
+        tokenCookiePresent: true,
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Investigates and fixes the root causes behind Axiom's slowest-endpoints-by-p95 panel:

| Path | p95 (Axiom) | Disposition |
|---|---|---|
| `/api/auth/callback/google` | 3220ms (also 1530ms) | Floor-bound — not fixed |
| `/api/v1/files/upload` | 2480ms | Partially floor-bound — dedup fixed, ~300ms not expected |
| `/api/v1/storage` | 1640ms | Fixed — ~300ms plausible |
| `/api/v1/consents` | 1170ms | Fixed (exclusion), win likely near-zero |
| `/api/auth/sign-out` | 1070ms | Platform-tail-bound — dedup helps a little |
| `/api/auth/sign-in/email` | 1050ms | Floor-bound — not fixed |
| `/api/v1/chats/new` | 971ms | Platform-tail-bound — dedup helps a little |
| `/api/v1/files/policy` | 905ms | Fixed — ~300ms plausible |
| `/api/v1/push/subscribe` | 747ms | Platform-tail-bound — dedup helps a little |

Full writeup with root-cause analysis, what was deliberately **not** changed and why, and benchmark methodology: `docs/p95-endpoint-optimization.md`.

**What changed:**
- Session was resolved twice per protected request (once in `evlog-auth` middleware for logging, once in every handler via `useUserSession()`). The middleware now shares its resolved session via `event.context`, positive results only — no auth-mutating route is affected.
- `files.userId` had no usable index; `getUserStorageUsageBytes()`'s SUM query did a full table scan. Added `idx_files_user_id` (pure `CREATE INDEX`, no table rebuild — verified against this repo's D1 migration safety checklist).
- `getOrCreateStoragePolicyRow()` and `getGlobalMonthlyTransformStats()` wrote to D1 on every call even in steady state. Both are now read-first.
- Upload re-fetched policy/usage 2-3x across the call chain; now fetched once and threaded through (the authoritative post-insert quota re-check is untouched).
- Parallelized independent D1 calls in `storage`, `files/policy`, and upload's pre-check.
- Added the same 60s KV-cache pattern `/storage` already had to `/files/policy`; both cache keys now invalidate together.

**Deliberately not changed:** Google OAuth round trips, scrypt password hashing, upload client-uplink time, Cloudflare Smart Placement, and an unverified `oAuthProxy` origin-mismatch theory — all documented with reasoning in the doc.

## Test plan

- [x] `pnpm run format && pnpm run typecheck` clean
- [x] Full test suite passing (151 files / 1414 tests)
- [x] New reproducible benchmark (`pnpm run bench:files-index`) proving the index turns a full scan into an index seek on a realistically-sized, seeded dataset
- [x] Real dev-server smoke test (not just mocked tests) of the session-dedup change: sign-up/sign-in, authenticated vs. signed-out access to protected endpoints, anonymous `/api/v1/consents`, and sign-out correctly invalidating the session for subsequent requests
- [ ] Apply migration to `chat-preview` then production `chat` after merge (see rollout notes in the doc — not done as part of this PR)