### PR TITLE
fix(profile): restore container and fix account tabs/keys alignment

### DIFF
--- a/app/layouts/profile.vue
+++ b/app/layouts/profile.vue
@@ -1,93 +1,97 @@
 <template>
-  <div class="pb-24">
-    <div class="mb-8 flex items-center justify-between gap-4">
-      <UiButton
-        to="/chats/new"
-        ghost
-        mode="default"
-        normal-case
-        size="sm"
-        text="Back to Chat"
-        class="group/cta"
-      >
-        <template #icon>
-          <Icon
-            name="lucide:arrow-left"
-            size="20"
-            class="cta-icon-left"
-          />
-        </template>
-      </UiButton>
-      <div class="flex items-center gap-2">
-        <SidebarThemeSwitcher
-          show-label
-          mode="default"
-          size="sm"
-        />
-        <UiButton
-          ghost
-          normal-case
-          size="sm"
-          text="Sign out"
-          class="group/cta"
-          :disabled="isSigningOut"
-          data-testid="settings-sign-out"
-          @click="signOut"
-        >
-          <template #icon>
-            <Icon
-              name="lucide:log-out"
-              size="20"
-              class="cta-icon order-last"
-            />
-          </template>
-        </UiButton>
-      </div>
-    </div>
-    <div class="grid gap-8 sm:grid-cols-3">
-      <div
-        class="flex flex-col items-center gap-3 text-center"
-      >
-        <div
-          class="avatar rounded-full"
-          :class="{ 'avatar-placeholder': !user?.image }"
-        >
-          <div
-            class="bubble w-20 rounded-full bg-base-100 dark:bg-base-content/50 text-text dark:text-base-100 shadow-none"
+  <div class="relative z-30">
+    <div class="relative w-full max-w-4xl mx-auto py-8 px-3 sm:px-24">
+      <div class="pb-24">
+        <div class="mb-8 flex items-center justify-between gap-4">
+          <UiButton
+            to="/chats/new"
+            ghost
+            mode="default"
+            normal-case
+            size="sm"
+            text="Back to Chat"
+            class="group/cta"
           >
-            <img
-              v-if="user?.image"
-              :alt="user.name"
-              :src="user.image"
-            >
-            <Icon
-              v-else
-              name="lucide:user-round"
-              size="32"
+            <template #icon>
+              <Icon
+                name="lucide:arrow-left"
+                size="20"
+                class="cta-icon-left"
+              />
+            </template>
+          </UiButton>
+          <div class="flex items-center gap-2">
+            <SidebarThemeSwitcher
+              show-label
+              mode="default"
+              size="sm"
             />
+            <UiButton
+              ghost
+              normal-case
+              size="sm"
+              text="Sign out"
+              class="group/cta"
+              :disabled="isSigningOut"
+              data-testid="settings-sign-out"
+              @click="signOut"
+            >
+              <template #icon>
+                <Icon
+                  name="lucide:log-out"
+                  size="20"
+                  class="cta-icon order-last"
+                />
+              </template>
+            </UiButton>
           </div>
         </div>
-        <div class="grid gap-1">
-          <p class="text-lg font-bold">{{ user?.name }}</p>
-          <p class="text-sm break-all text-base-content/70">{{ user?.email }}</p>
-        </div>
-      </div>
-      <div class="sm:col-span-2">
-        <nav
-          aria-label="Account sections"
-          class="tabs tabs-box mb-6 w-fit"
-        >
-          <NuxtLink
-            v-for="tab in tabs"
-            :key="tab.to"
-            :to="tab.to"
-            class="tab"
-            exact-active-class="tab-active"
+        <div class="grid gap-8 md:grid-cols-3">
+          <div
+            class="flex flex-col items-center gap-3 text-center"
           >
-            {{ tab.label }}
-          </NuxtLink>
-        </nav>
-        <NuxtPage />
+            <div
+              class="avatar rounded-full"
+              :class="{ 'avatar-placeholder': !user?.image }"
+            >
+              <div
+                class="bubble w-20 rounded-full bg-base-100 dark:bg-base-content/50 text-text dark:text-base-100 shadow-none"
+              >
+                <img
+                  v-if="user?.image"
+                  :alt="user.name"
+                  :src="user.image"
+                >
+                <Icon
+                  v-else
+                  name="lucide:user-round"
+                  size="32"
+                />
+              </div>
+            </div>
+            <div class="grid gap-1">
+              <p class="text-lg font-bold">{{ user?.name }}</p>
+              <p class="text-sm break-all text-base-content/70">{{ user?.email }}</p>
+            </div>
+          </div>
+          <div class="sm:col-span-2">
+            <nav
+              aria-label="Account sections"
+              class="tabs tabs-box tabs-sm mb-6 w-full"
+            >
+              <NuxtLink
+                v-for="tab in tabs"
+                :key="tab.to"
+                :to="tab.to"
+                class="tab grow"
+                exact-active-class="tab-active"
+              >
+                {{ tab.label }}
+              </NuxtLink>
+            </nav>
+            <NuxtPage />
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/layouts/profile.vue
+++ b/app/layouts/profile.vue
@@ -74,7 +74,7 @@
               <p class="text-sm break-all text-base-content/70">{{ user?.email }}</p>
             </div>
           </div>
-          <div class="sm:col-span-2">
+          <div class="md:col-span-2">
             <nav
               aria-label="Account sections"
               class="tabs tabs-box tabs-sm mb-6 w-full"

--- a/app/pages/profile/keys.vue
+++ b/app/pages/profile/keys.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mb-8 text-center">
+  <div class="mb-8">
     <h1 class="text-4xl font-bold">API Keys</h1>
     <h2 class="mt-2">Bringing your API keys to use LLMs from different providers</h2>
   </div>


### PR DESCRIPTION
## Summary

- The `profile` layout introduced in #313 never replicated the `max-w-4xl mx-auto py-8 px-3 sm:px-24` container that `profile/keys.vue` previously got for free from the `default` layout (it had no explicit `layout:` before #313), so `/profile/settings` and `/profile/keys` rendered full-bleed with no side margins on desktop.
- Wraps `profile.vue` in the same `relative z-30` / `max-w-4xl mx-auto py-8 px-3 sm:px-24` container used by `default.vue` and `legal.vue`, and switches the avatar/content split from `sm:grid-cols-3` to `md:grid-cols-3` so the 640–768px band stays single-column instead of cramming both panes into the narrower inset.
- Makes the "Account sections" tabs stretch full width (`tabs-sm`, `w-full`, `tab grow`) instead of shrinking to fit.
- Left-aligns the API Keys page title and subtitle instead of centering them.

## Test plan

- [x] `pnpm run format && pnpm run typecheck` — clean
- [x] Manually verified in Chrome (signed-in session) at ~1104px: container renders with visible side margins, avatar/tabs columns are proportionate, tabs fill the box width evenly, API Keys title/subtitle render left-aligned
- [x] `pnpm run test:unit` — 1145 passed
- [x] `pnpm run test:integration` — 348 passed
- [x] `pnpm run test:e2e` — 72 passed, 1 unrelated skip (iOS-gated theme test)
- [x] Opus code review — no blocking findings