### PR TITLE
Redesign model picker with dynamically-fetched model metadata

### DIFF
--- a/.drizzle/migrations/20260731225326_ancient_cardiac/migration.sql
+++ b/.drizzle/migrations/20260731225326_ancient_cardiac/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_settings` ADD `favorite_models` text;

--- a/.drizzle/migrations/20260731225326_ancient_cardiac/snapshot.json
+++ b/.drizzle/migrations/20260731225326_ancient_cardiac/snapshot.json
@@ -1,0 +1,2592 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "920f4d5e-66d2-497b-9564-351a6e3f221e",
+  "prevIds": [
+    "091e9f38-701d-4fea-a7b8-c479014d0a9a"
+  ],
+  "ddl": [
+    {
+      "name": "accounts",
+      "entityType": "tables"
+    },
+    {
+      "name": "sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "users",
+      "entityType": "tables"
+    },
+    {
+      "name": "verifications",
+      "entityType": "tables"
+    },
+    {
+      "name": "user_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "projects",
+      "entityType": "tables"
+    },
+    {
+      "name": "chats",
+      "entityType": "tables"
+    },
+    {
+      "name": "messages",
+      "entityType": "tables"
+    },
+    {
+      "name": "keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "files",
+      "entityType": "tables"
+    },
+    {
+      "name": "chat_share_files",
+      "entityType": "tables"
+    },
+    {
+      "name": "chat_shares",
+      "entityType": "tables"
+    },
+    {
+      "name": "storages",
+      "entityType": "tables"
+    },
+    {
+      "name": "image_transform_usage_monthly",
+      "entityType": "tables"
+    },
+    {
+      "name": "image_generation_locks",
+      "entityType": "tables"
+    },
+    {
+      "name": "push_subscriptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "research_jobs",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_login_method",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "reasoning_expanded",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "reasoning_auto_hide",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "allow_external_links",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "notification_prompt_state",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sidebar_pinned",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "favorite_models",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "instructions",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'idle'",
+      "generated": null,
+      "name": "memory_status",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_updated_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_dirty_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_provider",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_model",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_error",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pinned_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activity_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "''",
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shared",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branched_from_share_slug",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pinned_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_memory_summary",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_memory_summary_updated_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activity_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "parts",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "tools",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'off'",
+      "generated": null,
+      "name": "reasoning",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "usage",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "api_key",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_key",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "size",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_message_id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_provider",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_model",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generation_cost",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_share_id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "revoked",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "indexable",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "show_files",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "show_metadata",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "show_author_avatar",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "allow_branch",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "20971520",
+      "generated": null,
+      "name": "storage",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'free'",
+      "generated": null,
+      "name": "tier",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "10",
+      "generated": null,
+      "name": "max_files_per_message",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1048576000",
+      "generated": null,
+      "name": "max_message_files_bytes",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "30",
+      "generated": null,
+      "name": "file_retention_days",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "image_transform_limit_total",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "image_transform_used_total",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "month_key",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "transforms_used",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1000",
+      "generated": null,
+      "name": "transforms_limit",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "endpoint",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "p256dh_key",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "auth_key",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_message_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "level",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_job_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "answers",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "usage",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "result_message_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "accounts_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "accounts"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sessions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "user_settings_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "user_settings"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "projects_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chats_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "projects",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "chats_project_id_projects_id_fk",
+      "entityType": "fks",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "messages_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "messages"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "keys_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "files_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "files"
+    },
+    {
+      "columns": [
+        "origin_message_id"
+      ],
+      "tableTo": "messages",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "files_origin_message_id_messages_id_fk",
+      "entityType": "fks",
+      "table": "files"
+    },
+    {
+      "columns": [
+        "chat_share_id"
+      ],
+      "tableTo": "chat_shares",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_share_files_chat_share_id_chat_shares_id_fk",
+      "entityType": "fks",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        "file_id"
+      ],
+      "tableTo": "files",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_share_files_file_id_files_id_fk",
+      "entityType": "fks",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_shares_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "storages_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "storages"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "push_subscriptions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_research_jobs_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pk",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pk",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pk",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pk",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_settings_pk",
+      "table": "user_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pk",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chats_pk",
+      "table": "chats",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "messages_pk",
+      "table": "messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "keys_pk",
+      "table": "keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "files_pk",
+      "table": "files",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chat_share_files_pk",
+      "table": "chat_share_files",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chat_shares_pk",
+      "table": "chat_shares",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "storages_pk",
+      "table": "storages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "month_key"
+      ],
+      "nameExplicit": false,
+      "name": "image_transform_usage_monthly_pk",
+      "table": "image_transform_usage_monthly",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "image_generation_locks_pk",
+      "table": "image_generation_locks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "push_subscriptions_pk",
+      "table": "push_subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "research_jobs_pk",
+      "table": "research_jobs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "table": "accounts"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "table": "verifications"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_user_settings_user",
+      "entityType": "indexes",
+      "table": "user_settings"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_project_user",
+      "entityType": "indexes",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        {
+          "value": "activity_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_projects_activity_at",
+      "entityType": "indexes",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_user",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_slug",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "activity_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_chats_activity_at",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "chat_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_message_chat",
+      "entityType": "indexes",
+      "table": "messages"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_key_user",
+      "entityType": "indexes",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_key_user_provider",
+      "entityType": "indexes",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_file_user",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "storage_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_file_storageKey",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_files_expires_at",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_files_user_id",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_share_id",
+          "isExpression": false
+        },
+        {
+          "value": "file_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_file",
+      "entityType": "indexes",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_chat",
+      "entityType": "indexes",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_slug",
+      "entityType": "indexes",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_chat_id",
+      "entityType": "indexes",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_storage_user",
+      "entityType": "indexes",
+      "table": "storages"
+    },
+    {
+      "columns": [
+        {
+          "value": "endpoint",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_push_subscriptions_endpoint",
+      "entityType": "indexes",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_push_subscriptions_user_id",
+      "entityType": "indexes",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "status in ('pending', 'running')",
+      "origin": "manual",
+      "name": "uq_research_jobs_chat_active",
+      "entityType": "indexes",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_research_jobs_status_created",
+      "entityType": "indexes",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_research_jobs_user",
+      "entityType": "indexes",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        "token"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_token_unique",
+      "entityType": "uniques",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "email"
+      ],
+      "nameExplicit": false,
+      "name": "users_email_unique",
+      "entityType": "uniques",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "chats_slug_unique",
+      "entityType": "uniques",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "public_id"
+      ],
+      "nameExplicit": false,
+      "name": "messages_public_id_unique",
+      "entityType": "uniques",
+      "table": "messages"
+    }
+  ],
+  "renames": []
+}

--- a/.github/workflows/models-drift-check.yml
+++ b/.github/workflows/models-drift-check.yml
@@ -1,0 +1,77 @@
+name: Models Metadata Drift Check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: models-drift-check
+  cancel-in-progress: true
+
+jobs:
+  check-drift:
+    name: Check models.dev drift
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fetch model metadata
+        shell: bash
+        run: |
+          pnpm run models:fetch 2>&1 | tee "$RUNNER_TEMP/models-fetch.log"
+
+      - name: Check for snapshot changes
+        id: diff
+        run: |
+          if [ -n "$(git status --porcelain providers/data/models-dev-snapshot.json)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build pull request body
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          {
+            echo "Automated weekly refresh of"
+            echo "\`providers/data/models-dev-snapshot.json\` from models.dev,"
+            echo "matching the dependabot schedule."
+            echo ""
+            echo "Audit output from \`scripts/audit-curated-models.mjs\`"
+            echo "(see \`docs/models-data-fetching.md\`):"
+            echo ""
+            echo '```'
+            cat "$RUNNER_TEMP/models-fetch.log"
+            echo '```'
+          } > "$RUNNER_TEMP/pr-body.md"
+
+      - name: Open pull request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(models): refresh models.dev metadata snapshot"
+          title: "chore(models): refresh models.dev metadata snapshot"
+          body-path: ${{ runner.temp }}/pr-body.md
+          branch: chore/models-metadata-drift
+          add-paths: providers/data/models-dev-snapshot.json
+          labels: dependencies

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy Preview
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: github.event.workflow_run.conclusion == 'success'
     permissions:
       id-token: write

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   resolve-preview-context:
     name: Resolve preview context
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       pr-number: ${{ steps.pr.outputs.number }}
       is-direct: ${{ steps.direct-push.outputs.is-direct }}
@@ -87,7 +87,7 @@ jobs:
   build-production:
     name: Build and Deploy to Production
     needs: resolve-preview-context
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       deployment-url: ${{ steps.deploy.outputs.deployment-url }}
       bundle-size: ${{ steps.bundle-size.outputs.bundle-size }}
@@ -355,7 +355,7 @@ jobs:
     needs:
       - resolve-preview-context
       - build-production
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     env:
@@ -421,7 +421,7 @@ jobs:
       - resolve-preview-context
       - build-production
     if: needs.resolve-preview-context.outputs.is-direct == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 
@@ -485,7 +485,7 @@ jobs:
       - update-preview
       - deploy-preview-direct-push
     if: always()
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,13 @@ The first bookmark whose timestamp predates the migration is **not necessarily s
   (`llms.txt`, dynamic OG images, `nuxt-schema-org`, `/uk`, sitemap `lastmod`,
   indexing shared chats), the off-page checklist, and the SWR/buildId
   post-deploy verification trap
+- `docs/models-data-fetching.md` - Model catalog architecture: curated
+  capabilities (`providers/*.ts`) merged at import time with objective
+  metadata fetched from models.dev (`providers/data/*.snapshot.json`,
+  `scripts/fetch-models-metadata.mjs`); the per-field merge policy; why a
+  curated-id-driven join can't pull in junk/legacy/open-weights models;
+  the `EXEMPT_IDS` hard-fail behavior; DB-persisted cross-device favorites;
+  owner action items and known trade-offs
 
 ### Tech Stack
 

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -343,7 +343,6 @@ Meanwhile dark:xx and light:xx in *.vue templates will still work as expected.
 
   &[data-tip]::before {
     color: currentColor;
-    border: 1px solid color-mix(in oklab, currentColor 25%, transparent);
     font-size: 0.75rem;
     font-weight: 500;
   }

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -334,6 +334,21 @@ Meanwhile dark:xx and light:xx in *.vue templates will still work as expected.
 @utility bottom-safe {
   bottom: calc(env(safe-area-inset-bottom, 0));
 }
+@utility capability-chip {
+  background-color: color-mix(in oklab, currentColor 15%, var(--color-base-100));
+}
+
+@utility tooltip-soft {
+  --tt-bg: color-mix(in oklab, currentColor 18%, var(--color-base-100));
+
+  &[data-tip]::before {
+    color: currentColor;
+    border: 1px solid color-mix(in oklab, currentColor 25%, transparent);
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+}
+
 @utility bubble-without-background {
   @apply rounded-2xl backdrop-blur-lg backdrop-saturate-150;
 }

--- a/app/components/ChatInput/ModelsTrigger.vue
+++ b/app/components/ChatInput/ModelsTrigger.vue
@@ -1,13 +1,19 @@
 <template>
-  <details
-    ref="dropdown"
-    class="group dropdown dropdown-top"
+  <div
+    ref="root"
+    class="relative"
   >
-    <summary
+    <button
+      ref="trigger"
+      type="button"
       aria-label="Select model"
       data-testid="current-model-trigger"
       class="btn btn-ghost btn-sm rounded-full [--size:calc(var(--size-field)_*_6)] transition-colors duration-200 max-xxs:max-w-40"
-      :class="{ 'btn-active': isDropdownHovered }"
+      :class="{ 'btn-active': isOpen }"
+      aria-haspopup="listbox"
+      :aria-expanded="isOpen"
+      :aria-controls="panelId"
+      @click="toggle"
     >
       <SvgoGeminiShort
         v-if="getModel(toValue(userModel)).provider?.id === 'google'"
@@ -23,121 +29,141 @@
       <Icon
         name="lucide:chevron-down"
         size="14"
-        class="group-open:scale-y-[-1]"
+        :class="{ 'scale-y-[-1]': isOpen }"
       />
-    </summary>
+    </button>
     <ClientOnly>
-      <div class="dropdown-content z-50 w-64 pb-2">
-        <div class="bg-base-100 rounded-box w-full shadow-sm">
-          <ul class="menu menu-xs w-full">
-            <li
-              v-for="provider in providers"
-              :key="provider.id"
+      <Transition
+        enter-active-class="transition-[opacity,scale] duration-200 ease-[cubic-bezier(0.4,0,0.2,1)] origin-bottom"
+        leave-active-class="transition-[opacity,scale] duration-200 ease-[cubic-bezier(0.4,0,0.2,1)] origin-bottom"
+        enter-from-class="opacity-0 scale-95"
+        leave-to-class="opacity-0 scale-95"
+      >
+        <div
+          v-if="isOpen"
+          :id="panelId"
+          data-testid="models-picker-panel"
+          class="absolute bottom-full left-0 z-50 mb-2 w-[min(30rem,calc(100vw-4rem))]"
+        >
+          <div
+            class="bubble-without-background flex flex-col max-h-[60dvh] bg-base-100/90 border border-base-content/10 shadow-xl"
+          >
+            <div
+              class="shrink-0 flex items-center gap-1 p-2 border-b border-base-content/10"
             >
-              <span class="menu-title flex items-center gap-2">
-                <SvgoGeminiShort
-                  v-if="provider.id === 'google'"
-                  class="w-4 fill-base-content/40"
-                />
-                <SvgoOpenai
-                  v-if="provider.id === 'openai'"
-                  class="w-4 fill-base-content/40"
-                />
-                {{ provider.name }}
-              </span>
-              <ul>
-                <li
-                  v-for="model in provider.models"
-                  :key="model.id"
+              <ChatInputModelsTriggerSearch
+                v-model="searchQuery"
+                :autofocus="$device.isDesktop"
+                :controls="listboxId"
+                :active-descendant="highlightedOptionId"
+                class="grow min-w-0"
+                @keydown="onSearchKeydown"
+              />
+              <ChatInputModelsTriggerFilterDropdown
+                v-model="activeCategories"
+              />
+            </div>
+            <div class="relative flex flex-1 min-h-0">
+              <ChatInputModelsTriggerProviderRail
+                v-if="!isSearching"
+                :providers="providers"
+                :active-provider-id="activeProviderId"
+                :is-favorites-only="isFavoritesOnly"
+                :has-favorites="hasFavorites"
+                @toggle-provider="toggleProvider"
+                @toggle-favorites="toggleFavoritesOnly"
+              />
+              <div
+                :id="listboxId"
+                ref="resultsContainer"
+                role="listbox"
+                aria-label="Models"
+                class="flex-1 min-h-[14rem] overflow-y-auto p-1.5"
+              >
+                <template
+                  v-for="section in sections"
+                  :key="section.id"
                 >
-                  <button
-                    type="button"
-                    class="flex items-center"
-                    :class="{
-                      'bg-accent text-accent-content pointer-events-none':
-                        userModel === model.id,
-                      'tooltip tooltip-right': $device.isDesktop
-                    }"
-                    :aria-label="`Choose ${model.name}`"
-                    :data-tip="getModelPriceTip(model)"
-                    @click="selectModel(model.id)"
+                  <p
+                    v-if="section.label"
+                    :id="`${section.id}-label`"
+                    class="px-2 pt-1.5 pb-1 text-[0.65rem] font-semibold uppercase tracking-wide opacity-50"
                   >
-                    <span class="grow">{{ model.name }}</span>
-                    <span class="shrink-0 flex gap-1 items-center">
-                      <span
-                        v-if="model.reasoning"
-                        class="shrink-0 flex items-center p-0.5 rounded-full bg-warning-content"
-                        :class="{
-                          'tooltip tooltip-warning tooltip-top':
-                            $device.isDesktop
-                        }"
-                        data-tip="Reasoning"
-                      >
-                        <Icon
-                          name="lucide:brain"
-                          class="text-warning"
-                        />
-                      </span>
-                      <span
-                        v-if="model.tools.includes('web_search')"
-                        class="shrink-0 flex items-center p-0.5 rounded-full bg-info-content"
-                        :class="{
-                          'tooltip tooltip-info tooltip-top':
-                            $device.isDesktop
-                        }"
-                        data-tip="Web search"
-                      >
-                        <Icon
-                          v-if="model.tools.includes('web_search')"
-                          name="lucide:globe"
-                          class="text-info"
-                        />
-                      </span>
-                      <span
-                        v-if="model.tools.includes('image_generation')
-                          || isImageGenerationModel(model)
-                        "
-                        data-testid="model-image-generation-capability"
-                        class="shrink-0 flex items-center p-0.5 rounded-full bg-green-100 dark:bg-secondary-content"
-                        :class="{
-                          'tooltip tooltip-secondary tooltip-top':
-                            $device.isDesktop
-                        }"
-                        data-tip="Image generation"
-                      >
-                        <Icon
-                          name="lucide:image-plus"
-                          class="text-green-800 dark:text-secondary"
-                        />
-                      </span>
-                      <span
-                        v-if="model.research"
-                        class="shrink-0 flex items-center p-0.5 rounded-full bg-[color-mix(in_oklab,var(--color-success)_15%,var(--color-base-100))] text-success"
-                        :class="{
-                          'tooltip tooltip-success tooltip-top':
-                            $device.isDesktop
-                        }"
-                        data-tip="Deep research"
-                      >
-                        <Icon
-                          name="lucide:telescope"
-                          class="text-success"
-                        />
-                      </span>
-                    </span>
+                    {{ section.label }}
+                  </p>
+                  <ul
+                    class="flex flex-col gap-0.5"
+                    :role="section.label ? 'group' : 'presentation'"
+                    :aria-labelledby="section.label
+                      ? `${section.id}-label`
+                      : undefined
+                    "
+                  >
+                    <ChatInputModelsTriggerModelItem
+                      v-for="entry in section.entries"
+                      :key="entry.model.id"
+                      :model="entry.model"
+                      :provider-id="entry.providerId"
+                      :is-selected="userModel === entry.model.id"
+                      :is-highlighted="highlightedModelId === entry.model.id"
+                      :is-favorite="favoriteModels.includes(entry.model.id)"
+                      :is-detail-open="detailModelId === entry.model.id"
+                      @select="selectModel(entry.model.id)"
+                      @toggle-favorite="toggleFavoriteModel(entry.model.id)"
+                      @show-detail="showDetail(entry.model.id)"
+                      @hide-detail="hideDetail(entry.model.id)"
+                      @toggle-detail="toggleDetail(entry.model.id)"
+                    />
+                  </ul>
+                </template>
+                <div
+                  v-if="!filteredModels.length"
+                  data-testid="models-picker-empty"
+                  role="presentation"
+                  class="flex flex-col items-center gap-2 px-4 py-10 text-center"
+                >
+                  <Icon
+                    name="lucide:search-x"
+                    size="24"
+                    class="opacity-40"
+                  />
+                  <p class="text-xs opacity-60">
+                    {{ emptyMessage }}
+                  </p>
+                  <button
+                    v-if="hasActiveFilters"
+                    type="button"
+                    data-testid="models-picker-clear-filters"
+                    class="btn btn-ghost btn-xs rounded-full text-accent"
+                    @click="clearFilters"
+                  >
+                    Clear filters
                   </button>
-                </li>
-              </ul>
-            </li>
-          </ul>
+                </div>
+              </div>
+              <ChatInputModelsTriggerModelDetail
+                v-if="detailEntry"
+                :model="detailEntry.model"
+                :provider-name="detailEntry.providerName"
+                :is-interactive="!$device.isDesktop"
+                @close="closeDetail"
+                @show-detail="showDetail(detailEntry.model.id)"
+                @hide-detail="hideDetail(detailEntry.model.id)"
+              />
+            </div>
+          </div>
         </div>
-      </div>
+      </Transition>
     </ClientOnly>
-  </details>
+  </div>
 </template>
 
 <script setup lang="ts">
-import type { Model } from '#shared/types/providers.d'
+import type {
+  ModelCategory,
+  PickerModel,
+  PickerSection,
+} from '~/types/models-picker'
 
 defineProps<{
   isWebSearchEnabled: boolean
@@ -147,45 +173,344 @@ defineProps<{
 
 const { userModel } = useUserModel()
 const { providers } = getProviders()
-const { isIos, isAndroid } = useDevice()
+const { favoriteModels, toggleFavoriteModel } = useUserSetting()
 
-function getModelPriceTip(model: Model): string | undefined {
-  if (model.research) {
-    return `${model.research.costEstimate} · ${model.research.timeEstimate}`
+const isOpen = shallowRef<boolean>(false)
+const searchQuery = shallowRef<string>('')
+const activeProviderId = shallowRef<string | null>(null)
+const isFavoritesOnly = shallowRef<boolean>(false)
+const activeCategories = shallowRef<ModelCategory[]>([])
+const detailModelId = shallowRef<string | null>(null)
+const highlightedModelId = shallowRef<string | null>(null)
+const root = useTemplateRef<HTMLDivElement>('root')
+const trigger = useTemplateRef<HTMLButtonElement>('trigger')
+const resultsContainer = useTemplateRef<HTMLDivElement>('resultsContainer')
+const panelId = useId()
+const listboxId = useId()
+
+let hideDetailTimeoutId: ReturnType<typeof setTimeout> | undefined
+
+const allModels = computed<PickerModel[]>(() => {
+  return providers.flatMap((provider) => {
+    return provider.models.map((model) => {
+      return {
+        model,
+        providerId: provider.id,
+        providerName: provider.name,
+      }
+    })
+  })
+})
+
+const searchTerm = computed<string>(() => {
+  return searchQuery.value.trim().toLowerCase()
+})
+
+const isSearching = computed<boolean>(() => {
+  return searchTerm.value.length > 0
+})
+
+const hasFavorites = computed<boolean>(() => {
+  return favoriteModels.value.length > 0
+})
+
+const isRailFilterApplied = computed<boolean>(() => {
+  if (isSearching.value) {
+    return false
   }
 
-  if (!model.price) {
+  return !!activeProviderId.value || isFavoritesOnly.value
+})
+
+const hasActiveFilters = computed<boolean>(() => {
+  return activeCategories.value.length > 0 || isRailFilterApplied.value
+})
+
+const filteredModels = computed<PickerModel[]>(() => {
+  return allModels.value.filter(({ model, providerId }) => {
+    const matchesSearch = !isSearching.value
+      || model.name.toLowerCase().includes(searchTerm.value)
+
+    if (!matchesSearch) {
+      return false
+    }
+
+    if (
+      activeCategories.value.length
+      && !activeCategories.value.includes(getModelCategory(model))
+    ) {
+      return false
+    }
+
+    if (!isRailFilterApplied.value) {
+      return true
+    }
+
+    if (isFavoritesOnly.value && !favoriteModels.value.includes(model.id)) {
+      return false
+    }
+
+    return !activeProviderId.value || providerId === activeProviderId.value
+  })
+})
+
+const sections = computed<PickerSection[]>(() => {
+  const favorites = filteredModels.value.filter(({ model }) => {
+    return favoriteModels.value.includes(model.id)
+  })
+  const others = filteredModels.value.filter(({ model }) => {
+    return !favoriteModels.value.includes(model.id)
+  })
+
+  if (!favorites.length || !others.length) {
+    return [{ id: 'all', label: '', entries: [...favorites, ...others] }]
+  }
+
+  return [
+    { id: 'favorites', label: 'Favorites', entries: favorites },
+    { id: 'others', label: 'Other models', entries: others },
+  ]
+})
+
+const detailEntry = computed<PickerModel | null>(() => {
+  const entry = allModels.value.find(({ model }) => {
+    return model.id === detailModelId.value
+  })
+
+  return entry ?? null
+})
+
+const highlightedOptionId = computed<string | undefined>(() => {
+  if (!highlightedModelId.value) {
     return undefined
   }
 
-  return model.price.display ?? `${model.price.input} / ${model.price.output}`
-}
-
-const dropdown = useTemplateRef<HTMLDetailsElement>('dropdown')
-const isDropdownHovered = useElementHover(dropdown)
-
-onClickOutside(dropdown, () => {
-  if (dropdown.value?.open) {
-    dropdown.value.open = false
-  }
+  return `model-option-${highlightedModelId.value}`
 })
 
-watch(isDropdownHovered, (hovered) => {
-  if (!dropdown.value || isIos || isAndroid) {
+const emptyMessage = computed<string>(() => {
+  if (hasActiveFilters.value) {
+    return 'No models match the selected filters.'
+  }
+
+  return `No models match “${searchQuery.value.trim()}”.`
+})
+
+function close() {
+  isOpen.value = false
+  highlightedModelId.value = null
+  searchQuery.value = ''
+  closeDetail()
+}
+
+function closeAndRestoreFocus() {
+  close()
+  trigger.value?.focus()
+}
+
+function toggle() {
+  if (isOpen.value) {
+    close()
+
     return
   }
 
-  dropdown.value.open = hovered
-}, {
-  immediate: false,
-  flush: 'post',
-})
+  isOpen.value = true
+  highlightedModelId.value = toValue(userModel)
+  scrollHighlightedIntoView()
+}
+
+function toggleProvider(providerId: string) {
+  closeDetail()
+  activeProviderId.value = activeProviderId.value === providerId
+    ? null
+    : providerId
+}
+
+function toggleFavoritesOnly() {
+  closeDetail()
+  isFavoritesOnly.value = !isFavoritesOnly.value
+}
+
+function clearFilters() {
+  activeCategories.value = []
+  activeProviderId.value = null
+  isFavoritesOnly.value = false
+  searchQuery.value = ''
+}
+
+function clearHideDetailTimeout() {
+  if (hideDetailTimeoutId === undefined) {
+    return
+  }
+
+  clearTimeout(hideDetailTimeoutId)
+  hideDetailTimeoutId = undefined
+}
+
+function closeDetail() {
+  clearHideDetailTimeout()
+  detailModelId.value = null
+}
+
+function showDetail(modelId: string) {
+  clearHideDetailTimeout()
+  detailModelId.value = modelId
+}
+
+/**
+ * Hiding is delayed so the pointer can cross the dead space between the
+ * info button and the absolutely-positioned detail card without the card
+ * tearing down before `mouseenter` on the card itself can cancel this.
+ */
+function hideDetail(modelId: string) {
+  clearHideDetailTimeout()
+
+  hideDetailTimeoutId = setTimeout(() => {
+    if (detailModelId.value !== modelId) {
+      return
+    }
+
+    detailModelId.value = null
+  }, 100)
+}
+
+function toggleDetail(modelId: string) {
+  clearHideDetailTimeout()
+  detailModelId.value = detailModelId.value === modelId ? null : modelId
+}
 
 function selectModel(modelId: string) {
   userModel.value = modelId
+  closeAndRestoreFocus()
+}
 
-  if (dropdown.value) {
-    dropdown.value.open = false
+async function scrollHighlightedIntoView() {
+  await nextTick()
+
+  if (!highlightedModelId.value) {
+    return
+  }
+
+  const element = resultsContainer.value?.querySelector<HTMLElement>(
+    `[id="model-option-${highlightedModelId.value}"]`,
+  )
+
+  element?.scrollIntoView?.({ block: 'nearest' })
+}
+
+function highlightFirst() {
+  highlightedModelId.value = filteredModels.value[0]?.model.id ?? null
+  scrollHighlightedIntoView()
+}
+
+function highlightLast() {
+  const models = filteredModels.value
+
+  highlightedModelId.value = models[models.length - 1]?.model.id ?? null
+  scrollHighlightedIntoView()
+}
+
+function moveHighlight(step: number) {
+  const models = filteredModels.value
+
+  if (!models.length) {
+    return
+  }
+
+  const currentIndex = models.findIndex(({ model }) => {
+    return model.id === highlightedModelId.value
+  })
+
+  const nextIndex = currentIndex === -1
+    ? 0
+    : (currentIndex + step + models.length) % models.length
+
+  highlightedModelId.value = models[nextIndex]?.model.id ?? null
+  scrollHighlightedIntoView()
+}
+
+function selectHighlighted() {
+  if (!highlightedModelId.value) {
+    return
+  }
+
+  selectModel(highlightedModelId.value)
+}
+
+function onSearchKeydown(event: KeyboardEvent) {
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveHighlight(1)
+
+    return
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveHighlight(-1)
+
+    return
+  }
+
+  if (event.key === 'Home') {
+    event.preventDefault()
+    highlightFirst()
+
+    return
+  }
+
+  if (event.key === 'End') {
+    event.preventDefault()
+    highlightLast()
+
+    return
+  }
+
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    selectHighlighted()
   }
 }
+
+watch(hasFavorites, (value) => {
+  if (value) {
+    return
+  }
+
+  isFavoritesOnly.value = false
+})
+
+watch([searchTerm, activeCategories, activeProviderId, isFavoritesOnly], () => {
+  closeDetail()
+  highlightedModelId.value = filteredModels.value[0]?.model.id ?? null
+})
+
+onClickOutside(root, () => {
+  if (!isOpen.value) {
+    return
+  }
+
+  close()
+})
+
+onKeyStroke('Escape', () => {
+  if (!isOpen.value) {
+    return
+  }
+
+  if (detailModelId.value) {
+    closeDetail()
+
+    return
+  }
+
+  if (searchQuery.value) {
+    searchQuery.value = ''
+
+    return
+  }
+
+  closeAndRestoreFocus()
+})
 </script>

--- a/app/components/ChatInput/ModelsTrigger.vue
+++ b/app/components/ChatInput/ModelsTrigger.vue
@@ -60,7 +60,7 @@
                 @keydown="onSearchKeydown"
               />
               <ChatInputModelsTriggerFilterDropdown
-                v-model="activeCategories"
+                v-model="activeCategory"
               />
             </div>
             <div class="relative flex flex-1 min-h-0">
@@ -179,7 +179,7 @@ const isOpen = shallowRef<boolean>(false)
 const searchQuery = shallowRef<string>('')
 const activeProviderId = shallowRef<string | null>(null)
 const isFavoritesOnly = shallowRef<boolean>(false)
-const activeCategories = shallowRef<ModelCategory[]>([])
+const activeCategory = shallowRef<ModelCategory | null>(null)
 const detailModelId = shallowRef<string | null>(null)
 const highlightedModelId = shallowRef<string | null>(null)
 const root = useTemplateRef<HTMLDivElement>('root')
@@ -223,7 +223,7 @@ const isRailFilterApplied = computed<boolean>(() => {
 })
 
 const hasActiveFilters = computed<boolean>(() => {
-  return activeCategories.value.length > 0 || isRailFilterApplied.value
+  return activeCategory.value !== null || isRailFilterApplied.value
 })
 
 const filteredModels = computed<PickerModel[]>(() => {
@@ -236,8 +236,8 @@ const filteredModels = computed<PickerModel[]>(() => {
     }
 
     if (
-      activeCategories.value.length
-      && !activeCategories.value.includes(getModelCategory(model))
+      activeCategory.value !== null
+      && getModelCategory(model) !== activeCategory.value
     ) {
       return false
     }
@@ -333,7 +333,7 @@ function toggleFavoritesOnly() {
 }
 
 function clearFilters() {
-  activeCategories.value = []
+  activeCategory.value = null
   activeProviderId.value = null
   isFavoritesOnly.value = false
   searchQuery.value = ''
@@ -481,7 +481,7 @@ watch(hasFavorites, (value) => {
   isFavoritesOnly.value = false
 })
 
-watch([searchTerm, activeCategories, activeProviderId, isFavoritesOnly], () => {
+watch([searchTerm, activeCategory, activeProviderId, isFavoritesOnly], () => {
   closeDetail()
   highlightedModelId.value = filteredModels.value[0]?.model.id ?? null
 })

--- a/app/components/ChatInput/ModelsTrigger.vue
+++ b/app/components/ChatInput/ModelsTrigger.vue
@@ -63,7 +63,7 @@
                 v-model="activeCategory"
               />
             </div>
-            <div class="relative flex flex-1 min-h-0">
+            <div class="flex flex-1 min-h-0">
               <ChatInputModelsTriggerProviderRail
                 v-if="!isSearching"
                 :providers="providers"
@@ -99,21 +99,38 @@
                       : undefined
                     "
                   >
-                    <ChatInputModelsTriggerModelItem
+                    <template
                       v-for="entry in section.entries"
                       :key="entry.model.id"
-                      :model="entry.model"
-                      :provider-id="entry.providerId"
-                      :is-selected="userModel === entry.model.id"
-                      :is-highlighted="highlightedModelId === entry.model.id"
-                      :is-favorite="favoriteModels.includes(entry.model.id)"
-                      :is-detail-open="detailModelId === entry.model.id"
-                      @select="selectModel(entry.model.id)"
-                      @toggle-favorite="toggleFavoriteModel(entry.model.id)"
-                      @show-detail="showDetail(entry.model.id)"
-                      @hide-detail="hideDetail(entry.model.id)"
-                      @toggle-detail="toggleDetail(entry.model.id)"
-                    />
+                    >
+                      <ChatInputModelsTriggerModelItem
+                        :model="entry.model"
+                        :provider-id="entry.providerId"
+                        :is-selected="userModel === entry.model.id"
+                        :is-highlighted="highlightedModelId === entry.model.id"
+                        :is-favorite="favoriteModels.includes(entry.model.id)"
+                        :is-detail-open="detailModelId === entry.model.id"
+                        @select="selectModel(entry.model.id)"
+                        @toggle-favorite="toggleFavoriteModel(entry.model.id)"
+                        @show-detail="showDetail(entry.model.id)"
+                        @hide-detail="hideDetail(entry.model.id)"
+                        @toggle-detail="toggleDetail(entry.model.id)"
+                      />
+                      <li
+                        v-if="detailModelId === entry.model.id"
+                        role="presentation"
+                        class="py-0.5"
+                      >
+                        <ChatInputModelsTriggerModelDetail
+                          :model="entry.model"
+                          :provider-name="entry.providerName"
+                          :is-interactive="!$device.isDesktop"
+                          @close="closeDetail"
+                          @show-detail="showDetail(entry.model.id)"
+                          @hide-detail="hideDetail(entry.model.id)"
+                        />
+                      </li>
+                    </template>
                   </ul>
                 </template>
                 <div
@@ -141,15 +158,6 @@
                   </button>
                 </div>
               </div>
-              <ChatInputModelsTriggerModelDetail
-                v-if="detailEntry"
-                :model="detailEntry.model"
-                :provider-name="detailEntry.providerName"
-                :is-interactive="!$device.isDesktop"
-                @close="closeDetail"
-                @show-detail="showDetail(detailEntry.model.id)"
-                @hide-detail="hideDetail(detailEntry.model.id)"
-              />
             </div>
           </div>
         </div>
@@ -272,14 +280,6 @@ const sections = computed<PickerSection[]>(() => {
   ]
 })
 
-const detailEntry = computed<PickerModel | null>(() => {
-  const entry = allModels.value.find(({ model }) => {
-    return model.id === detailModelId.value
-  })
-
-  return entry ?? null
-})
-
 const highlightedOptionId = computed<string | undefined>(() => {
   if (!highlightedModelId.value) {
     return undefined
@@ -316,8 +316,7 @@ function toggle() {
   }
 
   isOpen.value = true
-  highlightedModelId.value = toValue(userModel)
-  scrollHighlightedIntoView()
+  setHighlight(toValue(userModel))
 }
 
 function toggleProvider(providerId: string) {
@@ -359,8 +358,8 @@ function showDetail(modelId: string) {
 }
 
 /**
- * Hiding is delayed so the pointer can cross the dead space between the
- * info button and the absolutely-positioned detail card without the card
+ * Hiding is delayed so the pointer can cross the row padding and list gap
+ * separating the info button from the adjacent detail card without the card
  * tearing down before `mouseenter` on the card itself can cancel this.
  */
 function hideDetail(modelId: string) {
@@ -399,16 +398,24 @@ async function scrollHighlightedIntoView() {
   element?.scrollIntoView?.({ block: 'nearest' })
 }
 
-function highlightFirst() {
-  highlightedModelId.value = filteredModels.value[0]?.model.id ?? null
+/**
+ * Closing the detail keeps the inline detail card from shifting rows out from
+ * under the highlight while the user is arrowing through the list.
+ */
+function setHighlight(modelId: string | null) {
+  closeDetail()
+  highlightedModelId.value = modelId
   scrollHighlightedIntoView()
+}
+
+function highlightFirst() {
+  setHighlight(filteredModels.value[0]?.model.id ?? null)
 }
 
 function highlightLast() {
   const models = filteredModels.value
 
-  highlightedModelId.value = models[models.length - 1]?.model.id ?? null
-  scrollHighlightedIntoView()
+  setHighlight(models[models.length - 1]?.model.id ?? null)
 }
 
 function moveHighlight(step: number) {
@@ -426,8 +433,7 @@ function moveHighlight(step: number) {
     ? 0
     : (currentIndex + step + models.length) % models.length
 
-  highlightedModelId.value = models[nextIndex]?.model.id ?? null
-  scrollHighlightedIntoView()
+  setHighlight(models[nextIndex]?.model.id ?? null)
 }
 
 function selectHighlighted() {

--- a/app/components/ChatInput/ModelsTrigger.vue
+++ b/app/components/ChatInput/ModelsTrigger.vue
@@ -117,8 +117,6 @@
                           :is-detail-open="detailModelId === entry.model.id"
                           @select="selectModel(entry.model.id)"
                           @toggle-favorite="toggleFavoriteModel(entry.model.id)"
-                          @show-detail="showDetail(entry.model.id)"
-                          @hide-detail="hideDetail(entry.model.id)"
                           @toggle-detail="toggleDetail(entry.model.id)"
                         />
                         <li
@@ -129,10 +127,7 @@
                           <ChatInputModelsTriggerModelDetail
                             :model="entry.model"
                             :provider-name="entry.providerName"
-                            :is-interactive="!$device.isDesktop"
                             @close="closeDetail"
-                            @show-detail="showDetail(entry.model.id)"
-                            @hide-detail="hideDetail(entry.model.id)"
                           />
                         </li>
                       </template>
@@ -181,8 +176,6 @@
                         :is-highlighted="false"
                         :is-favorite="false"
                         :is-detail-open="detailModelId === entry.model.id"
-                        @show-detail="showDetail(entry.model.id)"
-                        @hide-detail="hideDetail(entry.model.id)"
                         @toggle-detail="toggleDetail(entry.model.id)"
                       />
                       <li
@@ -193,10 +186,7 @@
                         <ChatInputModelsTriggerModelDetail
                           :model="entry.model"
                           :provider-name="entry.providerName"
-                          :is-interactive="!$device.isDesktop"
                           @close="closeDetail"
-                          @show-detail="showDetail(entry.model.id)"
-                          @hide-detail="hideDetail(entry.model.id)"
                         />
                       </li>
                     </template>
@@ -266,8 +256,6 @@ const panelId = useId()
 const listboxId = useId()
 const legacyListId = useId()
 const legacyLabelId = useId()
-
-let hideDetailTimeoutId: ReturnType<typeof setTimeout> | undefined
 
 const allModels = computed<PickerModel[]>(() => {
   return providers.flatMap((provider) => {
@@ -453,44 +441,11 @@ function clearFilters() {
   searchQuery.value = ''
 }
 
-function clearHideDetailTimeout() {
-  if (hideDetailTimeoutId === undefined) {
-    return
-  }
-
-  clearTimeout(hideDetailTimeoutId)
-  hideDetailTimeoutId = undefined
-}
-
 function closeDetail() {
-  clearHideDetailTimeout()
   detailModelId.value = null
 }
 
-function showDetail(modelId: string) {
-  clearHideDetailTimeout()
-  detailModelId.value = modelId
-}
-
-/**
- * Hiding is delayed so the pointer can cross the row padding and list gap
- * separating the info button from the adjacent detail card without the card
- * tearing down before `mouseenter` on the card itself can cancel this.
- */
-function hideDetail(modelId: string) {
-  clearHideDetailTimeout()
-
-  hideDetailTimeoutId = setTimeout(() => {
-    if (detailModelId.value !== modelId) {
-      return
-    }
-
-    detailModelId.value = null
-  }, 100)
-}
-
 function toggleDetail(modelId: string) {
-  clearHideDetailTimeout()
   detailModelId.value = detailModelId.value === modelId ? null : modelId
 }
 

--- a/app/components/ChatInput/ModelsTrigger.vue
+++ b/app/components/ChatInput/ModelsTrigger.vue
@@ -74,44 +74,113 @@
                 @toggle-favorites="toggleFavoritesOnly"
               />
               <div
-                :id="listboxId"
                 ref="resultsContainer"
-                role="listbox"
-                aria-label="Models"
                 class="flex-1 min-h-[14rem] overflow-y-auto p-1.5"
+                :class="{ 'pb-9': filteredModels.length }"
               >
-                <template
-                  v-for="section in sections"
-                  :key="section.id"
+                <div
+                  :id="listboxId"
+                  role="listbox"
+                  aria-label="Models"
                 >
-                  <p
-                    v-if="section.label"
-                    :id="`${section.id}-label`"
-                    class="px-2 pt-1.5 pb-1 text-[0.65rem] font-semibold uppercase tracking-wide opacity-50"
+                  <template
+                    v-for="section in sections"
+                    :key="section.id"
                   >
-                    {{ section.label }}
-                  </p>
+                    <p
+                      v-if="section.label"
+                      :id="`${section.id}-label`"
+                      class="px-2 pt-1.5 pb-1 text-[0.65rem] font-semibold uppercase tracking-wide opacity-50"
+                    >
+                      {{ section.label }}
+                    </p>
+                    <ul
+                      class="flex flex-col gap-0.5"
+                      :role="section.label ? 'group' : 'presentation'"
+                      :aria-labelledby="section.label
+                        ? `${section.id}-label`
+                        : undefined
+                      "
+                    >
+                      <template
+                        v-for="entry in section.entries"
+                        :key="entry.model.id"
+                      >
+                        <ChatInputModelsTriggerModelItem
+                          :model="entry.model"
+                          :provider-id="entry.providerId"
+                          :is-selected="userModel === entry.model.id"
+                          :is-highlighted="
+                            highlightedModelId === entry.model.id
+                          "
+                          :is-favorite="favoriteModels.includes(entry.model.id)"
+                          :is-detail-open="detailModelId === entry.model.id"
+                          @select="selectModel(entry.model.id)"
+                          @toggle-favorite="toggleFavoriteModel(entry.model.id)"
+                          @show-detail="showDetail(entry.model.id)"
+                          @hide-detail="hideDetail(entry.model.id)"
+                          @toggle-detail="toggleDetail(entry.model.id)"
+                        />
+                        <li
+                          v-if="detailModelId === entry.model.id"
+                          role="presentation"
+                          class="py-0.5"
+                        >
+                          <ChatInputModelsTriggerModelDetail
+                            :model="entry.model"
+                            :provider-name="entry.providerName"
+                            :is-interactive="!$device.isDesktop"
+                            @close="closeDetail"
+                            @show-detail="showDetail(entry.model.id)"
+                            @hide-detail="hideDetail(entry.model.id)"
+                          />
+                        </li>
+                      </template>
+                    </ul>
+                  </template>
+                </div>
+                <div
+                  v-if="legacyModels.length"
+                  data-testid="models-picker-legacy"
+                  class="mt-1 pt-1 border-t border-base-content/10"
+                >
+                  <button
+                    :id="legacyLabelId"
+                    type="button"
+                    data-testid="models-picker-legacy-toggle"
+                    class="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-xl text-[0.65rem] font-semibold uppercase tracking-wide opacity-50 cursor-pointer transition-colors hover:bg-base-content/5 hover:opacity-80"
+                    :aria-expanded="isLegacyExpanded"
+                    :aria-controls="legacyListId"
+                    @click="toggleLegacy"
+                  >
+                    <Icon
+                      name="lucide:chevron-right"
+                      size="12"
+                      class="transition-transform"
+                      :class="{ 'rotate-90': isLegacyExpanded }"
+                    />
+                    {{ legacyLabel }}
+                  </button>
                   <ul
+                    v-show="isLegacyExpanded"
+                    :id="legacyListId"
+                    data-testid="models-picker-legacy-list"
+                    role="listbox"
+                    :aria-labelledby="legacyLabelId"
                     class="flex flex-col gap-0.5"
-                    :role="section.label ? 'group' : 'presentation'"
-                    :aria-labelledby="section.label
-                      ? `${section.id}-label`
-                      : undefined
-                    "
                   >
                     <template
-                      v-for="entry in section.entries"
+                      v-for="entry in legacyModels"
                       :key="entry.model.id"
                     >
                       <ChatInputModelsTriggerModelItem
                         :model="entry.model"
                         :provider-id="entry.providerId"
-                        :is-selected="userModel === entry.model.id"
-                        :is-highlighted="highlightedModelId === entry.model.id"
-                        :is-favorite="favoriteModels.includes(entry.model.id)"
+                        is-legacy
+                        :is-selected="false"
+                        :is-highlighted="false"
+                        :is-favorite="false"
                         :is-detail-open="detailModelId === entry.model.id"
-                        @select="selectModel(entry.model.id)"
-                        @toggle-favorite="toggleFavoriteModel(entry.model.id)"
                         @show-detail="showDetail(entry.model.id)"
                         @hide-detail="hideDetail(entry.model.id)"
                         @toggle-detail="toggleDetail(entry.model.id)"
@@ -132,12 +201,11 @@
                       </li>
                     </template>
                   </ul>
-                </template>
+                </div>
                 <div
-                  v-if="!filteredModels.length"
+                  v-if="!filteredModels.length && !legacyModels.length"
                   data-testid="models-picker-empty"
-                  role="presentation"
-                  class="flex flex-col items-center gap-2 px-4 py-10 text-center"
+                  class="min-h-full flex flex-col items-center justify-center gap-2 px-4 py-10 text-center"
                 >
                   <Icon
                     name="lucide:search-x"
@@ -190,11 +258,14 @@ const isFavoritesOnly = shallowRef<boolean>(false)
 const activeCategory = shallowRef<ModelCategory | null>(null)
 const detailModelId = shallowRef<string | null>(null)
 const highlightedModelId = shallowRef<string | null>(null)
+const isLegacyExpanded = shallowRef<boolean>(false)
 const root = useTemplateRef<HTMLDivElement>('root')
 const trigger = useTemplateRef<HTMLButtonElement>('trigger')
 const resultsContainer = useTemplateRef<HTMLDivElement>('resultsContainer')
 const panelId = useId()
 const listboxId = useId()
+const legacyListId = useId()
+const legacyLabelId = useId()
 
 let hideDetailTimeoutId: ReturnType<typeof setTimeout> | undefined
 
@@ -234,32 +305,52 @@ const hasActiveFilters = computed<boolean>(() => {
   return activeCategory.value !== null || isRailFilterApplied.value
 })
 
+function matchesActiveFilters({ model, providerId }: PickerModel): boolean {
+  const matchesSearch = !isSearching.value
+    || model.name.toLowerCase().includes(searchTerm.value)
+
+  if (!matchesSearch) {
+    return false
+  }
+
+  if (
+    activeCategory.value !== null
+    && getModelCategory(model) !== activeCategory.value
+  ) {
+    return false
+  }
+
+  if (!isRailFilterApplied.value) {
+    return true
+  }
+
+  if (isFavoritesOnly.value && !favoriteModels.value.includes(model.id)) {
+    return false
+  }
+
+  return !activeProviderId.value || providerId === activeProviderId.value
+}
+
+const matchingModels = computed<PickerModel[]>(() => {
+  return allModels.value.filter(matchesActiveFilters)
+})
+
 const filteredModels = computed<PickerModel[]>(() => {
-  return allModels.value.filter(({ model, providerId }) => {
-    const matchesSearch = !isSearching.value
-      || model.name.toLowerCase().includes(searchTerm.value)
-
-    if (!matchesSearch) {
-      return false
-    }
-
-    if (
-      activeCategory.value !== null
-      && getModelCategory(model) !== activeCategory.value
-    ) {
-      return false
-    }
-
-    if (!isRailFilterApplied.value) {
-      return true
-    }
-
-    if (isFavoritesOnly.value && !favoriteModels.value.includes(model.id)) {
-      return false
-    }
-
-    return !activeProviderId.value || providerId === activeProviderId.value
+  return matchingModels.value.filter(({ model }) => {
+    return model.status !== 'deprecated'
   })
+})
+
+const legacyModels = computed<PickerModel[]>(() => {
+  return matchingModels.value.filter(({ model }) => {
+    return model.status === 'deprecated'
+  })
+})
+
+const legacyLabel = computed<string>(() => {
+  const count = legacyModels.value.length
+
+  return `${count} legacy ${count === 1 ? 'model' : 'models'}`
 })
 
 const sections = computed<PickerSection[]>(() => {
@@ -300,7 +391,13 @@ function close() {
   isOpen.value = false
   highlightedModelId.value = null
   searchQuery.value = ''
+  isLegacyExpanded.value = false
   closeDetail()
+}
+
+function toggleLegacy() {
+  closeDetail()
+  isLegacyExpanded.value = !isLegacyExpanded.value
 }
 
 function closeAndRestoreFocus() {
@@ -316,7 +413,25 @@ function toggle() {
   }
 
   isOpen.value = true
-  setHighlight(toValue(userModel))
+  setHighlight(getInitialHighlight())
+}
+
+/**
+ * A model deprecated after the user picked it still renders in the legacy
+ * list, so highlighting it would aim `aria-activedescendant` at an option
+ * outside the listbox the search input controls.
+ */
+function getInitialHighlight(): string | null {
+  const selectedId = toValue(userModel)
+  const isSelectable = filteredModels.value.some(({ model }) => {
+    return model.id === selectedId
+  })
+
+  if (isSelectable) {
+    return selectedId
+  }
+
+  return filteredModels.value[0]?.model.id ?? null
 }
 
 function toggleProvider(providerId: string) {

--- a/app/components/ChatInput/ModelsTrigger/FilterDropdown.vue
+++ b/app/components/ChatInput/ModelsTrigger/FilterDropdown.vue
@@ -6,7 +6,7 @@
   >
     <summary
       data-testid="models-picker-filter-trigger"
-      class="btn btn-ghost btn-sm btn-circle relative"
+      class="btn btn-ghost btn-sm btn-circle relative hitslop"
       :class="{ 'text-accent': selected }"
       aria-label="Filter models by category"
     >

--- a/app/components/ChatInput/ModelsTrigger/FilterDropdown.vue
+++ b/app/components/ChatInput/ModelsTrigger/FilterDropdown.vue
@@ -36,6 +36,7 @@
       >
         <button
           type="button"
+          :aria-pressed="selected === option.value"
           :class="{ 'menu-active': selected === option.value }"
           class="flex items-center gap-2"
         >

--- a/app/components/ChatInput/ModelsTrigger/FilterDropdown.vue
+++ b/app/components/ChatInput/ModelsTrigger/FilterDropdown.vue
@@ -48,6 +48,24 @@
           <span class="grow">{{ option.label }}</span>
         </button>
       </li>
+      <li
+        role="presentation"
+        data-testid="models-picker-filter-clear"
+        :class="{ 'menu-disabled': selected === null }"
+      >
+        <button
+          type="button"
+          class="flex w-full justify-start text-error disabled:opacity-50"
+          :disabled="selected === null ? true : undefined"
+          @click="onClear"
+        >
+          <Icon
+            name="lucide:list-x"
+            size="14"
+          />
+          Clear
+        </button>
+      </li>
     </ul>
   </details>
 </template>
@@ -72,6 +90,11 @@ function close() {
 
 function selectCategory(category: ModelCategory) {
   selected.value = selected.value === category ? null : category
+  close()
+}
+
+function onClear() {
+  selected.value = null
   close()
 }
 </script>

--- a/app/components/ChatInput/ModelsTrigger/FilterDropdown.vue
+++ b/app/components/ChatInput/ModelsTrigger/FilterDropdown.vue
@@ -7,7 +7,7 @@
     <summary
       data-testid="models-picker-filter-trigger"
       class="btn btn-ghost btn-sm btn-circle relative"
-      :class="{ 'text-accent': selected.length }"
+      :class="{ 'text-accent': selected }"
       aria-label="Filter models by category"
     >
       <Icon
@@ -15,35 +15,37 @@
         size="16"
       />
       <span
-        v-if="selected.length"
+        v-if="selected"
+        aria-hidden="true"
         class="badge badge-xs badge-accent absolute -top-0.5 -right-0.5"
-      >
-        {{ selected.length }}
-      </span>
+      />
     </summary>
     <ul
       data-testid="models-picker-filter-menu"
+      role="listbox"
+      aria-label="Filter models by category"
       class="dropdown-content menu menu-sm z-50 mt-1 w-52 p-1 rounded-box bg-base-100 border border-base-content/10 shadow-lg"
     >
       <li
         v-for="option in modelCategoryOptions"
         :key="option.value"
+        role="option"
+        :aria-selected="selected === option.value"
+        :data-testid="`models-picker-filter-${option.value}`"
+        @click="selectCategory(option.value)"
       >
-        <label class="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            class="checkbox checkbox-xs checkbox-accent"
-            :data-testid="`models-picker-filter-${option.value}`"
-            :checked="selected.includes(option.value)"
-            @change="toggle(option.value)"
-          >
+        <button
+          type="button"
+          :class="{ 'menu-active': selected === option.value }"
+          class="flex items-center gap-2"
+        >
           <Icon
             :name="option.icon"
             size="14"
             class="opacity-60"
           />
           <span class="grow">{{ option.label }}</span>
-        </label>
+        </button>
       </li>
     </ul>
   </details>
@@ -52,7 +54,7 @@
 <script setup lang="ts">
 import type { ModelCategory } from '~/types/models-picker'
 
-const selected = defineModel<ModelCategory[]>({ default: () => [] })
+const selected = defineModel<ModelCategory | null>({ default: null })
 const dropdown = useTemplateRef<HTMLDetailsElement>('dropdown')
 
 onClickOutside(dropdown, () => {
@@ -67,15 +69,8 @@ function close() {
   dropdown.value.open = false
 }
 
-function toggle(category: ModelCategory) {
-  if (selected.value.includes(category)) {
-    selected.value = selected.value.filter((value) => {
-      return value !== category
-    })
-
-    return
-  }
-
-  selected.value = [...selected.value, category]
+function selectCategory(category: ModelCategory) {
+  selected.value = selected.value === category ? null : category
+  close()
 }
 </script>

--- a/app/components/ChatInput/ModelsTrigger/FilterDropdown.vue
+++ b/app/components/ChatInput/ModelsTrigger/FilterDropdown.vue
@@ -1,0 +1,81 @@
+<template>
+  <details
+    ref="dropdown"
+    class="dropdown dropdown-end shrink-0"
+    @keydown.escape.stop="close"
+  >
+    <summary
+      data-testid="models-picker-filter-trigger"
+      class="btn btn-ghost btn-sm btn-circle relative"
+      :class="{ 'text-accent': selected.length }"
+      aria-label="Filter models by category"
+    >
+      <Icon
+        name="lucide:list-filter"
+        size="16"
+      />
+      <span
+        v-if="selected.length"
+        class="badge badge-xs badge-accent absolute -top-0.5 -right-0.5"
+      >
+        {{ selected.length }}
+      </span>
+    </summary>
+    <ul
+      data-testid="models-picker-filter-menu"
+      class="dropdown-content menu menu-sm z-50 mt-1 w-52 p-1 rounded-box bg-base-100 border border-base-content/10 shadow-lg"
+    >
+      <li
+        v-for="option in modelCategoryOptions"
+        :key="option.value"
+      >
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            class="checkbox checkbox-xs checkbox-accent"
+            :data-testid="`models-picker-filter-${option.value}`"
+            :checked="selected.includes(option.value)"
+            @change="toggle(option.value)"
+          >
+          <Icon
+            :name="option.icon"
+            size="14"
+            class="opacity-60"
+          />
+          <span class="grow">{{ option.label }}</span>
+        </label>
+      </li>
+    </ul>
+  </details>
+</template>
+
+<script setup lang="ts">
+import type { ModelCategory } from '~/types/models-picker'
+
+const selected = defineModel<ModelCategory[]>({ default: () => [] })
+const dropdown = useTemplateRef<HTMLDetailsElement>('dropdown')
+
+onClickOutside(dropdown, () => {
+  close()
+})
+
+function close() {
+  if (!dropdown.value?.open) {
+    return
+  }
+
+  dropdown.value.open = false
+}
+
+function toggle(category: ModelCategory) {
+  if (selected.value.includes(category)) {
+    selected.value = selected.value.filter((value) => {
+      return value !== category
+    })
+
+    return
+  }
+
+  selected.value = [...selected.value, category]
+}
+</script>

--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -148,7 +148,8 @@ const capabilities = computed<CapabilityBadge[]>(() => {
     badges.push({
       label: 'Image generation',
       icon: 'lucide:image-plus',
-      class: 'badge-secondary',
+      class: '[--badge-color:var(--color-violet-700)] '
+        + 'dark:[--badge-color:var(--color-violet-200)]',
     })
   }
 

--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -13,8 +13,20 @@
         {{ model.name }}
       </h3>
       <span
+        v-if="model.status === 'deprecated'"
+        data-testid="model-detail-deprecated-badge"
+        class="badge badge-xs badge-error badge-outline shrink-0 gap-0.5 font-semibold"
+      >
+        <Icon
+          name="lucide:triangle-alert"
+          size="11"
+        />
+        Deprecated
+      </span>
+      <span
         v-if="model.priceTier"
-        class="badge badge-xs shrink-0 font-semibold"
+        data-testid="model-detail-price-tier"
+        class="badge badge-xs badge-soft shrink-0 font-semibold"
         :class="getPriceTierClass(model.priceTier)"
       >
         {{ model.priceTier }}
@@ -40,6 +52,7 @@
     </p>
     <div
       v-if="capabilities.length"
+      data-testid="model-detail-capabilities"
       class="mt-2.5 flex flex-wrap gap-1"
     >
       <span

--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -3,8 +3,6 @@
     :id="detailId"
     data-testid="model-detail-panel"
     class="p-3 rounded-2xl bg-base-100/95 backdrop-blur-lg border border-base-content/10 shadow-xl"
-    @mouseenter="onMouseEnter"
-    @mouseleave="onMouseLeave"
   >
     <div class="flex items-start gap-2">
       <h3 class="grow text-sm font-semibold">
@@ -13,13 +11,22 @@
       <span
         v-if="model.priceTier"
         data-testid="model-detail-price-tier"
-        class="badge badge-xs badge-soft shrink-0 font-semibold"
-        :class="getPriceTierClass(model.priceTier)"
+        class="badge badge-xs badge-soft shrink-0 font-semibold tooltip tooltip-soft tooltip-bottom"
+        :class="[
+          getPriceTierClass(model.priceTier),
+          getPriceTierTooltipClass(model.priceTier),
+        ]"
+        :data-tip="priceTip"
       >
         {{ model.priceTier }}
+        <span
+          v-if="priceTip"
+          class="sr-only"
+        >
+          {{ priceTip }}
+        </span>
       </span>
       <button
-        v-if="isInteractive"
         type="button"
         class="btn btn-ghost btn-xs btn-circle shrink-0 -mt-1"
         aria-label="Close model details"
@@ -106,34 +113,19 @@ interface SpecRow {
 const props = defineProps<{
   model: Model
   providerName: string
-  isInteractive: boolean
 }>()
 
 const emit = defineEmits<{
   close: []
-  showDetail: []
-  hideDetail: []
 }>()
 
 const detailId = computed<string>(() => {
   return `model-detail-${props.model.id}`
 })
 
-function onMouseEnter() {
-  if (props.isInteractive) {
-    return
-  }
-
-  emit('showDetail')
-}
-
-function onMouseLeave() {
-  if (props.isInteractive) {
-    return
-  }
-
-  emit('hideDetail')
-}
+const priceTip = computed<string | undefined>(() => {
+  return getModelPriceTip(props.model)
+})
 
 const capabilities = computed<CapabilityBadge[]>(() => {
   const { model } = props

--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -1,0 +1,233 @@
+<template>
+  <div
+    :id="detailId"
+    data-testid="model-detail-panel"
+    role="region"
+    :aria-label="`${model.name} details`"
+    class="absolute inset-x-0 bottom-0 z-10 max-h-full overflow-y-auto p-3 rounded-2xl bg-base-100/95 backdrop-blur-lg border border-base-content/10 shadow-xl"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+  >
+    <div class="flex items-start gap-2">
+      <h3 class="grow text-sm font-semibold">
+        {{ model.name }}
+      </h3>
+      <span
+        v-if="model.priceTier"
+        class="badge badge-xs shrink-0 font-semibold"
+        :class="getPriceTierClass(model.priceTier)"
+      >
+        {{ model.priceTier }}
+      </span>
+      <button
+        v-if="isInteractive"
+        type="button"
+        class="btn btn-ghost btn-xs btn-circle shrink-0 -mt-1"
+        aria-label="Close model details"
+        @click="emit('close')"
+      >
+        <Icon
+          name="lucide:x"
+          size="12"
+        />
+      </button>
+    </div>
+    <p
+      v-if="model.description"
+      class="mt-1.5 text-xs opacity-70"
+    >
+      {{ model.description }}
+    </p>
+    <div
+      v-if="capabilities.length"
+      class="mt-2.5 flex flex-wrap gap-1"
+    >
+      <span
+        v-for="capability in capabilities"
+        :key="capability.label"
+        class="badge badge-xs badge-soft"
+        :class="capability.class"
+      >
+        <Icon
+          :name="capability.icon"
+          size="11"
+        />
+        {{ capability.label }}
+      </span>
+    </div>
+    <dl
+      class="mt-3 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs"
+      data-testid="model-detail-specs"
+    >
+      <template
+        v-for="row in rows"
+        :key="row.label"
+      >
+        <dt class="opacity-50">
+          {{ row.label }}
+        </dt>
+        <dd class="text-right break-words">
+          {{ row.value }}
+        </dd>
+      </template>
+    </dl>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Model } from '#shared/types/providers.d'
+
+interface CapabilityBadge {
+  label: string
+  icon: string
+  class: string
+}
+
+interface SpecRow {
+  label: string
+  value: string
+}
+
+const props = defineProps<{
+  model: Model
+  providerName: string
+  isInteractive: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  showDetail: []
+  hideDetail: []
+}>()
+
+const detailId = computed<string>(() => {
+  return `model-detail-${props.model.id}`
+})
+
+function onMouseEnter() {
+  if (props.isInteractive) {
+    return
+  }
+
+  emit('showDetail')
+}
+
+function onMouseLeave() {
+  if (props.isInteractive) {
+    return
+  }
+
+  emit('hideDetail')
+}
+
+const capabilities = computed<CapabilityBadge[]>(() => {
+  const { model } = props
+  const badges: CapabilityBadge[] = []
+
+  if (model.reasoning) {
+    badges.push({
+      label: 'Reasoning',
+      icon: 'lucide:brain',
+      class: 'badge-warning',
+    })
+  }
+
+  if (model.tools.includes('web_search')) {
+    badges.push({
+      label: 'Web search',
+      icon: 'lucide:globe',
+      class: 'badge-info',
+    })
+  }
+
+  if (hasImageGenerationCapability(model)) {
+    badges.push({
+      label: 'Image generation',
+      icon: 'lucide:image-plus',
+      class: 'badge-secondary',
+    })
+  }
+
+  if (model.research) {
+    badges.push({
+      label: 'Deep research',
+      icon: 'lucide:telescope',
+      class: 'badge-success',
+    })
+  }
+
+  return badges
+})
+
+const priceValue = computed<string>(() => {
+  const { price } = props.model
+
+  if (price.display) {
+    return price.display
+  }
+
+  if (price.input && price.output) {
+    return `${price.input} in / ${price.output} out per 1M tokens`
+  }
+
+  return price.input || '—'
+})
+
+const rows = computed<SpecRow[]>(() => {
+  const { model, providerName } = props
+  const contextLength = formatModelTokenLimit(model.contextLength)
+  const maxOutputTokens = formatModelTokenLimit(model.maxOutputTokens)
+  const specs: SpecRow[] = [{ label: 'Provider', value: providerName }]
+
+  if (contextLength) {
+    specs.push({ label: 'Context', value: contextLength })
+  }
+
+  if (maxOutputTokens) {
+    specs.push({ label: 'Max output', value: maxOutputTokens })
+  }
+
+  if (model.modalities.input.length) {
+    specs.push({
+      label: 'Input',
+      value: model.modalities.input.join(', '),
+    })
+  }
+
+  if (model.modalities.output.length) {
+    specs.push({
+      label: 'Output',
+      value: model.modalities.output.join(', '),
+    })
+  }
+
+  specs.push({ label: 'Price', value: priceValue.value })
+
+  if (model.reasoning?.mode === 'levels' && model.reasoning.levels.length) {
+    specs.push({
+      label: 'Reasoning levels',
+      value: model.reasoning.levels.join(', '),
+    })
+  }
+
+  if (model.research) {
+    specs.push({
+      label: 'Research cost',
+      value: model.research.costEstimate,
+    })
+    specs.push({
+      label: 'Research time',
+      value: model.research.timeEstimate,
+    })
+  }
+
+  if (model.releaseDate) {
+    specs.push({
+      label: 'Added on',
+      value: formatReleaseDate(model.releaseDate),
+    })
+  }
+
+  return specs
+})
+</script>

--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -4,14 +4,14 @@
     data-testid="model-detail-panel"
     class="p-3 rounded-2xl bg-base-100/95 backdrop-blur-lg border border-base-content/10 shadow-xl"
   >
-    <div class="flex items-start gap-2">
+    <div class="flex items-center gap-2">
       <h3 class="grow text-sm font-semibold">
         {{ model.name }}
       </h3>
       <span
         v-if="model.priceTier"
         data-testid="model-detail-price-tier"
-        class="badge badge-xs badge-soft shrink-0 font-semibold tooltip tooltip-soft tooltip-bottom"
+        class="badge badge-soft shrink-0 font-semibold tooltip tooltip-soft tooltip-bottom"
         :class="getPriceTierClass(model.priceTier)"
         :data-tip="priceTip"
       >
@@ -25,7 +25,7 @@
       </span>
       <button
         type="button"
-        class="btn btn-ghost btn-xs btn-circle shrink-0 -mt-1"
+        class="btn btn-ghost btn-xs btn-circle shrink-0"
         aria-label="Close model details"
         @click="emit('close')"
       >
@@ -64,7 +64,7 @@
       <span
         v-for="capability in capabilities"
         :key="capability.label"
-        class="badge badge-xs badge-soft"
+        class="badge badge-sm badge-soft"
         :class="capability.class"
       >
         <Icon

--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -4,7 +4,7 @@
     data-testid="model-detail-panel"
     role="region"
     :aria-label="`${model.name} details`"
-    class="absolute inset-x-0 bottom-0 z-10 max-h-full overflow-y-auto p-3 rounded-2xl bg-base-100/95 backdrop-blur-lg border border-base-content/10 shadow-xl"
+    class="p-3 rounded-2xl bg-base-100/95 backdrop-blur-lg border border-base-content/10 shadow-xl"
     @mouseenter="onMouseEnter"
     @mouseleave="onMouseLeave"
   >

--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -2,8 +2,6 @@
   <div
     :id="detailId"
     data-testid="model-detail-panel"
-    role="region"
-    :aria-label="`${model.name} details`"
     class="p-3 rounded-2xl bg-base-100/95 backdrop-blur-lg border border-base-content/10 shadow-xl"
     @mouseenter="onMouseEnter"
     @mouseleave="onMouseLeave"
@@ -12,17 +10,6 @@
       <h3 class="grow text-sm font-semibold">
         {{ model.name }}
       </h3>
-      <span
-        v-if="model.status === 'deprecated'"
-        data-testid="model-detail-deprecated-badge"
-        class="badge badge-xs badge-error badge-outline shrink-0 gap-0.5 font-semibold"
-      >
-        <Icon
-          name="lucide:triangle-alert"
-          size="11"
-        />
-        Deprecated
-      </span>
       <span
         v-if="model.priceTier"
         data-testid="model-detail-price-tier"
@@ -44,6 +31,21 @@
         />
       </button>
     </div>
+    <p
+      v-if="model.status === 'deprecated'"
+      data-testid="model-detail-deprecated-notice"
+      class="mt-2 flex items-start gap-1.5 p-2 rounded-xl text-xs text-error capability-chip"
+    >
+      <Icon
+        name="lucide:triangle-alert"
+        size="13"
+        class="shrink-0 mt-px"
+      />
+      <span>
+        The provider has deprecated this model, so it can stop responding at
+        any time and can no longer be selected. Pick a supported model instead.
+      </span>
+    </p>
     <p
       v-if="model.description"
       class="mt-1.5 text-xs opacity-70"

--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -25,7 +25,7 @@
       </span>
       <button
         type="button"
-        class="btn btn-ghost btn-xs btn-circle shrink-0"
+        class="btn btn-ghost btn-xs btn-circle shrink-0 hitslop"
         aria-label="Close model details"
         @click="emit('close')"
       >

--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -12,10 +12,7 @@
         v-if="model.priceTier"
         data-testid="model-detail-price-tier"
         class="badge badge-xs badge-soft shrink-0 font-semibold tooltip tooltip-soft tooltip-bottom"
-        :class="[
-          getPriceTierClass(model.priceTier),
-          getPriceTierTooltipClass(model.priceTier),
-        ]"
+        :class="getPriceTierClass(model.priceTier)"
         :data-tip="priceTip"
       >
         {{ model.priceTier }}

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -5,7 +5,7 @@
     :aria-selected="isSelected"
   >
     <div
-      class="flex items-center gap-0.5 rounded-xl pl-2 pr-1 py-1 transition-colors"
+      class="flex items-center gap-1 rounded-xl pl-2 pr-1 py-1 transition-colors"
       :class="{
         'bg-accent/15': isSelected,
         'bg-base-content/10': isHighlighted && !isSelected,
@@ -14,11 +14,13 @@
     >
       <button
         type="button"
-        class="grow min-w-0 flex flex-col items-start gap-0.5 py-1 text-left cursor-pointer"
-        :aria-label="`Choose ${model.name}`"
+        class="grow min-w-0 flex flex-wrap xs:flex-nowrap items-center gap-x-2 gap-y-1 py-1 text-left cursor-pointer"
+        :aria-label="selectLabel"
         @click="emit('select')"
       >
-        <span class="w-full min-w-0 flex items-center gap-1.5">
+        <span
+          class="w-full xs:w-auto xs:grow min-w-0 flex items-center gap-1.5"
+        >
           <SvgoGeminiShort
             v-if="providerId === 'google'"
             class="w-3.5 shrink-0 fill-base-content/40"
@@ -36,7 +38,7 @@
           <span
             v-if="model.priceTier"
             data-testid="model-price-tier"
-            class="badge badge-xs shrink-0 font-semibold"
+            class="badge badge-xs badge-soft shrink-0 font-semibold"
             :class="getPriceTierClass(model.priceTier)"
             :title="priceTip"
           >
@@ -48,109 +50,122 @@
               {{ priceTip }}
             </span>
           </span>
-          <span class="grow" />
-          <span class="shrink-0 flex gap-1 items-center">
-            <span
-              v-if="model.reasoning"
-              class="shrink-0 flex items-center p-0.5 rounded-full bg-warning-content"
-              :class="{
-                'tooltip tooltip-warning tooltip-top': $device.isDesktop
-              }"
-              data-tip="Reasoning"
-            >
-              <Icon
-                name="lucide:brain"
-                class="text-warning"
-              />
-            </span>
-            <span
-              v-if="model.tools.includes('web_search')"
-              class="shrink-0 flex items-center p-0.5 rounded-full bg-info-content"
-              :class="{
-                'tooltip tooltip-info tooltip-top': $device.isDesktop
-              }"
-              data-tip="Web search"
-            >
-              <Icon
-                name="lucide:globe"
-                class="text-info"
-              />
-            </span>
-            <span
-              v-if="hasImageGenerationCapability(model)"
-              data-testid="model-image-generation-capability"
-              class="shrink-0 flex items-center p-0.5 rounded-full bg-green-100 dark:bg-secondary-content"
-              :class="{
-                'tooltip tooltip-secondary tooltip-top': $device.isDesktop
-              }"
-              data-tip="Image generation"
-            >
-              <Icon
-                name="lucide:image-plus"
-                class="text-green-800 dark:text-secondary"
-              />
-            </span>
-            <span
-              v-if="model.research"
-              class="shrink-0 flex items-center p-0.5 rounded-full bg-[color-mix(in_oklab,var(--color-success)_15%,var(--color-base-100))] text-success"
-              :class="{
-                'tooltip tooltip-success tooltip-top': $device.isDesktop
-              }"
-              data-tip="Deep research"
-            >
-              <Icon
-                name="lucide:telescope"
-                class="text-success"
-              />
-            </span>
+          <span
+            v-if="model.status === 'deprecated'"
+            data-testid="model-deprecated-badge"
+            class="badge badge-xs badge-error badge-outline shrink-0 gap-0.5 font-semibold"
+          >
+            <Icon
+              name="lucide:triangle-alert"
+              size="11"
+            />
+            <span class="sr-only sm:not-sr-only">Deprecated</span>
           </span>
         </span>
         <span
-          v-if="model.description"
-          class="w-full truncate text-xs opacity-60"
+          v-if="hasCapabilities"
+          data-testid="model-capabilities"
+          class="shrink-0 flex gap-1 items-center"
         >
-          {{ model.description }}
+          <span
+            v-if="model.reasoning"
+            class="shrink-0 flex items-center p-0.5 rounded-full bg-warning-content"
+            :class="{
+              'tooltip tooltip-warning tooltip-top': $device.isDesktop
+            }"
+            data-tip="Reasoning"
+          >
+            <Icon
+              name="lucide:brain"
+              class="text-warning"
+            />
+          </span>
+          <span
+            v-if="model.tools.includes('web_search')"
+            class="shrink-0 flex items-center p-0.5 rounded-full bg-info-content"
+            :class="{
+              'tooltip tooltip-info tooltip-top': $device.isDesktop
+            }"
+            data-tip="Web search"
+          >
+            <Icon
+              name="lucide:globe"
+              class="text-info"
+            />
+          </span>
+          <span
+            v-if="hasImageGenerationCapability(model)"
+            data-testid="model-image-generation-capability"
+            class="shrink-0 flex items-center p-0.5 rounded-full bg-green-100 dark:bg-secondary-content"
+            :class="{
+              'tooltip tooltip-secondary tooltip-top': $device.isDesktop
+            }"
+            data-tip="Image generation"
+          >
+            <Icon
+              name="lucide:image-plus"
+              class="text-green-800 dark:text-secondary"
+            />
+          </span>
+          <span
+            v-if="model.research"
+            class="shrink-0 flex items-center p-0.5 rounded-full bg-[color-mix(in_oklab,var(--color-success)_15%,var(--color-base-100))] text-success"
+            :class="{
+              'tooltip tooltip-success tooltip-top': $device.isDesktop
+            }"
+            data-tip="Deep research"
+          >
+            <Icon
+              name="lucide:telescope"
+              class="text-success"
+            />
+          </span>
         </span>
       </button>
-      <button
-        type="button"
-        data-testid="model-favorite-toggle"
-        class="btn btn-ghost btn-xs btn-circle shrink-0"
-        :class="{ 'text-warning': isFavorite }"
-        :aria-label="isFavorite
-          ? `Remove ${model.name} from favorites`
-          : `Add ${model.name} to favorites`
-        "
-        :aria-pressed="isFavorite"
-        @click.stop="emit('toggleFavorite')"
+      <span
+        data-testid="model-actions"
+        class="shrink-0 flex items-center gap-1 max-xs:flex-col max-xs:gap-1.5"
       >
-        <Icon
-          name="lucide:star"
-          mode="svg"
-          size="14"
-          :class="{ '[&_path]:fill-current': isFavorite }"
-        />
-      </button>
-      <button
-        type="button"
-        data-testid="model-info-trigger"
-        class="btn btn-ghost btn-xs btn-circle shrink-0"
-        :class="{ 'text-accent': isDetailOpen }"
-        :aria-label="`About ${model.name}`"
-        :aria-expanded="isDetailOpen"
-        :aria-controls="isDetailOpen ? detailId : undefined"
-        :aria-describedby="isDetailOpen ? detailId : undefined"
-        @click.stop="onInfoClick"
-        @mouseenter="revealDetail"
-        @mouseleave="dismissDetail"
-        @focus="revealDetail"
-        @blur="dismissDetail"
-      >
-        <Icon
-          name="lucide:info"
-          size="14"
-        />
-      </button>
+        <button
+          type="button"
+          data-testid="model-info-trigger"
+          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)]"
+          :class="{ 'text-accent': isDetailOpen }"
+          :aria-label="`About ${model.name}`"
+          :aria-expanded="isDetailOpen"
+          :aria-controls="isDetailOpen ? detailId : undefined"
+          :aria-describedby="isDetailOpen ? detailId : undefined"
+          @click.stop="onInfoClick"
+          @mouseenter="revealDetail"
+          @mouseleave="dismissDetail"
+          @focus="revealDetail"
+          @blur="dismissDetail"
+        >
+          <Icon
+            name="lucide:info"
+            size="14"
+          />
+        </button>
+        <button
+          type="button"
+          data-testid="model-favorite-toggle"
+          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)]"
+          :class="{ 'text-warning': isFavorite }"
+          :aria-label="isFavorite
+            ? `Remove ${model.name} from favorites`
+            : `Add ${model.name} to favorites`
+          "
+          :aria-pressed="isFavorite"
+          @click.stop="emit('toggleFavorite')"
+        >
+          <Icon
+            name="lucide:star"
+            mode="svg"
+            size="14"
+            :class="{ '[&_path]:fill-current': isFavorite }"
+          />
+        </button>
+      </span>
     </div>
   </li>
 </template>
@@ -179,6 +194,29 @@ const { isDesktop } = useDevice()
 
 const priceTip = computed<string | undefined>(() => {
   return getModelPriceTip(props.model)
+})
+
+const hasCapabilities = computed<boolean>(() => {
+  const { model } = props
+
+  return !!model.reasoning
+    || model.tools.includes('web_search')
+    || hasImageGenerationCapability(model)
+    || !!model.research
+})
+
+/**
+ * The explicit label overrides the button content, so the deprecation badge
+ * inside it would otherwise never reach assistive technology.
+ */
+const selectLabel = computed<string>(() => {
+  const { model } = props
+
+  if (model.status === 'deprecated') {
+    return `Choose ${model.name}, deprecated`
+  }
+
+  return `Choose ${model.name}`
 })
 
 const optionId = computed<string>(() => {

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -48,10 +48,7 @@
             v-if="model.priceTier"
             data-testid="model-price-tier"
             class="badge badge-xs badge-soft shrink-0 font-semibold tooltip tooltip-soft tooltip-bottom"
-            :class="[
-              getPriceTierClass(model.priceTier),
-              getPriceTierTooltipClass(model.priceTier),
-            ]"
+            :class="getPriceTierClass(model.priceTier)"
             :data-tip="priceTip"
           >
             {{ model.priceTier }}

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -107,7 +107,7 @@
         <button
           type="button"
           data-testid="model-info-trigger"
-          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)]"
+          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)] hitslop"
           :class="{ 'text-accent': isDetailOpen, 'btn-active': isDetailOpen }"
           :aria-label="`About ${model.name}`"
           :aria-expanded="isDetailOpen"
@@ -124,7 +124,7 @@
           v-if="!isLegacy"
           type="button"
           data-testid="model-favorite-toggle"
-          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)] tooltip tooltip-left"
+          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)] tooltip tooltip-left hitslop"
           :class="{ 'text-warning': isFavorite }"
           :aria-label="isFavorite
             ? `Remove ${model.name} from favorites`

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -108,7 +108,7 @@
           type="button"
           data-testid="model-info-trigger"
           class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)]"
-          :class="{ 'text-accent': isDetailOpen }"
+          :class="{ 'text-accent': isDetailOpen, 'btn-active': isDetailOpen }"
           :aria-label="`About ${model.name}`"
           :aria-expanded="isDetailOpen"
           :aria-controls="isDetailOpen ? detailId : undefined"

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -124,7 +124,7 @@
           v-if="!isLegacy"
           type="button"
           data-testid="model-favorite-toggle"
-          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)] tooltip tooltip-left hitslop"
+          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)] tooltip tooltip-left"
           :class="{ 'text-warning': isFavorite }"
           :aria-label="isFavorite
             ? `Remove ${model.name} from favorites`

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -28,7 +28,7 @@
           Deprecated, no longer selectable.
         </span>
         <span
-          class="w-full xs:w-auto xs:grow min-w-0 flex items-center gap-1.5"
+          class="w-full xs:w-auto min-w-0 flex items-center gap-1.5"
         >
           <SvgoGeminiShort
             v-if="providerId === 'google'"
@@ -46,25 +46,29 @@
           </span>
         </span>
         <span
-          v-if="hasCapabilities || model.priceTier"
-          data-testid="model-capabilities"
-          class="shrink-0 flex gap-1 items-center ml-5"
+          v-if="model.priceTier"
+          data-testid="model-price-tier"
+          class="badge badge-xs badge-soft shrink-0 font-semibold tooltip tooltip-soft tooltip-bottom max-xs:ml-5"
+          :class="getPriceTierClass(model.priceTier)"
+          :data-tip="priceTip"
         >
+          {{ model.priceTier }}
           <span
-            v-if="model.priceTier"
-            data-testid="model-price-tier"
-            class="badge badge-xs badge-soft shrink-0 font-semibold tooltip tooltip-soft tooltip-bottom"
-            :class="getPriceTierClass(model.priceTier)"
-            :data-tip="priceTip"
+            v-if="priceTip"
+            class="sr-only"
           >
-            {{ model.priceTier }}
-            <span
-              v-if="priceTip"
-              class="sr-only"
-            >
-              {{ priceTip }}
-            </span>
+            {{ priceTip }}
           </span>
+        </span>
+        <span
+          v-if="hasCapabilities"
+          data-testid="model-capabilities"
+          class="shrink-0 flex gap-1 items-center xs:ml-auto"
+          :class="{
+            'max-xs:ml-5': !model.priceTier,
+            'max-xs:-ml-1': !!model.priceTier
+          }"
+        >
           <span
             v-if="model.reasoning"
             class="capability-chip shrink-0 flex items-center p-0.5 rounded-full text-warning"

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -44,6 +44,12 @@
           >
             {{ model.name }}
           </span>
+        </span>
+        <span
+          v-if="hasCapabilities || model.priceTier"
+          data-testid="model-capabilities"
+          class="shrink-0 flex gap-1 items-center ml-5"
+        >
           <span
             v-if="model.priceTier"
             data-testid="model-price-tier"
@@ -59,12 +65,6 @@
               {{ priceTip }}
             </span>
           </span>
-        </span>
-        <span
-          v-if="hasCapabilities"
-          data-testid="model-capabilities"
-          class="shrink-0 flex gap-1 items-center"
-        >
           <span
             v-if="model.reasoning"
             class="capability-chip shrink-0 flex items-center p-0.5 rounded-full text-warning"
@@ -102,7 +102,7 @@
       </component>
       <span
         data-testid="model-actions"
-        class="shrink-0 flex items-center gap-1 max-xs:flex-col max-xs:gap-1.5"
+        class="shrink-0 flex items-center gap-1 max-xs:flex-col"
       >
         <button
           type="button"

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -2,22 +2,31 @@
   <li
     :id="optionId"
     role="option"
-    :aria-selected="isSelected"
+    :aria-selected="isLegacy ? false : isSelected"
+    :aria-disabled="isLegacy ? true : undefined"
   >
     <div
       class="flex items-center gap-1 rounded-xl pl-2 pr-1 py-1 transition-colors"
       :class="{
-        'bg-accent/15': isSelected,
-        'bg-base-content/10': isHighlighted && !isSelected,
-        'hover:bg-base-content/5': !isSelected && !isHighlighted
+        'bg-accent/15': isSelected && !isLegacy,
+        'bg-base-content/10': isHighlighted && !isSelected && !isLegacy,
+        'hover:bg-base-content/5': !isSelected && !isHighlighted && !isLegacy
       }"
     >
-      <button
-        type="button"
-        class="grow min-w-0 flex flex-wrap xs:flex-nowrap items-center gap-x-2 gap-y-1 py-1 text-left cursor-pointer"
-        :aria-label="selectLabel"
-        @click="emit('select')"
+      <component
+        :is="isLegacy ? 'div' : 'button'"
+        :type="isLegacy ? undefined : 'button'"
+        :aria-label="isLegacy ? undefined : selectLabel"
+        class="grow min-w-0 flex flex-wrap xs:flex-nowrap items-center gap-x-2 gap-y-1 py-1 text-left"
+        :class="isLegacy ? 'opacity-50' : 'cursor-pointer'"
+        @click="onSelect"
       >
+        <span
+          v-if="isLegacy"
+          class="sr-only"
+        >
+          Deprecated, no longer selectable.
+        </span>
         <span
           class="w-full xs:w-auto xs:grow min-w-0 flex items-center gap-1.5"
         >
@@ -50,17 +59,6 @@
               {{ priceTip }}
             </span>
           </span>
-          <span
-            v-if="model.status === 'deprecated'"
-            data-testid="model-deprecated-badge"
-            class="badge badge-xs badge-error badge-outline shrink-0 gap-0.5 font-semibold"
-          >
-            <Icon
-              name="lucide:triangle-alert"
-              size="11"
-            />
-            <span class="sr-only sm:not-sr-only">Deprecated</span>
-          </span>
         </span>
         <span
           v-if="hasCapabilities"
@@ -69,59 +67,39 @@
         >
           <span
             v-if="model.reasoning"
-            class="shrink-0 flex items-center p-0.5 rounded-full bg-warning-content"
-            :class="{
-              'tooltip tooltip-warning tooltip-top': $device.isDesktop
-            }"
+            class="capability-chip shrink-0 flex items-center p-0.5 rounded-full text-warning"
+            :class="{ 'tooltip tooltip-soft tooltip-bottom': hasTooltip }"
             data-tip="Reasoning"
           >
-            <Icon
-              name="lucide:brain"
-              class="text-warning"
-            />
+            <Icon name="lucide:brain" />
           </span>
           <span
             v-if="model.tools.includes('web_search')"
-            class="shrink-0 flex items-center p-0.5 rounded-full bg-info-content"
-            :class="{
-              'tooltip tooltip-info tooltip-top': $device.isDesktop
-            }"
+            class="capability-chip shrink-0 flex items-center p-0.5 rounded-full text-info"
+            :class="{ 'tooltip tooltip-soft tooltip-bottom': hasTooltip }"
             data-tip="Web search"
           >
-            <Icon
-              name="lucide:globe"
-              class="text-info"
-            />
+            <Icon name="lucide:globe" />
           </span>
           <span
             v-if="hasImageGenerationCapability(model)"
             data-testid="model-image-generation-capability"
-            class="shrink-0 flex items-center p-0.5 rounded-full bg-green-100 dark:bg-secondary-content"
-            :class="{
-              'tooltip tooltip-secondary tooltip-top': $device.isDesktop
-            }"
+            class="capability-chip shrink-0 flex items-center p-0.5 rounded-full text-violet-700 dark:text-violet-200"
+            :class="{ 'tooltip tooltip-soft tooltip-bottom': hasTooltip }"
             data-tip="Image generation"
           >
-            <Icon
-              name="lucide:image-plus"
-              class="text-green-800 dark:text-secondary"
-            />
+            <Icon name="lucide:image-plus" />
           </span>
           <span
             v-if="model.research"
-            class="shrink-0 flex items-center p-0.5 rounded-full bg-[color-mix(in_oklab,var(--color-success)_15%,var(--color-base-100))] text-success"
-            :class="{
-              'tooltip tooltip-success tooltip-top': $device.isDesktop
-            }"
+            class="capability-chip shrink-0 flex items-center p-0.5 rounded-full text-success"
+            :class="{ 'tooltip tooltip-soft tooltip-bottom': hasTooltip }"
             data-tip="Deep research"
           >
-            <Icon
-              name="lucide:telescope"
-              class="text-success"
-            />
+            <Icon name="lucide:telescope" />
           </span>
         </span>
-      </button>
+      </component>
       <span
         data-testid="model-actions"
         class="shrink-0 flex items-center gap-1 max-xs:flex-col max-xs:gap-1.5"
@@ -147,6 +125,7 @@
           />
         </button>
         <button
+          v-if="!isLegacy"
           type="button"
           data-testid="model-favorite-toggle"
           class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)]"
@@ -180,6 +159,7 @@ const props = defineProps<{
   isHighlighted: boolean
   isFavorite: boolean
   isDetailOpen: boolean
+  isLegacy?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -196,6 +176,10 @@ const priceTip = computed<string | undefined>(() => {
   return getModelPriceTip(props.model)
 })
 
+const hasTooltip = computed<boolean>(() => {
+  return isDesktop && !props.isLegacy
+})
+
 const hasCapabilities = computed<boolean>(() => {
   const { model } = props
 
@@ -205,18 +189,8 @@ const hasCapabilities = computed<boolean>(() => {
     || !!model.research
 })
 
-/**
- * The explicit label overrides the button content, so the deprecation badge
- * inside it would otherwise never reach assistive technology.
- */
 const selectLabel = computed<string>(() => {
-  const { model } = props
-
-  if (model.status === 'deprecated') {
-    return `Choose ${model.name}, deprecated`
-  }
-
-  return `Choose ${model.name}`
+  return `Choose ${props.model.name}`
 })
 
 const optionId = computed<string>(() => {
@@ -226,6 +200,14 @@ const optionId = computed<string>(() => {
 const detailId = computed<string>(() => {
   return `model-detail-${props.model.id}`
 })
+
+function onSelect() {
+  if (props.isLegacy) {
+    return
+  }
+
+  emit('select')
+}
 
 /**
  * Pointer and keyboard both open the detail on desktop only. A touch tap

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -47,9 +47,12 @@
           <span
             v-if="model.priceTier"
             data-testid="model-price-tier"
-            class="badge badge-xs badge-soft shrink-0 font-semibold"
-            :class="getPriceTierClass(model.priceTier)"
-            :title="priceTip"
+            class="badge badge-xs badge-soft shrink-0 font-semibold tooltip tooltip-soft tooltip-bottom"
+            :class="[
+              getPriceTierClass(model.priceTier),
+              getPriceTierTooltipClass(model.priceTier),
+            ]"
+            :data-tip="priceTip"
           >
             {{ model.priceTier }}
             <span
@@ -114,10 +117,6 @@
           :aria-controls="isDetailOpen ? detailId : undefined"
           :aria-describedby="isDetailOpen ? detailId : undefined"
           @click.stop="onInfoClick"
-          @mouseenter="revealDetail"
-          @mouseleave="dismissDetail"
-          @focus="revealDetail"
-          @blur="dismissDetail"
         >
           <Icon
             name="lucide:info"
@@ -128,13 +127,17 @@
           v-if="!isLegacy"
           type="button"
           data-testid="model-favorite-toggle"
-          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)]"
+          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)] tooltip tooltip-left"
           :class="{ 'text-warning': isFavorite }"
           :aria-label="isFavorite
             ? `Remove ${model.name} from favorites`
             : `Add ${model.name} to favorites`
           "
           :aria-pressed="isFavorite"
+          :data-tip="isFavorite
+            ? 'Remove from favorites'
+            : 'Add to favorites'
+          "
           @click.stop="emit('toggleFavorite')"
         >
           <Icon
@@ -165,8 +168,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   select: []
   toggleFavorite: []
-  showDetail: []
-  hideDetail: []
   toggleDetail: []
 }>()
 
@@ -209,32 +210,7 @@ function onSelect() {
   emit('select')
 }
 
-/**
- * Pointer and keyboard both open the detail on desktop only. A touch tap
- * fires `focus` before `click`, so an ungated focus handler would open the
- * detail and let the following `toggleDetail` immediately close it again.
- */
-function revealDetail() {
-  if (!isDesktop) {
-    return
-  }
-
-  emit('showDetail')
-}
-
-function dismissDetail() {
-  if (!isDesktop) {
-    return
-  }
-
-  emit('hideDetail')
-}
-
 function onInfoClick() {
-  if (isDesktop) {
-    return
-  }
-
   emit('toggleDetail')
 }
 </script>

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -1,0 +1,220 @@
+<template>
+  <li
+    :id="optionId"
+    role="option"
+    :aria-selected="isSelected"
+  >
+    <div
+      class="flex items-center gap-0.5 rounded-xl pl-2 pr-1 py-1 transition-colors"
+      :class="{
+        'bg-accent/15': isSelected,
+        'bg-base-content/10': isHighlighted && !isSelected,
+        'hover:bg-base-content/5': !isSelected && !isHighlighted
+      }"
+    >
+      <button
+        type="button"
+        class="grow min-w-0 flex flex-col items-start gap-0.5 py-1 text-left cursor-pointer"
+        :aria-label="`Choose ${model.name}`"
+        @click="emit('select')"
+      >
+        <span class="w-full min-w-0 flex items-center gap-1.5">
+          <SvgoGeminiShort
+            v-if="providerId === 'google'"
+            class="w-3.5 shrink-0 fill-base-content/40"
+          />
+          <SvgoOpenai
+            v-else-if="providerId === 'openai'"
+            class="w-3.5 shrink-0 fill-base-content/40"
+          />
+          <span
+            class="truncate text-sm font-medium"
+            :class="{ 'text-accent': isSelected }"
+          >
+            {{ model.name }}
+          </span>
+          <span
+            v-if="model.priceTier"
+            data-testid="model-price-tier"
+            class="badge badge-xs shrink-0 font-semibold"
+            :class="getPriceTierClass(model.priceTier)"
+            :title="priceTip"
+          >
+            {{ model.priceTier }}
+            <span
+              v-if="priceTip"
+              class="sr-only"
+            >
+              {{ priceTip }}
+            </span>
+          </span>
+          <span class="grow" />
+          <span class="shrink-0 flex gap-1 items-center">
+            <span
+              v-if="model.reasoning"
+              class="shrink-0 flex items-center p-0.5 rounded-full bg-warning-content"
+              :class="{
+                'tooltip tooltip-warning tooltip-top': $device.isDesktop
+              }"
+              data-tip="Reasoning"
+            >
+              <Icon
+                name="lucide:brain"
+                class="text-warning"
+              />
+            </span>
+            <span
+              v-if="model.tools.includes('web_search')"
+              class="shrink-0 flex items-center p-0.5 rounded-full bg-info-content"
+              :class="{
+                'tooltip tooltip-info tooltip-top': $device.isDesktop
+              }"
+              data-tip="Web search"
+            >
+              <Icon
+                name="lucide:globe"
+                class="text-info"
+              />
+            </span>
+            <span
+              v-if="hasImageGenerationCapability(model)"
+              data-testid="model-image-generation-capability"
+              class="shrink-0 flex items-center p-0.5 rounded-full bg-green-100 dark:bg-secondary-content"
+              :class="{
+                'tooltip tooltip-secondary tooltip-top': $device.isDesktop
+              }"
+              data-tip="Image generation"
+            >
+              <Icon
+                name="lucide:image-plus"
+                class="text-green-800 dark:text-secondary"
+              />
+            </span>
+            <span
+              v-if="model.research"
+              class="shrink-0 flex items-center p-0.5 rounded-full bg-[color-mix(in_oklab,var(--color-success)_15%,var(--color-base-100))] text-success"
+              :class="{
+                'tooltip tooltip-success tooltip-top': $device.isDesktop
+              }"
+              data-tip="Deep research"
+            >
+              <Icon
+                name="lucide:telescope"
+                class="text-success"
+              />
+            </span>
+          </span>
+        </span>
+        <span
+          v-if="model.description"
+          class="w-full truncate text-xs opacity-60"
+        >
+          {{ model.description }}
+        </span>
+      </button>
+      <button
+        type="button"
+        data-testid="model-favorite-toggle"
+        class="btn btn-ghost btn-xs btn-circle shrink-0"
+        :class="{ 'text-warning': isFavorite }"
+        :aria-label="isFavorite
+          ? `Remove ${model.name} from favorites`
+          : `Add ${model.name} to favorites`
+        "
+        :aria-pressed="isFavorite"
+        @click.stop="emit('toggleFavorite')"
+      >
+        <Icon
+          name="lucide:star"
+          mode="svg"
+          size="14"
+          :class="{ '[&_path]:fill-current': isFavorite }"
+        />
+      </button>
+      <button
+        type="button"
+        data-testid="model-info-trigger"
+        class="btn btn-ghost btn-xs btn-circle shrink-0"
+        :class="{ 'text-accent': isDetailOpen }"
+        :aria-label="`About ${model.name}`"
+        :aria-expanded="isDetailOpen"
+        :aria-controls="isDetailOpen ? detailId : undefined"
+        :aria-describedby="isDetailOpen ? detailId : undefined"
+        @click.stop="onInfoClick"
+        @mouseenter="revealDetail"
+        @mouseleave="dismissDetail"
+        @focus="revealDetail"
+        @blur="dismissDetail"
+      >
+        <Icon
+          name="lucide:info"
+          size="14"
+        />
+      </button>
+    </div>
+  </li>
+</template>
+
+<script setup lang="ts">
+import type { Model } from '#shared/types/providers.d'
+
+const props = defineProps<{
+  model: Model
+  providerId: string
+  isSelected: boolean
+  isHighlighted: boolean
+  isFavorite: boolean
+  isDetailOpen: boolean
+}>()
+
+const emit = defineEmits<{
+  select: []
+  toggleFavorite: []
+  showDetail: []
+  hideDetail: []
+  toggleDetail: []
+}>()
+
+const { isDesktop } = useDevice()
+
+const priceTip = computed<string | undefined>(() => {
+  return getModelPriceTip(props.model)
+})
+
+const optionId = computed<string>(() => {
+  return `model-option-${props.model.id}`
+})
+
+const detailId = computed<string>(() => {
+  return `model-detail-${props.model.id}`
+})
+
+/**
+ * Pointer and keyboard both open the detail on desktop only. A touch tap
+ * fires `focus` before `click`, so an ungated focus handler would open the
+ * detail and let the following `toggleDetail` immediately close it again.
+ */
+function revealDetail() {
+  if (!isDesktop) {
+    return
+  }
+
+  emit('showDetail')
+}
+
+function dismissDetail() {
+  if (!isDesktop) {
+    return
+  }
+
+  emit('hideDetail')
+}
+
+function onInfoClick() {
+  if (isDesktop) {
+    return
+  }
+
+  emit('toggleDetail')
+}
+</script>

--- a/app/components/ChatInput/ModelsTrigger/ProviderRail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ProviderRail.vue
@@ -1,0 +1,76 @@
+<template>
+  <div
+    data-testid="models-picker-rail"
+    class="shrink-0 flex flex-col items-center gap-1 p-1.5 border-r border-base-content/10"
+  >
+    <template v-if="hasFavorites">
+      <button
+        type="button"
+        data-testid="models-picker-rail-favorites"
+        class="btn btn-ghost btn-sm btn-circle"
+        :class="{
+          'btn-active text-warning': isFavoritesOnly,
+          'tooltip tooltip-right': $device.isDesktop
+        }"
+        data-tip="Favorites"
+        aria-label="Show favorite models only"
+        :aria-pressed="isFavoritesOnly"
+        @click="emit('toggleFavorites')"
+      >
+        <Icon
+          name="lucide:star"
+          mode="svg"
+          size="16"
+          :class="{ '[&_path]:fill-current': isFavoritesOnly }"
+        />
+      </button>
+      <div class="divider my-0.5 h-px w-full before:h-px after:h-px" />
+    </template>
+    <button
+      v-for="provider in providers"
+      :key="provider.id"
+      type="button"
+      :data-testid="`models-picker-rail-${provider.id}`"
+      class="btn btn-ghost btn-sm btn-circle"
+      :class="{
+        'btn-active text-accent': activeProviderId === provider.id,
+        'tooltip tooltip-right': $device.isDesktop
+      }"
+      :data-tip="provider.name"
+      :aria-label="`Show ${provider.name} models only`"
+      :aria-pressed="activeProviderId === provider.id"
+      @click="emit('toggleProvider', provider.id)"
+    >
+      <SvgoGeminiShort
+        v-if="provider.id === 'google'"
+        class="w-4 fill-current"
+      />
+      <SvgoOpenai
+        v-else-if="provider.id === 'openai'"
+        class="w-4 fill-current"
+      />
+      <span
+        v-else
+        class="text-xs font-semibold uppercase"
+      >
+        {{ provider.name.slice(0, 2) }}
+      </span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Providers } from '#shared/types/providers.d'
+
+defineProps<{
+  providers: Providers
+  activeProviderId: string | null
+  isFavoritesOnly: boolean
+  hasFavorites: boolean
+}>()
+
+const emit = defineEmits<{
+  toggleProvider: [providerId: string]
+  toggleFavorites: []
+}>()
+</script>

--- a/app/components/ChatInput/ModelsTrigger/ProviderRail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ProviderRail.vue
@@ -7,7 +7,7 @@
       <button
         type="button"
         data-testid="models-picker-rail-favorites"
-        class="btn btn-ghost btn-sm btn-circle"
+        class="btn btn-ghost btn-sm btn-circle hitslop"
         :class="{
           'btn-active text-warning': isFavoritesOnly,
           'tooltip tooltip-soft tooltip-right': $device.isDesktop
@@ -31,7 +31,7 @@
       :key="provider.id"
       type="button"
       :data-testid="`models-picker-rail-${provider.id}`"
-      class="btn btn-ghost btn-sm btn-circle"
+      class="btn btn-ghost btn-sm btn-circle hitslop"
       :class="{
         'btn-active text-accent': activeProviderId === provider.id,
         'tooltip tooltip-soft tooltip-right': $device.isDesktop

--- a/app/components/ChatInput/ModelsTrigger/ProviderRail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ProviderRail.vue
@@ -7,7 +7,7 @@
       <button
         type="button"
         data-testid="models-picker-rail-favorites"
-        class="btn btn-ghost btn-sm btn-circle hitslop"
+        class="btn btn-ghost btn-sm btn-circle"
         :class="{
           'btn-active text-warning': isFavoritesOnly,
           'tooltip tooltip-soft tooltip-right': $device.isDesktop
@@ -31,7 +31,7 @@
       :key="provider.id"
       type="button"
       :data-testid="`models-picker-rail-${provider.id}`"
-      class="btn btn-ghost btn-sm btn-circle hitslop"
+      class="btn btn-ghost btn-sm btn-circle"
       :class="{
         'btn-active text-accent': activeProviderId === provider.id,
         'tooltip tooltip-soft tooltip-right': $device.isDesktop

--- a/app/components/ChatInput/ModelsTrigger/ProviderRail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ProviderRail.vue
@@ -10,7 +10,7 @@
         class="btn btn-ghost btn-sm btn-circle"
         :class="{
           'btn-active text-warning': isFavoritesOnly,
-          'tooltip tooltip-right': $device.isDesktop
+          'tooltip tooltip-soft tooltip-right': $device.isDesktop
         }"
         data-tip="Favorites"
         aria-label="Show favorite models only"
@@ -34,7 +34,7 @@
       class="btn btn-ghost btn-sm btn-circle"
       :class="{
         'btn-active text-accent': activeProviderId === provider.id,
-        'tooltip tooltip-right': $device.isDesktop
+        'tooltip tooltip-soft tooltip-right': $device.isDesktop
       }"
       :data-tip="provider.name"
       :aria-label="`Show ${provider.name} models only`"

--- a/app/components/ChatInput/ModelsTrigger/Search.vue
+++ b/app/components/ChatInput/ModelsTrigger/Search.vue
@@ -1,0 +1,65 @@
+<template>
+  <label class="input input-sm w-full">
+    <Icon
+      name="lucide:search"
+      size="14"
+      class="opacity-50"
+    />
+    <input
+      ref="input"
+      v-model="query"
+      type="text"
+      data-testid="models-picker-search"
+      aria-label="Search models"
+      placeholder="Search models"
+      autocomplete="off"
+      spellcheck="false"
+      role="combobox"
+      aria-autocomplete="list"
+      aria-expanded="true"
+      :aria-controls="controls"
+      :aria-activedescendant="activeDescendant"
+      @keydown="emit('keydown', $event)"
+    >
+    <button
+      v-if="query"
+      type="button"
+      class="btn btn-ghost btn-xs btn-circle -mr-2"
+      aria-label="Clear search"
+      @click="clear"
+    >
+      <Icon
+        name="lucide:x"
+        size="12"
+      />
+    </button>
+  </label>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  autofocus?: boolean
+  controls?: string
+  activeDescendant?: string
+}>()
+
+const emit = defineEmits<{
+  keydown: [event: KeyboardEvent]
+}>()
+
+const query = defineModel<string>({ default: '' })
+const input = useTemplateRef<HTMLInputElement>('input')
+
+function clear() {
+  query.value = ''
+  input.value?.focus()
+}
+
+onMounted(() => {
+  if (!props.autofocus) {
+    return
+  }
+
+  input.value?.focus()
+})
+</script>

--- a/app/composables/user-setting.ts
+++ b/app/composables/user-setting.ts
@@ -29,6 +29,10 @@ export function useUserSetting() {
     'user-settings:sidebar-pinned',
     () => null,
   )
+  const serverFavoriteModels = useState<string[] | null>(
+    'user-settings:favorite-models',
+    () => null,
+  )
   const isLoadingSettings = useState<boolean>(
     'user-settings:is-loading',
     () => false,
@@ -43,6 +47,10 @@ export function useUserSetting() {
   )
   const lastSyncToken = useState<number>(
     'user-settings:sync-token',
+    () => 0,
+  )
+  const lastFavoriteModelsRequestToken = useState<number>(
+    'user-settings:favorite-models-request-token',
     () => 0,
   )
   const prefStorage = usePreferenceStorage()
@@ -82,6 +90,29 @@ export function useUserSetting() {
     },
     set(value) {
       prefStorage.setItem('settings_sidebar_pinned', String(value))
+      trigger()
+    },
+  }))
+  const fallbackFavoriteModels = customRef<string[]>((track, trigger) => ({
+    get() {
+      track()
+
+      const raw = prefStorage.getItem('settings_favorite_models')
+
+      if (raw === null) {
+        return []
+      }
+
+      try {
+        const parsed = JSON.parse(raw)
+
+        return Array.isArray(parsed) ? parsed as string[] : []
+      } catch {
+        return []
+      }
+    },
+    set(value) {
+      prefStorage.setItem('settings_favorite_models', JSON.stringify(value))
       trigger()
     },
   }))
@@ -148,6 +179,41 @@ export function useUserSetting() {
     return serverSidebarPinned.value
   })
 
+  const rawFavoriteModels = computed<string[]>(() => {
+    if (
+      !activeUserId.value
+      || loadedUserId.value !== activeUserId.value
+      || serverFavoriteModels.value === null
+    ) {
+      return fallbackFavoriteModels.value
+    }
+
+    return serverFavoriteModels.value
+  })
+
+  const catalogModelIds = computed<Set<string>>(() => {
+    const { providers } = getProviders()
+
+    return new Set(
+      providers.flatMap((provider) => {
+        return provider.models.map((model) => {
+          return model.id
+        })
+      }),
+    )
+  })
+
+  // Filtered against the live catalog so a favorited model that was later
+  // removed or renamed upstream can't keep a phantom entry visible in the
+  // picker UI. `rawFavoriteModels` (unfiltered) remains what gets read for
+  // building the next PATCH payload, so a stale id is never silently
+  // dropped from what's actually persisted.
+  const favoriteModels = computed<string[]>(() => {
+    return rawFavoriteModels.value.filter((modelId) => {
+      return catalogModelIds.value.has(modelId)
+    })
+  })
+
   async function syncForUser(userId: string) {
     activeUserId.value = userId
     settingsError.value = null
@@ -196,6 +262,10 @@ export function useUserSetting() {
       const nextSidebarPinned = Boolean(response.sidebarPinned)
       serverSidebarPinned.value = nextSidebarPinned
       fallbackSidebarPinned.value = nextSidebarPinned
+
+      const nextFavoriteModels = response.favoriteModels ?? []
+      serverFavoriteModels.value = nextFavoriteModels
+      fallbackFavoriteModels.value = nextFavoriteModels
     } catch (exception) {
       if (
         activeUserId.value !== userId
@@ -210,6 +280,7 @@ export function useUserSetting() {
       serverAllowExternalLinks.value = null
       serverNotificationPromptState.value = null
       serverSidebarPinned.value = null
+      serverFavoriteModels.value = null
 
       const parsedException = parseError(exception)
 
@@ -462,6 +533,78 @@ export function useUserSetting() {
     }
   }
 
+  async function setFavoriteModels(favoriteModels: string[]) {
+    settingsError.value = null
+
+    const previousFallbackFavoriteModels
+      = fallbackFavoriteModels.value
+    fallbackFavoriteModels.value = favoriteModels
+
+    if (!activeUserId.value) {
+      return
+    }
+
+    const currentUserId = activeUserId.value as string
+    const previousServerFavoriteModels
+      = serverFavoriteModels.value as string[]
+
+    serverFavoriteModels.value = favoriteModels
+    isSavingSettings.value = true
+
+    const requestToken = lastFavoriteModelsRequestToken.value + 1
+    lastFavoriteModelsRequestToken.value = requestToken
+
+    try {
+      await $fetch('/api/v1/profiles/settings', {
+        method: 'PATCH',
+        body: {
+          favoriteModels,
+        },
+      })
+
+      if (
+        activeUserId.value !== currentUserId
+        || lastFavoriteModelsRequestToken.value !== requestToken
+      ) {
+        return
+      }
+
+      loadedUserId.value = currentUserId
+      serverFavoriteModels.value = favoriteModels
+      fallbackFavoriteModels.value = favoriteModels
+    } catch (exception) {
+      if (
+        activeUserId.value !== currentUserId
+        || lastFavoriteModelsRequestToken.value !== requestToken
+      ) {
+        return
+      }
+
+      serverFavoriteModels.value = previousServerFavoriteModels
+      fallbackFavoriteModels.value = previousFallbackFavoriteModels
+
+      const parsedException = parseError(exception)
+
+      settingsError.value = parsedException.message
+        || 'Failed to save profile settings'
+    } finally {
+      if (lastFavoriteModelsRequestToken.value === requestToken) {
+        isSavingSettings.value = false
+      }
+    }
+  }
+
+  async function toggleFavoriteModel(modelId: string) {
+    const current = rawFavoriteModels.value
+    const next = current.includes(modelId)
+      ? current.filter((id) => {
+        return id !== modelId
+      })
+      : [...current, modelId]
+
+    await setFavoriteModels(next)
+  }
+
   function clearUserContext() {
     activeUserId.value = null
     loadedUserId.value = null
@@ -470,6 +613,7 @@ export function useUserSetting() {
     serverAllowExternalLinks.value = null
     serverNotificationPromptState.value = null
     serverSidebarPinned.value = null
+    serverFavoriteModels.value = null
     settingsError.value = null
     isLoadingSettings.value = false
     isSavingSettings.value = false
@@ -482,6 +626,7 @@ export function useUserSetting() {
     allowExternalLinks,
     notificationPromptState,
     sidebarPinned,
+    favoriteModels,
     isLoadingSettings,
     isSavingSettings,
     settingsError,
@@ -491,6 +636,8 @@ export function useUserSetting() {
     setAllowExternalLinks,
     setNotificationPromptState,
     setSidebarPinned,
+    setFavoriteModels,
+    toggleFavoriteModel,
     clearUserContext,
   }
 }

--- a/app/types/models-picker.d.ts
+++ b/app/types/models-picker.d.ts
@@ -1,0 +1,21 @@
+import type { Model } from '#shared/types/providers.d'
+
+export type ModelCategory = 'chat' | 'research' | 'image-generation'
+
+export interface ModelCategoryOption {
+  value: ModelCategory
+  label: string
+  icon: string
+}
+
+export interface PickerModel {
+  model: Model
+  providerId: string
+  providerName: string
+}
+
+export interface PickerSection {
+  id: string
+  label: string
+  entries: PickerModel[]
+}

--- a/app/utils/models-picker.ts
+++ b/app/utils/models-picker.ts
@@ -11,11 +11,16 @@ export const modelCategoryOptions: ModelCategoryOption[] = [
   },
 ]
 
-const priceTierClasses: Record<ModelPriceTier, string> = {
-  '$': 'badge-success',
-  '$$': 'badge-info',
-  '$$$': 'badge-warning',
-  '$$$+': 'badge-error',
+interface PriceTierClasses {
+  badge: string
+  tooltip: string
+}
+
+const priceTierClasses: Record<ModelPriceTier, PriceTierClasses> = {
+  '$': { badge: 'badge-success', tooltip: 'tooltip-success' },
+  '$$': { badge: 'badge-info', tooltip: 'tooltip-info' },
+  '$$$': { badge: 'badge-warning', tooltip: 'tooltip-warning' },
+  '$$$+': { badge: 'badge-error', tooltip: 'tooltip-error' },
 }
 
 const monthNames = [
@@ -36,7 +41,11 @@ export function getModelCategory(model: Model): ModelCategory {
 }
 
 export function getPriceTierClass(tier: ModelPriceTier): string {
-  return priceTierClasses[tier] ?? 'badge-success'
+  return priceTierClasses[tier]?.badge ?? 'badge-success'
+}
+
+export function getPriceTierTooltipClass(tier: ModelPriceTier): string {
+  return priceTierClasses[tier]?.tooltip ?? 'tooltip-success'
 }
 
 export function hasImageGenerationCapability(model: Model): boolean {

--- a/app/utils/models-picker.ts
+++ b/app/utils/models-picker.ts
@@ -11,16 +11,11 @@ export const modelCategoryOptions: ModelCategoryOption[] = [
   },
 ]
 
-interface PriceTierClasses {
-  badge: string
-  tooltip: string
-}
-
-const priceTierClasses: Record<ModelPriceTier, PriceTierClasses> = {
-  '$': { badge: 'badge-success', tooltip: 'tooltip-success' },
-  '$$': { badge: 'badge-info', tooltip: 'tooltip-info' },
-  '$$$': { badge: 'badge-warning', tooltip: 'tooltip-warning' },
-  '$$$+': { badge: 'badge-error', tooltip: 'tooltip-error' },
+const priceTierClasses: Record<ModelPriceTier, string> = {
+  '$': 'badge-success',
+  '$$': 'badge-info',
+  '$$$': 'badge-warning',
+  '$$$+': 'badge-error',
 }
 
 const monthNames = [
@@ -41,11 +36,7 @@ export function getModelCategory(model: Model): ModelCategory {
 }
 
 export function getPriceTierClass(tier: ModelPriceTier): string {
-  return priceTierClasses[tier]?.badge ?? 'badge-success'
-}
-
-export function getPriceTierTooltipClass(tier: ModelPriceTier): string {
-  return priceTierClasses[tier]?.tooltip ?? 'tooltip-success'
+  return priceTierClasses[tier] ?? 'badge-success'
 }
 
 export function hasImageGenerationCapability(model: Model): boolean {

--- a/app/utils/models-picker.ts
+++ b/app/utils/models-picker.ts
@@ -1,0 +1,90 @@
+import type { Model, ModelPriceTier } from '#shared/types/providers.d'
+import type { ModelCategory, ModelCategoryOption } from '~/types/models-picker'
+
+export const modelCategoryOptions: ModelCategoryOption[] = [
+  { value: 'chat', label: 'Chat', icon: 'lucide:message-square' },
+  { value: 'research', label: 'Deep research', icon: 'lucide:telescope' },
+  {
+    value: 'image-generation',
+    label: 'Image generation',
+    icon: 'lucide:image-plus',
+  },
+]
+
+const priceTierClasses: Record<ModelPriceTier, string> = {
+  '$': 'badge-ghost text-base-content/50',
+  '$$': 'badge-ghost text-base-content/65',
+  '$$$': 'badge-ghost text-base-content/80',
+  '$$$+': 'badge-ghost text-base-content/95',
+}
+
+const monthNames = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+]
+
+export function getModelCategory(model: Model): ModelCategory {
+  if (model.research) {
+    return 'research'
+  }
+
+  if (isImageGenerationModel(model)) {
+    return 'image-generation'
+  }
+
+  return 'chat'
+}
+
+export function getPriceTierClass(tier: ModelPriceTier): string {
+  return priceTierClasses[tier] ?? 'badge-ghost text-base-content/50'
+}
+
+export function hasImageGenerationCapability(model: Model): boolean {
+  return model.tools.includes('image_generation')
+    || isImageGenerationModel(model)
+}
+
+export function getModelPriceTip(model: Model): string | undefined {
+  if (model.research) {
+    return `${model.research.costEstimate} · ${model.research.timeEstimate}`
+  }
+
+  if (model.price.display) {
+    return model.price.display
+  }
+
+  if (!model.price.output) {
+    return model.price.input || undefined
+  }
+
+  return `${model.price.input} / ${model.price.output}`
+}
+
+/**
+ * `gpt-image-2` genuinely reports zero context and zero max output upstream,
+ * so callers use the empty string to drop the row instead of printing "0".
+ * Named apart from `formatTokenCount` in `shared/utils/message-format.ts`,
+ * which auto-import would otherwise shadow.
+ */
+export function formatModelTokenLimit(count: number): string {
+  if (!count) {
+    return ''
+  }
+
+  return `${count.toLocaleString('en-US')} tokens`
+}
+
+/**
+ * Formats an ISO date without `Date`, whose local-timezone parsing shifts
+ * `2026-05-01` into April for every negative UTC offset.
+ */
+export function formatReleaseDate(isoDate: string): string {
+  const [year, month] = isoDate.split('-')
+  const monthName = monthNames[Number(month) - 1]
+
+  if (!year || !monthName) {
+    return isoDate
+  }
+
+  return `${monthName} ${year}`
+}

--- a/app/utils/models-picker.ts
+++ b/app/utils/models-picker.ts
@@ -12,10 +12,10 @@ export const modelCategoryOptions: ModelCategoryOption[] = [
 ]
 
 const priceTierClasses: Record<ModelPriceTier, string> = {
-  '$': 'badge-ghost text-base-content/50',
-  '$$': 'badge-ghost text-base-content/65',
-  '$$$': 'badge-ghost text-base-content/80',
-  '$$$+': 'badge-ghost text-base-content/95',
+  '$': 'badge-success',
+  '$$': 'badge-info',
+  '$$$': 'badge-warning',
+  '$$$+': 'badge-error',
 }
 
 const monthNames = [
@@ -36,7 +36,7 @@ export function getModelCategory(model: Model): ModelCategory {
 }
 
 export function getPriceTierClass(tier: ModelPriceTier): string {
-  return priceTierClasses[tier] ?? 'badge-ghost text-base-content/50'
+  return priceTierClasses[tier] ?? 'badge-success'
 }
 
 export function hasImageGenerationCapability(model: Model): boolean {

--- a/content/legal/cookie-policy.md
+++ b/content/legal/cookie-policy.md
@@ -57,6 +57,7 @@ These only remember how you like the app set up. They are stored **only if you a
 | `settings_reasoning_auto_hide` | localStorage | Besidka | Whether reasoning collapses by itself once an answer is done | Until removed |
 | `settings_reasoning_level` | localStorage | Besidka | Your preferred reasoning effort level | Until removed |
 | `settings_sidebar_pinned` | localStorage | Besidka | Whether the sidebar stays pinned open | Until removed |
+| `settings_favorite_models` | localStorage | Besidka | Your favorited models in the model picker, mirrored from your account settings | Until removed |
 | `model` | localStorage | Besidka | The model you used last, so a new chat starts with it | Until removed |
 | `chat_input` | localStorage | Besidka | The draft of the message currently in the input box, so it is still there if you navigate away and come back. Like the backup above it holds **your text verbatim**, in your browser only. Unlike the backup it is a convenience, so it is consent-gated and is deleted if you deny preferences | Until sent, cleared, or removed |
 | `plyr` | localStorage | Besidka | Video player preferences such as volume, captions and quality | Until removed |

--- a/docs/models-data-fetching.md
+++ b/docs/models-data-fetching.md
@@ -107,21 +107,48 @@ is "leaving on \<date\>," only that it currently is or isn't deprecated.
 value list, so an unrecognized future status string is dropped rather than
 persisted as-is), `ModelSnapshotEntry`/`Model` carry it as an optional field,
 and `mergeModelMetadata()` passes it through untouched — same fetched-metadata
-category as `releaseDate`. There is intentionally no UI badge for it yet;
-this PR only gets the field flowing through the data layer and into the
-audit warning above.
+category as `releaseDate`.
 
-As of this pass, two currently curated ids are flagged deprecated:
+`status === 'deprecated'` is enforced two ways once a model reaches this
+state:
 
-- **`gemini-3-pro-preview`** — a standalone curated chat model, not wired
-  as anyone's `assistModel`/`controllerModel`/`default`.
-- **`gemini-3.1-flash-lite-preview`** — curated with `forProjectMemory: true`
-  *and* wired as the `assistModel` for **both** Gemini Deep Research tiers
-  (`deep-research-max-preview-04-2026` and `deep-research-preview-04-2026`)
-  in `providers/google.ts`. `deprecated` doesn't mean already removed, but if
-  Google does pull it, both Deep Research configs' assist step breaks, not
-  just a picker row. Whether to swap it for a non-deprecated assist model
-  now or wait is a product decision for the owner — not guessed at here.
+- **Picker UI**: a deprecated model is removed from the normal selectable
+  list and collected into a collapsed "N legacy models" disclosure at the
+  bottom of the picker (`ModelsTrigger.vue`), mirroring t3.chat's own
+  pattern. Legacy rows are `aria-disabled`, expose no select or favorite
+  control, and their info button still opens the detail panel, which now
+  explains that the provider retired the model and it can no longer be
+  picked. A model that's deprecated but already the user's current
+  selection keeps resolving normally everywhere else — only the picker's
+  own selection surface stops offering it as a new pick.
+- **Server guard**: `useChatProvider()` (`server/utils/chats/provider.ts`)
+  rejects a deprecated model id with a structured 400 before any provider
+  call, closing the gap a client-side-only gate leaves open (a
+  `localStorage`/devtools edit could otherwise still send a deprecated
+  model id straight to the API).
+
+As of this pass, one currently curated id is flagged deprecated:
+
+- **`gemini-3-pro-preview`** — a standalone curated chat model whose
+  successor, `gemini-3.1-pro-preview`, is already curated separately. Left
+  in the catalog (not deleted — a user with it persisted would otherwise
+  see `getModel()` silently resolve to nothing) and handled entirely by the
+  legacy-section UI and server guard above.
+
+**`gemini-3.1-flash-lite-preview`** was ALSO flagged deprecated on an
+earlier pass of this audit, but that was a genuine bug, not a "leave it in
+the legacy section" case: it had already been superseded two months earlier
+by a stable, non-deprecated release, `gemini-3.1-flash-lite` (released
+2026-05-07 vs. the preview's 2026-03-03). The curated id, both Deep Research
+`assistModel` references (`deep-research-max-preview-04-2026` and
+`deep-research-preview-04-2026`), and the `forProjectMemory: true` flag were
+all swapped to the stable id in `providers/google.ts` — the deprecated
+preview id is no longer curated at all. The lesson: a `status: 'deprecated'`
+hit on a curated id should first be checked for a same-family successor
+already available upstream (often just the same name minus `-preview`, or
+the next point release) before assuming the legacy-section treatment is the
+right fix — swapping the id is strictly better when a real successor
+exists.
 
 ## Hard failure on a retired model
 
@@ -240,16 +267,24 @@ deliberately not fixed now — logged here instead of silently dropped:
   `last_updated` — so a "leaving on \<date\>" countdown badge isn't
   derivable from this data source; that would need a hand-curated
   retirement date per model. See "Model status" above for the coarse
-  present-tense `status` field this data source does carry, which is now
-  fetched and surfaced in the audit warning, but has no UI badge yet.
-- **`gemini-3.1-flash-lite-preview`'s fetched `description` already reads
-  *"Legacy model retained for compatibility with older integrations"***
-  (visible in the committed snapshot as of this PR, not a hypothetical
-  future fetch) — its `status: "deprecated"` flag and this description
-  both predate this PR's changes; nothing here newly triggered it. Its
-  likely stable successor, the non-preview `gemini-3.1-flash-lite`, exists
-  upstream and is not deprecated. See "Model status" above for the
-  Deep Research `assistModel` risk this creates.
+  present-tense `status` field this data source does carry instead, and
+  how it now drives the legacy-section UI and server guard.
+
+## New models added this pass — confidence on capability flags
+
+`gpt-5.6`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5` (OpenAI) and
+`gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite` (Google) were
+added to the curated files this pass, found via the audit report above.
+
+**`tool_call`/`reasoning: true` are confirmed** for all seven from
+models.dev's own fields, and OpenAI's docs additionally confirm web search
+for `gpt-5.6-sol`/`terra`/`luna` explicitly. **`tools: ['image_generation']`
+on all seven is a convention copy from sibling models in the same lineage
+(every `gpt-5.x`/`gemini-3.x` mainline entry already gets it), not a
+per-model capability confirmed against any field models.dev exposes.** If a
+model in this set turns out not to actually support image generation, a user
+picking that tool would only find out at generation time. Worth a spot-check
+before relying on it for a model you haven't tried yet.
 
 ## Ids deliberately not auto-added (owner review needed)
 
@@ -275,11 +310,15 @@ automatic add:
   bare `gpt-5.6` id was curated instead, matching how every other mainline
   release in this lineage (`gpt-5`, `gpt-5.1`, `gpt-5.2`, `gpt-5.4`) has no
   separate top-tier alias id.
-- **`gemini-3.5-flash-lite`** — a lite-tier sibling of the newly-curated
-  `gemini-3.5-flash`; leaving it out is a scope call (2 new models, not 3),
-  not a capability concern.
-- **`gemini-3.1-flash-lite`** — looks like the stable, non-preview
-  graduation of the currently-curated `gemini-3.1-flash-lite-preview` (see
-  the deprecation note above), but renaming vs. adding-alongside is a
-  decision that affects `forProjectMemory` and both Deep Research
-  `assistModel` references — left for the owner rather than guessed here.
+Two ids originally listed here on an earlier pass of this audit were
+subsequently added, not left out — corrected in a follow-up commit:
+
+- **`gemini-3.5-flash-lite`** is curated alongside `gemini-3.5-flash`. The
+  original exclusion reasoning ("scope call, not a capability concern") was
+  wrong on its own terms: `gemini-2.5-flash-lite` is already curated
+  alongside `gemini-2.5-flash`, so the lite-tier sibling is this app's
+  established convention for this provider, not a new product decision.
+- **`gemini-3.1-flash-lite`** is curated — it's the stable, non-preview
+  successor of the now-fully-removed `gemini-3.1-flash-lite-preview` (see
+  "Model status" above). `forProjectMemory: true` and both Deep Research
+  `assistModel` references were repointed to it.

--- a/docs/models-data-fetching.md
+++ b/docs/models-data-fetching.md
@@ -30,6 +30,7 @@ Workers build stays hermetic and offline, reading the committed snapshot.
 | `name` | fetched, unless the model is a research agent or models.dev publishes the bare id as the name |
 | `description` | fetched, unless the model is a research agent |
 | `contextLength`, `maxOutputTokens`, `modalities` | fetched |
+| `status` | fetched, present only when models.dev flags `deprecated`/`beta`/`alpha` |
 | `price.input`, `price.output` | fetched, unless the model is a research agent (billed per task) |
 | `price.display` | curated (per-image copy) |
 | `price.tokens` | curated (the structural cost divisor) |
@@ -55,6 +56,72 @@ The join only ever looks curated ids **up** in the remote catalog; it never
 iterates models.dev outward. Embedding, video, music, TTS, realtime and
 open-weights models that models.dev also lists therefore cannot reach the
 app, regardless of what the remote catalog grows.
+
+## Auditing curated vs. available models
+
+The curated-id-driven join above is deliberately one-directional: it means a
+junk model can never sneak in, but it also means a genuinely new, worthwhile
+model silently never appears until a human adds its id to `providers/*.ts`
+first. That's exactly what happened with GPT-5.6 — it existed on models.dev
+and in OpenAI's own docs for weeks before anyone noticed it was missing from
+the picker, because nothing was watching for it.
+
+`pnpm run models:fetch` now always prints a second report after the normal
+curated-id lookup: the full diff between every model id models.dev lists
+under the `google` and `openai` namespaces and the set of ids currently
+curated in `providers/google.ts` / `providers/openai.ts`. The report is
+grouped by provider and sorted newest release date first, so a fresh release
+worth reviewing surfaces near the top instead of being buried under years of
+embedding/TTS/video/dated-snapshot noise.
+
+This is informational only — it always prints and never fails the command.
+An unreviewed upstream model is expected and normal (models.dev tracks many
+models this app will never curate: embeddings, TTS, video, realtime,
+open-weights, and OpenAI/Google-internal chat-latest aliases). The point is
+visibility, not enforcement: read the printed list occasionally, decide what
+(if anything) is worth curating, same as reading
+`git diff providers/data/models-dev-snapshot.json` after a fetch.
+
+The diff logic lives in `scripts/audit-curated-models.mjs` as pure functions
+(`findUncuratedModels`, `formatUncuratedModelsReport`, and the deprecated-model
+pair below), kept out of `scripts/fetch-models-metadata.mjs` itself because
+that script fetches the network and writes the snapshot as a side effect of
+being imported — a unit test can't import it directly. Covered by
+`tests/unit/scripts/audit-curated-models.spec.ts`.
+
+The same run also prints a second, more urgent warning ahead of the
+uncurated-models report: any **currently curated** id whose models.dev
+`status` is `"deprecated"` right now, prefixed `⚠ DEPRECATED` so it can't be
+mistaken for the routine "not curated yet" list. This is still a report, not
+a hard failure — a deprecated model isn't necessarily already broken for
+BYOK users — but it's a stronger signal than "here's what's new upstream."
+See "Model status" below for what this caught on this pass.
+
+## Model status (deprecated/beta/alpha)
+
+Some models.dev entries carry a `status` field (`"deprecated"`, `"beta"`, or
+`"alpha"`) alongside `release_date`/`last_updated`. It's a coarse, *current*
+flag, not a forward-looking retirement date — models.dev never says a model
+is "leaving on \<date\>," only that it currently is or isn't deprecated.
+`toSnapshotEntry()` now captures it when present (validated against a known
+value list, so an unrecognized future status string is dropped rather than
+persisted as-is), `ModelSnapshotEntry`/`Model` carry it as an optional field,
+and `mergeModelMetadata()` passes it through untouched — same fetched-metadata
+category as `releaseDate`. There is intentionally no UI badge for it yet;
+this PR only gets the field flowing through the data layer and into the
+audit warning above.
+
+As of this pass, two currently curated ids are flagged deprecated:
+
+- **`gemini-3-pro-preview`** — a standalone curated chat model, not wired
+  as anyone's `assistModel`/`controllerModel`/`default`.
+- **`gemini-3.1-flash-lite-preview`** — curated with `forProjectMemory: true`
+  *and* wired as the `assistModel` for **both** Gemini Deep Research tiers
+  (`deep-research-max-preview-04-2026` and `deep-research-preview-04-2026`)
+  in `providers/google.ts`. `deprecated` doesn't mean already removed, but if
+  Google does pull it, both Deep Research configs' assist step breaks, not
+  just a picker row. Whether to swap it for a non-deprecated assist model
+  now or wait is a product decision for the owner — not guessed at here.
 
 ## Hard failure on a retired model
 
@@ -169,3 +236,50 @@ deliberately not fixed now — logged here instead of silently dropped:
   server-side.** An id that doesn't match any known model is stored as-is
   and simply never rendered (see "Favorites are DB-persisted" above) —
   inert, not a correctness risk, so not worth rejecting at the API layer.
+- **models.dev has no retirement *date* field**, only `release_date` and
+  `last_updated` — so a "leaving on \<date\>" countdown badge isn't
+  derivable from this data source; that would need a hand-curated
+  retirement date per model. See "Model status" above for the coarse
+  present-tense `status` field this data source does carry, which is now
+  fetched and surfaced in the audit warning, but has no UI badge yet.
+- **`gemini-3.1-flash-lite-preview`'s fetched `description` already reads
+  *"Legacy model retained for compatibility with older integrations"***
+  (visible in the committed snapshot as of this PR, not a hypothetical
+  future fetch) — its `status: "deprecated"` flag and this description
+  both predate this PR's changes; nothing here newly triggered it. Its
+  likely stable successor, the non-preview `gemini-3.1-flash-lite`, exists
+  upstream and is not deprecated. See "Model status" above for the
+  Deep Research `assistModel` risk this creates.
+
+## Ids deliberately not auto-added (owner review needed)
+
+Found upstream via the audit report above but intentionally left out of
+`providers/*.ts` in this pass — each needs a human product decision, not an
+automatic add:
+
+- **`gpt-5-pro`, `gpt-5.2-pro`, `gpt-5.4-pro`, `gpt-5.5-pro`** — a premium
+  "Pro" tier positioned above the mainline model at several times the
+  price; adding a whole new price tier to the picker is a bigger surface
+  decision than adding the next point release.
+- **`gpt-5.2-chat-latest`, `gpt-5.3-chat-latest`** — rolling aliases
+  ("-latest") that repoint to whatever OpenAI currently ships under that
+  name; curating a moving target breaks the assumption that a curated id
+  is a stable, specific model.
+- **`gpt-5.3-codex`, `gpt-5.3-codex-spark`** — coding-agent-specialized
+  variants, a different product positioning than this app's general chat
+  models (also: no plain `gpt-5.3` mainline model exists upstream at all).
+- **`gpt-5.6-sol`** — not a distinct model. OpenAI's own docs state
+  "Model ID: gpt-5.6-sol (aliased as gpt-5.6)", and its models.dev entry is
+  byte-identical to bare `gpt-5.6` (same cost, description, release date).
+  Curating both would show two indistinguishable rows for one model; the
+  bare `gpt-5.6` id was curated instead, matching how every other mainline
+  release in this lineage (`gpt-5`, `gpt-5.1`, `gpt-5.2`, `gpt-5.4`) has no
+  separate top-tier alias id.
+- **`gemini-3.5-flash-lite`** — a lite-tier sibling of the newly-curated
+  `gemini-3.5-flash`; leaving it out is a scope call (2 new models, not 3),
+  not a capability concern.
+- **`gemini-3.1-flash-lite`** — looks like the stable, non-preview
+  graduation of the currently-curated `gemini-3.1-flash-lite-preview` (see
+  the deprecation note above), but renaming vs. adding-alongside is a
+  decision that affects `forProjectMemory` and both Deep Research
+  `assistModel` references — left for the owner rather than guessed here.

--- a/docs/models-data-fetching.md
+++ b/docs/models-data-fetching.md
@@ -1,0 +1,171 @@
+# Model catalog: curated capabilities + fetched metadata
+
+The model catalog is split in two halves that are merged at import time.
+
+| Half | Lives in | Owner |
+|---|---|---|
+| Capabilities and product decisions | `providers/google.ts`, `providers/openai.ts` | hand-curated |
+| Objective metadata | `providers/data/models-dev-snapshot.json` | generated from [models.dev](https://models.dev) |
+
+`providers/index.ts` joins them through `mergeModelMetadata()` in
+`providers/merge.ts` and exports the same fully shaped `Providers` array
+consumers have always read through `getProviders()`.
+
+## Refreshing the snapshot
+
+```bash
+pnpm run models:fetch
+git diff providers/data/models-dev-snapshot.json
+```
+
+This is a manual maintenance step, like `pnpm run db:generate`. It is
+deliberately **not** part of `pnpm run build` or the Cloudflare deploy: the
+Workers build stays hermetic and offline, reading the committed snapshot.
+
+## Per-field merge policy
+
+| Field | Source |
+|---|---|
+| `id` | curated (the lookup key) |
+| `name` | fetched, unless the model is a research agent or models.dev publishes the bare id as the name |
+| `description` | fetched, unless the model is a research agent |
+| `contextLength`, `maxOutputTokens`, `modalities` | fetched |
+| `price.input`, `price.output` | fetched, unless the model is a research agent (billed per task) |
+| `price.display` | curated (per-image copy) |
+| `price.tokens` | curated (the structural cost divisor) |
+| `priceTier` | derived at merge time |
+| `tools`, `reasoning`, `research`, `imageGeneration`, `forProjectMemory`, `default` | curated |
+
+Research agents are recognised by their curated `research` block, so the
+policy never hardcodes model ids.
+
+Prices are rendered as strings with full precision, because
+`getModelCostMap()` in `server/utils/ai/cost-map.ts` parses them back into
+billing numbers. `providers/merge.ts` is covered by
+`tests/unit/providers/merge.spec.ts`, which asserts that round trip against
+the real catalog — keep that test passing before committing a refreshed
+snapshot.
+
+A `from $x` prefix marks context-tiered pricing (models.dev `cost.tiers`),
+where the figure is the cheapest tier rather than the only one.
+
+## Why a curated id can never pull in a junk model
+
+The join only ever looks curated ids **up** in the remote catalog; it never
+iterates models.dev outward. Embedding, video, music, TTS, realtime and
+open-weights models that models.dev also lists therefore cannot reach the
+app, regardless of what the remote catalog grows.
+
+## Hard failure on a retired model
+
+If a curated id disappears from models.dev, `pnpm run models:fetch` prints
+the full list and exits non-zero without writing the snapshot. That is the
+point of fetching: a retired or renamed model becomes a loud, deliberate
+edit instead of silently stale hardcoded values.
+
+`EXEMPT_IDS` in `scripts/fetch-models-metadata.mjs` lists the ids that are
+knowingly absent upstream — currently `o3-deep-research` and
+`o4-mini-deep-research`, whose Deep Research snapshots OpenAI bills
+separately but models.dev does not track. Exempt models carry their full
+metadata in the curated file, and the merge throws at import time if any of
+it is missing.
+
+## Optional owner-run spot-check
+
+Provider-native list-model endpoints require a real provider API key, and
+this project holds none — it is 100% BYOK, and adding a maintainer-side
+provider credential was rejected: the models.dev hard-fail already catches
+retirements, and key entitlement varies per key, tier and region anyway, so
+one maintainer key proves nothing about what users can call.
+
+If you want to verify by hand, swap in your own key:
+
+```bash
+curl -s https://api.openai.com/v1/models \
+  -H "Authorization: Bearer $OPENAI_API_KEY" | jq '.data[].id'
+
+curl -s "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY" \
+  | jq '.models[].name'
+```
+
+## No scheduled refresh workflow
+
+There is no cron workflow opening a refresh PR. The repo has no
+`create-pull-request` precedent in `.github/workflows/`, and a bot PR that
+renames user-visible models needs a human reading the diff anyway. Run
+`pnpm run models:fetch` when adding a model or when provider pricing
+changes.
+
+## Favorites are DB-persisted, not localStorage
+
+Unlike the current-model selection (`useUserModel()`, localStorage-only),
+favorited models are stored server-side on `user_settings.favoriteModels`
+(a nullable JSON `string[]` column, additive migration, no SQL default)
+so they sync across devices. `useUserSetting()` gained
+`favoriteModels`/`setFavoriteModels`/`toggleFavoriteModel`, mirroring the
+existing `sidebarPinned` field's server-value-with-localStorage-fallback
+pattern exactly. The localStorage fallback key (`settings_favorite_models`,
+used only while logged out or not yet synced) is declared in
+`content/legal/cookie-policy.md`'s Preferences table; the DB side needs no
+privacy-policy change, it's covered by that document's existing generic
+"Your settings, such as your preferred model..." line.
+
+The favorites list is computed against the *live* provider catalog, not
+the raw stored ids — if a favorited model is later removed or renamed
+upstream, its stale id is silently excluded from what's shown (the
+favorites star tab, the favorited-models section) without ever being
+deleted from what's persisted, so nothing is lost if that id ever
+reappears.
+
+## Owner action items
+
+Nothing is required to deploy this. Specifically:
+
+- **No new secrets or environment variables.** The picker, the fetch
+  script, and the favorites feature all run with what's already
+  configured.
+- **No manual production migration step.** The `favoriteModels` column is
+  a plain additive `ALTER TABLE ... ADD COLUMN`, no `DROP TABLE`, no
+  cascade risk — CI applies D1 migrations on deploy the same as any other
+  PR.
+- **`pnpm run models:fetch` is a manual, occasional maintenance command**,
+  not something you need to run regularly. Run it when you want to pull
+  in a provider's latest pricing/context-window changes, or before adding
+  a new curated model id (so its metadata is available at merge time
+  instead of hitting the "no snapshot entry" hard failure). After running
+  it, `git diff providers/data/models-dev-snapshot.json` and skim it
+  before committing — a refreshed snapshot can rename a model users
+  already picked (as happened with Nano Banana in this PR).
+- **The optional provider-key spot-check** (two `curl` commands, above)
+  is only useful if you suspect a specific model has quietly stopped
+  working for BYOK users. It is not part of any regular workflow.
+
+## Known trade-offs and deferred follow-ups (from the implementation review)
+
+These were raised by an adversarial review pass, confirmed real, and
+deliberately not fixed now — logged here instead of silently dropped:
+
+- **Search only matches the model name.** Typing an old pre-rename name
+  (e.g. "Gemini 2.5 Flash Image" for what's now "Nano Banana") or a
+  provider name won't surface a match. Low value relative to the effort
+  of indexing aliases; revisit if users report it.
+- **Duplicated ARIA id construction.** `model-option-${id}` and
+  `model-detail-${id}` are built independently in more than one component
+  instead of through a shared helper. Nothing is broken today — tests
+  pin the literal on both sides — but renaming the pattern later means
+  updating every call site by hand.
+- **Two independent price-string renderers** (the row tooltip vs. the
+  detail panel) produce differently formatted output from the same model
+  data. Cosmetic inconsistency only.
+- **Capability-icon conditionals are duplicated** between the row and the
+  detail panel for reasoning/web-search/deep-research (the
+  image-generation one was deduplicated during review). A fifth
+  capability would need adding in two places.
+- **Staged Escape** (closes the detail panel, then clears search, then
+  closes the picker) can take up to three presses to fully dismiss.
+  Deliberate — matches a pattern several command-palette-style UIs use —
+  but flagged in case it reads as unresponsive.
+- **Favorite model ids are never validated against the real catalog
+  server-side.** An id that doesn't match any known model is stored as-is
+  and simply never rendered (see "Favorites are DB-persisted" above) —
+  inert, not a correctness risk, so not worth rejecting at the API layer.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -155,7 +155,6 @@ export default defineNuxtConfig({
       privacyEmail: '',
       authorGithubProfile: '',
       defaultModel,
-      // @ts-expect-error
       providers,
       redirectUserTo: '/chats/new',
       redirectGuestTo: '/signin',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -227,11 +227,14 @@ export default defineNuxtConfig({
     },
   },
   eslint: {
-    checker: process.env.CI !== 'true'
-      ? {
-        eslintPath: 'eslint',
-      }
-      : false,
+    // vite-plugin-checker's client runtime virtual module fails to
+    // resolve under Vite 8 (`Failed to resolve import
+    // "/_nuxt/@vite-plugin-checker-runtime"`), which aborts the entire
+    // client bundle silently — SSR HTML looks fine but nothing
+    // hydrates. ESLint still runs fully via `pnpm run lint`/`format`
+    // and the pre-commit/pre-push hooks; the in-browser overlay isn't
+    // worth a broken dev client.
+    checker: false,
   },
   svgo: {
     autoImportPath: '~/assets/icons',
@@ -291,7 +294,11 @@ export default defineNuxtConfig({
     compatibilityVersion: 5,
   },
   typescript: {
-    typeCheck: process.env.CI !== 'true',
+    // Also routes through vite-plugin-checker, same as eslint.checker
+    // above — same Vite 8 client-injection breakage. Run
+    // `pnpm run typecheck` instead; it isn't live-in-terminal during
+    // dev anymore, but the dev client actually hydrates.
+    typeCheck: false,
   },
   vite: {
     build: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -227,14 +227,11 @@ export default defineNuxtConfig({
     },
   },
   eslint: {
-    // vite-plugin-checker's client runtime virtual module fails to
-    // resolve under Vite 8 (`Failed to resolve import
-    // "/_nuxt/@vite-plugin-checker-runtime"`), which aborts the entire
-    // client bundle silently — SSR HTML looks fine but nothing
-    // hydrates. ESLint still runs fully via `pnpm run lint`/`format`
-    // and the pre-commit/pre-push hooks; the in-browser overlay isn't
-    // worth a broken dev client.
-    checker: false,
+    checker: process.env.CI !== 'true'
+      ? {
+        eslintPath: 'eslint',
+      }
+      : false,
   },
   svgo: {
     autoImportPath: '~/assets/icons',
@@ -294,11 +291,7 @@ export default defineNuxtConfig({
     compatibilityVersion: 5,
   },
   typescript: {
-    // Also routes through vite-plugin-checker, same as eslint.checker
-    // above — same Vite 8 client-injection breakage. Run
-    // `pnpm run typecheck` instead; it isn't live-in-terminal during
-    // dev anymore, but the dev client actually hydrates.
-    typeCheck: false,
+    typeCheck: process.env.CI !== 'true',
   },
   vite: {
     build: {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"test:affected:fast": "node scripts/test-affected.mjs --type=unit && node scripts/test-affected.mjs --type=integration",
 		"coverage": "vitest run --coverage --passWithNoTests",
 		"coverage:ui": "vitest --coverage --ui",
+		"models:fetch": "node scripts/fetch-models-metadata.mjs",
 		"db:generate": "drizzle-kit generate",
 		"db:reset": "rm -rf .wrangler/state/v3/d1 && drizzle-kit generate && pnpm exec wrangler d1 migrations apply DB",
 		"db:migrate": "pnpm exec wrangler d1 migrations apply DB",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   unhead: 3.2.1
   '@unhead/vue': 3.2.1
   '@unhead/bundler': 3.2.1
+  vite-plugin-checker: 0.14.5
 
 importers:
 
@@ -8906,8 +8907,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  vite-plugin-checker@0.14.4:
-    resolution: {integrity: sha512-Tw0U9UgHIRiZ+Yoe4Gh0RrYoBiCVmO9j4tomVdYr0KUjUsqXMPhqW8ouoSWmOzGp5Iimipbl3bNXZcK7OeP7Qg==}
+  vite-plugin-checker@0.14.5:
+    resolution: {integrity: sha512-c9lQ92eisUO+F7Fd93aelojmiOS+NQpPgQ1XR2LTQHox1/laZf4yAoQj+L3RA9Vgh10e2nFd9b8r2LLyYZsbpA==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@biomejs/biome': '>=2.4.12'
@@ -12007,7 +12008,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
-      vite-plugin-checker: 0.14.4(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(meow@14.1.0)(optionator@0.9.4)(typescript@6.0.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@6.0.3))
+      vite-plugin-checker: 0.14.5(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(meow@14.1.0)(optionator@0.9.4)(typescript@6.0.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@6.0.3))
       vue: 3.5.40(typescript@6.0.3)
       vue-bundle-renderer: 2.3.1
     optionalDependencies:
@@ -19441,7 +19442,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.14.4(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(meow@14.1.0)(optionator@0.9.4)(typescript@6.0.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@6.0.3)):
+  vite-plugin-checker@0.14.5(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(meow@14.1.0)(optionator@0.9.4)(typescript@6.0.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@6.0.3)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ overrides:
   unhead: 3.2.1
   '@unhead/vue': 3.2.1
   '@unhead/bundler': 3.2.1
+  vite-plugin-checker: 0.14.5
 
 allowBuilds:
   '@parcel/watcher': true

--- a/providers/data/models-dev-snapshot.json
+++ b/providers/data/models-dev-snapshot.json
@@ -103,6 +103,31 @@
       "output": 9
     }
   },
+  "gemini-3.5-flash-lite": {
+    "name": "Gemini 3.5 Flash Lite",
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "releaseDate": "2026-07-21",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.3,
+      "output": 2.5
+    }
+  },
   "gemini-3.1-pro-preview": {
     "name": "Gemini 3.1 Pro Preview",
     "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
@@ -129,11 +154,10 @@
     },
     "tieredPricing": true
   },
-  "gemini-3.1-flash-lite-preview": {
-    "name": "Gemini 3.1 Flash Lite Preview",
-    "description": "Legacy model retained for compatibility with older integrations",
-    "releaseDate": "2026-03-03",
-    "status": "deprecated",
+  "gemini-3.1-flash-lite": {
+    "name": "Gemini 3.1 Flash Lite",
+    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "releaseDate": "2026-05-07",
     "limit": {
       "context": 1048576,
       "output": 65536

--- a/providers/data/models-dev-snapshot.json
+++ b/providers/data/models-dev-snapshot.json
@@ -53,6 +53,56 @@
     },
     "tieredPricing": true
   },
+  "gemini-3.6-flash": {
+    "name": "Gemini 3.6 Flash",
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "releaseDate": "2026-07-21",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.5,
+      "output": 7.5
+    }
+  },
+  "gemini-3.5-flash": {
+    "name": "Gemini 3.5 Flash",
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "releaseDate": "2026-05-19",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.5,
+      "output": 9
+    }
+  },
   "gemini-3.1-pro-preview": {
     "name": "Gemini 3.1 Pro Preview",
     "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
@@ -324,6 +374,102 @@
       "input": 0.3,
       "output": 30
     }
+  },
+  "gpt-5.6": {
+    "name": "GPT-5.6",
+    "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+    "releaseDate": "2026-07-09",
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 30
+    },
+    "tieredPricing": true
+  },
+  "gpt-5.6-terra": {
+    "name": "GPT-5.6 Terra",
+    "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+    "releaseDate": "2026-07-09",
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 12
+    },
+    "tieredPricing": true
+  },
+  "gpt-5.6-luna": {
+    "name": "GPT-5.6 Luna",
+    "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+    "releaseDate": "2026-07-09",
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.2,
+      "output": 1.2
+    },
+    "tieredPricing": true
+  },
+  "gpt-5.5": {
+    "name": "GPT-5.5",
+    "description": "Default frontier GPT for coding, computer use, research, and knowledge work",
+    "releaseDate": "2026-04-23",
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 30
+    },
+    "tieredPricing": true
   },
   "gpt-5.4": {
     "name": "GPT-5.4",

--- a/providers/data/models-dev-snapshot.json
+++ b/providers/data/models-dev-snapshot.json
@@ -401,8 +401,8 @@
       "output": 30
     }
   },
-  "gpt-5.6": {
-    "name": "GPT-5.6",
+  "gpt-5.6-sol": {
+    "name": "GPT-5.6 Sol",
     "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
     "releaseDate": "2026-07-09",
     "limit": {

--- a/providers/data/models-dev-snapshot.json
+++ b/providers/data/models-dev-snapshot.json
@@ -133,6 +133,7 @@
     "name": "Gemini 3.1 Flash Lite Preview",
     "description": "Legacy model retained for compatibility with older integrations",
     "releaseDate": "2026-03-03",
+    "status": "deprecated",
     "limit": {
       "context": 1048576,
       "output": 65536
@@ -158,6 +159,7 @@
     "name": "Gemini 3 Pro Preview",
     "description": "Preview Gemini flagship for complex reasoning, coding, and rich multimodal prompts",
     "releaseDate": "2025-11-18",
+    "status": "deprecated",
     "limit": {
       "context": 1048576,
       "output": 65536

--- a/providers/data/models-dev-snapshot.json
+++ b/providers/data/models-dev-snapshot.json
@@ -1,0 +1,528 @@
+{
+  "deep-research-max-preview-04-2026": {
+    "name": "Deep Research Max Preview (Apr-21-2026)",
+    "description": "Maximum-comprehensiveness agentic researcher for multi-step investigation, synthesis, and cited reports",
+    "releaseDate": "2026-04-21",
+    "limit": {
+      "context": 131072,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 12
+    },
+    "tieredPricing": true
+  },
+  "deep-research-preview-04-2026": {
+    "name": "Deep Research Preview (Apr-21-2026)",
+    "description": "Agentic model for autonomous multi-step research, synthesis, and cited reports",
+    "releaseDate": "2026-04-21",
+    "limit": {
+      "context": 131072,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 12
+    },
+    "tieredPricing": true
+  },
+  "gemini-3.1-pro-preview": {
+    "name": "Gemini 3.1 Pro Preview",
+    "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
+    "releaseDate": "2026-02-19",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 12
+    },
+    "tieredPricing": true
+  },
+  "gemini-3.1-flash-lite-preview": {
+    "name": "Gemini 3.1 Flash Lite Preview",
+    "description": "Legacy model retained for compatibility with older integrations",
+    "releaseDate": "2026-03-03",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.25,
+      "output": 1.5
+    }
+  },
+  "gemini-3-pro-preview": {
+    "name": "Gemini 3 Pro Preview",
+    "description": "Preview Gemini flagship for complex reasoning, coding, and rich multimodal prompts",
+    "releaseDate": "2025-11-18",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 12
+    },
+    "tieredPricing": true
+  },
+  "gemini-3-flash-preview": {
+    "name": "Gemini 3 Flash Preview",
+    "description": "New Gemini flash lane bringing frontier-style multimodal reasoning to cheaper runs",
+    "releaseDate": "2025-12-17",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.5,
+      "output": 3
+    }
+  },
+  "gemini-2.5-pro": {
+    "name": "Gemini 2.5 Pro",
+    "description": "Google's proven reasoning model for coding, math, and multimodal analysis",
+    "releaseDate": "2025-06-17",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.25,
+      "output": 10
+    },
+    "tieredPricing": true
+  },
+  "gemini-2.5-flash": {
+    "name": "Gemini 2.5 Flash",
+    "description": "Fast Gemini workhorse for multimodal apps where latency and price matter",
+    "releaseDate": "2025-06-17",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.3,
+      "output": 2.5
+    }
+  },
+  "gemini-2.5-flash-lite": {
+    "name": "Gemini 2.5 Flash-Lite",
+    "description": "Lean Gemini 2.5 lane for cheap multimodal traffic and quick agents",
+    "releaseDate": "2025-06-17",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.1,
+      "output": 0.4
+    }
+  },
+  "gemini-3.1-flash-image": {
+    "name": "Nano Banana 2",
+    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+    "releaseDate": "2026-05-28",
+    "limit": {
+      "context": 65536,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "cost": {
+      "input": 0.5,
+      "output": 60
+    }
+  },
+  "gemini-3.1-flash-lite-image": {
+    "name": "Nano Banana 2 Lite",
+    "description": "Fastest, most cost-efficient Gemini image model for high-volume 1K generation and editing",
+    "releaseDate": "2026-06-30",
+    "limit": {
+      "context": 65536,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "cost": {
+      "input": 0.25,
+      "output": 30
+    }
+  },
+  "gemini-3-pro-image": {
+    "name": "Nano Banana Pro",
+    "description": "Nano Banana Pro for higher-fidelity image generation and design-heavy edits",
+    "releaseDate": "2026-05-28",
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 120
+    }
+  },
+  "gemini-2.5-flash-image": {
+    "name": "Nano Banana",
+    "description": "Nano Banana image model for fast generation, edits, and character-consistent assets",
+    "releaseDate": "2025-08-26",
+    "limit": {
+      "context": 32768,
+      "output": 32768
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text",
+        "image"
+      ]
+    },
+    "cost": {
+      "input": 0.3,
+      "output": 30
+    }
+  },
+  "gpt-5.4": {
+    "name": "GPT-5.4",
+    "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
+    "releaseDate": "2026-03-05",
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2.5,
+      "output": 15
+    },
+    "tieredPricing": true
+  },
+  "gpt-5.4-mini": {
+    "name": "GPT-5.4 mini",
+    "description": "Strong small GPT for coding subagents, quick tool use, and high-volume work",
+    "releaseDate": "2026-03-17",
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.75,
+      "output": 4.5
+    }
+  },
+  "gpt-5.4-nano": {
+    "name": "GPT-5.4 nano",
+    "description": "Cheapest GPT-5.4 lane for simple routing, extraction, and bulk automation",
+    "releaseDate": "2026-03-17",
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.2,
+      "output": 1.25
+    }
+  },
+  "gpt-5.2": {
+    "name": "GPT-5.2",
+    "description": "Reliable GPT generation for broad coding, writing, and tool-assisted product work",
+    "releaseDate": "2025-12-11",
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.75,
+      "output": 14
+    }
+  },
+  "gpt-5.1": {
+    "name": "GPT-5.1",
+    "description": "Sharper GPT-5 generation for coding, product work, and tool-assisted tasks",
+    "releaseDate": "2025-11-13",
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.25,
+      "output": 10
+    }
+  },
+  "gpt-5": {
+    "name": "GPT-5",
+    "description": "Original GPT-5 workhorse for reasoning, coding, writing, and tool workflows",
+    "releaseDate": "2025-08-07",
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1.25,
+      "output": 10
+    }
+  },
+  "gpt-5-mini": {
+    "name": "GPT-5 Mini",
+    "description": "Small GPT-5 for responsive agents, coding help, and everyday automation",
+    "releaseDate": "2025-08-07",
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.25,
+      "output": 2
+    }
+  },
+  "gpt-5-nano": {
+    "name": "GPT-5 Nano",
+    "description": "Tiny GPT-5 lane for routing, extraction, classification, and bulk jobs",
+    "releaseDate": "2025-08-07",
+    "limit": {
+      "context": 400000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.05,
+      "output": 0.4
+    }
+  },
+  "gpt-image-2": {
+    "name": "gpt-image-2",
+    "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+    "releaseDate": "2026-04-21",
+    "limit": {
+      "context": 0,
+      "output": 0
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 30
+    }
+  }
+}

--- a/providers/google.ts
+++ b/providers/google.ts
@@ -1,3 +1,5 @@
+import type { CuratedProvider } from './merge'
+
 export default {
   id: 'google',
   name: 'Google AI Studio',
@@ -6,16 +8,10 @@ export default {
       id: 'deep-research-max-preview-04-2026',
       name: 'Gemini Deep Research Max',
       description: 'Autonomous agent for exhaustive, cross-checked web research and cited reports on deep or high-stakes topics, for $3–7 per task',
-      contextLength: 1_000_000,
-      maxOutputTokens: 65_536,
       price: {
         tokens: 1_000_000,
         input: '$3–7 / task',
         output: '',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text'],
       },
       tools: [],
       research: {
@@ -29,16 +25,10 @@ export default {
       id: 'deep-research-preview-04-2026',
       name: 'Gemini Deep Research',
       description: 'Autonomous agent that browses the web, cross-checks sources, and writes a cited research report for $1–3 per task',
-      contextLength: 1_000_000,
-      maxOutputTokens: 65_536,
       price: {
         tokens: 1_000_000,
         input: '$1–3 / task',
         output: '',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text'],
       },
       tools: [],
       research: {
@@ -50,11 +40,8 @@ export default {
     },
     {
       id: 'gemini-3.1-pro-preview',
-      name: 'Gemini 3.1 Pro',
       price: {
         tokens: 1_000_000,
-        input: 'from $2.00',
-        output: 'from $12.00',
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -64,11 +51,8 @@ export default {
     },
     {
       id: 'gemini-3.1-flash-lite-preview',
-      name: 'Gemini 3.1 Flash Lite',
       price: {
         tokens: 1_000_000,
-        input: '$0.25',
-        output: '$1.50',
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -79,11 +63,8 @@ export default {
     },
     {
       id: 'gemini-3-pro-preview',
-      name: 'Gemini 3 Pro',
       price: {
         tokens: 1_000_000,
-        input: 'from $2.00',
-        output: 'from $12.00',
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -93,11 +74,8 @@ export default {
     },
     {
       id: 'gemini-3-flash-preview',
-      name: 'Gemini 3 Flash',
       price: {
         tokens: 1_000_000,
-        input: '$0.50',
-        output: '$3.00',
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -107,11 +85,8 @@ export default {
     },
     {
       id: 'gemini-2.5-pro',
-      name: 'Gemini 2.5 Pro',
       price: {
         tokens: 1_000_000,
-        input: 'from $1.25',
-        output: 'from $10.00',
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -121,11 +96,8 @@ export default {
     },
     {
       id: 'gemini-2.5-flash',
-      name: 'Gemini 2.5 Flash',
       price: {
         tokens: 1_000_000,
-        input: '$0.30',
-        output: '$2.50',
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -136,11 +108,8 @@ export default {
     {
       id: 'gemini-2.5-flash-lite',
       default: true,
-      name: 'Gemini 2.5 Flash-Lite',
       price: {
         tokens: 1_000_000,
-        input: '$0.10',
-        output: '$0.40',
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -150,19 +119,9 @@ export default {
     },
     {
       id: 'gemini-3.1-flash-image',
-      name: 'Gemini 3.1 Flash Image',
-      description: 'High-quality, low-latency image generation and editing for interactive and high-volume workflows',
-      contextLength: 131_072,
-      maxOutputTokens: 32_768,
       price: {
         tokens: 1,
-        input: '',
-        output: '',
         display: '$0.067 / 1K image, plus input',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text', 'image'],
       },
       tools: [],
       imageGeneration: {
@@ -171,19 +130,9 @@ export default {
     },
     {
       id: 'gemini-3.1-flash-lite-image',
-      name: 'Gemini 3.1 Flash Lite Image',
-      description: 'Ultra-low-latency, cost-efficient image generation and editing optimized for 1K output',
-      contextLength: 65_536,
-      maxOutputTokens: 4_096,
       price: {
         tokens: 1,
-        input: '',
-        output: '',
         display: '$0.0336 / 1K image, plus input',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text', 'image'],
       },
       tools: [],
       imageGeneration: {
@@ -192,19 +141,9 @@ export default {
     },
     {
       id: 'gemini-3-pro-image',
-      name: 'Gemini 3 Pro Image',
-      description: 'Professional-grade image generation and editing for complex design, mockups, and data visualization',
-      contextLength: 65_536,
-      maxOutputTokens: 32_768,
       price: {
         tokens: 1,
-        input: '',
-        output: '',
         display: '$0.134 / 1K or 2K image, plus input',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text', 'image'],
       },
       tools: [],
       imageGeneration: {
@@ -213,19 +152,9 @@ export default {
     },
     {
       id: 'gemini-2.5-flash-image',
-      name: 'Gemini 2.5 Flash Image',
-      description: 'Fast native image generation and conversational editing for high-volume creative workflows',
-      contextLength: 65_536,
-      maxOutputTokens: 32_768,
       price: {
         tokens: 1,
-        input: '',
-        output: '',
         display: '$0.039 / 1K image, plus input',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text', 'image'],
       },
       tools: [],
       imageGeneration: {
@@ -233,4 +162,4 @@ export default {
       },
     },
   ],
-}
+} satisfies CuratedProvider

--- a/providers/google.ts
+++ b/providers/google.ts
@@ -39,6 +39,28 @@ export default {
       },
     },
     {
+      id: 'gemini-3.6-flash',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search', 'image_generation'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
+      id: 'gemini-3.5-flash',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search', 'image_generation'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
       id: 'gemini-3.1-pro-preview',
       price: {
         tokens: 1_000_000,

--- a/providers/google.ts
+++ b/providers/google.ts
@@ -16,7 +16,7 @@ export default {
       tools: [],
       research: {
         tier: 'thorough',
-        assistModel: 'gemini-3.1-flash-lite-preview',
+        assistModel: 'gemini-3.1-flash-lite',
         costEstimate: '$3–7 / task',
         timeEstimate: 'up to 60 min',
       },
@@ -33,7 +33,7 @@ export default {
       tools: [],
       research: {
         tier: 'quick',
-        assistModel: 'gemini-3.1-flash-lite-preview',
+        assistModel: 'gemini-3.1-flash-lite',
         costEstimate: '$1–3 / task',
         timeEstimate: 'under 20 min',
       },
@@ -61,6 +61,17 @@ export default {
       },
     },
     {
+      id: 'gemini-3.5-flash-lite',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search', 'image_generation'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
       id: 'gemini-3.1-pro-preview',
       price: {
         tokens: 1_000_000,
@@ -72,7 +83,7 @@ export default {
       },
     },
     {
-      id: 'gemini-3.1-flash-lite-preview',
+      id: 'gemini-3.1-flash-lite',
       price: {
         tokens: 1_000_000,
       },

--- a/providers/index.ts
+++ b/providers/index.ts
@@ -1,20 +1,27 @@
+import type { Providers } from '../shared/types/providers.d'
+import type { ModelSnapshot } from './merge'
+import snapshot from './data/models-dev-snapshot.json'
+import { mergeProvider } from './merge'
 // import anthropic from './anthropic'
 import google from './google'
 import openai from './openai'
 
-export const providers = [
+const curatedProviders = [
   // @TODO Anthropic is under development yet
   // anthropic,
   google,
   openai,
 ]
 
+export const providers: Providers = curatedProviders.map((provider) => {
+  return mergeProvider(provider, snapshot as ModelSnapshot)
+})
+
 const defaultFirstFoundModel = providers[0]?.models[0]?.id
 let defaultMarkedModel: string = ''
 
 for (const provider of providers) {
   for (const model of provider.models) {
-    // @ts-expect-error
     if (model.default) {
       defaultMarkedModel = model.id
       break

--- a/providers/merge.ts
+++ b/providers/merge.ts
@@ -1,0 +1,306 @@
+import type { ReasoningCapability } from '../shared/types/reasoning.d'
+import type { ModelResearchConfig } from '../shared/types/research.d'
+import type {
+  Model,
+  ModelImageGenerationCapability,
+  ModelPriceTier,
+  ModelTool,
+  Provider,
+} from '../shared/types/providers.d'
+
+export interface CuratedModelPrice {
+  tokens: number
+  input?: string
+  output?: string
+  display?: string
+}
+
+export interface CuratedModel {
+  id: string
+  name?: string
+  description?: string
+  contextLength?: number
+  maxOutputTokens?: number
+  price: CuratedModelPrice
+  modalities?: Model['modalities']
+  tools: ModelTool[]
+  default?: boolean
+  forProjectMemory?: boolean
+  imageGeneration?: ModelImageGenerationCapability
+  reasoning?: ReasoningCapability
+  research?: ModelResearchConfig
+}
+
+export interface CuratedProvider {
+  id: string
+  name: string
+  models: CuratedModel[]
+}
+
+export interface ModelSnapshotEntry {
+  name: string
+  description: string
+  releaseDate?: string
+  limit: {
+    context: number
+    output: number
+  }
+  modalities: {
+    input: string[]
+    output: string[]
+  }
+  cost: {
+    input: number
+    output: number
+  }
+  tieredPricing?: boolean
+}
+
+export type ModelSnapshot = Record<string, ModelSnapshotEntry>
+
+const highestPriceTier: ModelPriceTier = '$$$+'
+
+const tierCeilingsPerMillionTokens: [number, ModelPriceTier][] = [
+  [0.5, '$'],
+  [2, '$$'],
+  [5, '$$$'],
+]
+
+const researchTierCeilingsPerTask: [number, ModelPriceTier][] = [
+  [2, '$$'],
+  [8, '$$$'],
+]
+
+const tierCeilingsPerImage: [number, ModelPriceTier][] = [
+  [0.05, '$'],
+  [0.1, '$$'],
+  [0.25, '$$$'],
+]
+
+function resolveTier(
+  amount: number,
+  ceilings: [number, ModelPriceTier][],
+): ModelPriceTier {
+  for (const [ceiling, tier] of ceilings) {
+    if (amount <= ceiling) {
+      return tier
+    }
+  }
+
+  return highestPriceTier
+}
+
+/**
+ * Read the upper bound out of a human price string such as `'$3–7 / task'`,
+ * `'$0.041–$0.053 / medium image'`, `'~$10 / task'` or `'$0.25'`. Only
+ * digits attached to a `$` count, so trailing units ("/ 1K image") never
+ * leak into the number. The second bound's `$` is optional so both range
+ * spellings (one leading `$`, or one per number) resolve the same way.
+ */
+export function parseUpperBoundPrice(value: string): number | null {
+  const match = value.match(
+    /\$\s*(\d+(?:\.\d+)?)(?:\s*[–—-]\s*\$?\s*(\d+(?:\.\d+)?))?/,
+  )
+  const upperBound = match?.[2] ?? match?.[1]
+
+  if (upperBound === undefined) {
+    return null
+  }
+
+  return Number(upperBound)
+}
+
+/**
+ * Render a per-million-token dollar amount for display without losing
+ * precision: `parsePrice()` in `server/utils/ai/cost-map.ts` reads these
+ * strings back as billing input, so a fixed two-decimal round would
+ * silently change costs for models priced at fractions of a cent. The
+ * `from` prefix marks context-tiered pricing, where the number is the
+ * cheapest tier rather than the only one.
+ */
+export function formatPrice(amount: number, tiered?: boolean): string {
+  const isRoundedToCents = Number.isInteger(amount * 100)
+  const formatted = isRoundedToCents ? amount.toFixed(2) : String(amount)
+
+  return tiered ? `from $${formatted}` : `$${formatted}`
+}
+
+/**
+ * models.dev falls back to the bare model id when a provider publishes no
+ * marketing name (`gpt-image-2`). Such an entry is worse than the curated
+ * name, so it never wins the merge.
+ */
+function isPlaceholderName(name: string, modelId: string): boolean {
+  return name.toLowerCase() === modelId.toLowerCase()
+}
+
+function resolvePriceTier(
+  curated: CuratedModel,
+  snapshot: ModelSnapshotEntry | undefined,
+): ModelPriceTier {
+  if (curated.research) {
+    const costPerTask = parseUpperBoundPrice(curated.research.costEstimate)
+
+    if (costPerTask !== null) {
+      return resolveTier(costPerTask, researchTierCeilingsPerTask)
+    }
+  }
+
+  if (curated.imageGeneration) {
+    const costPerImage = parseUpperBoundPrice(curated.price.display ?? '')
+
+    if (costPerImage !== null) {
+      return resolveTier(costPerImage, tierCeilingsPerImage)
+    }
+  }
+
+  if (snapshot) {
+    return resolveTier(snapshot.cost.input, tierCeilingsPerMillionTokens)
+  }
+
+  const curatedInput = parseUpperBoundPrice(curated.price.input ?? '')
+
+  if (curatedInput !== null) {
+    return resolveTier(curatedInput, tierCeilingsPerMillionTokens)
+  }
+
+  return highestPriceTier
+}
+
+/**
+ * Optional fields are omitted rather than set to `undefined`: the merged
+ * catalog is injected into `runtimeConfig.public`, and Nuxt serializes an
+ * `undefined` config value as an empty string — which would make
+ * `price.display ?? …` resolve to `''` instead of falling through.
+ */
+function curatedCapabilities(curated: CuratedModel) {
+  return {
+    tools: curated.tools,
+    ...(curated.default ? { default: curated.default } : {}),
+    ...(curated.forProjectMemory
+      ? { forProjectMemory: curated.forProjectMemory }
+      : {}),
+    ...(curated.imageGeneration
+      ? { imageGeneration: curated.imageGeneration }
+      : {}),
+    ...(curated.reasoning ? { reasoning: curated.reasoning } : {}),
+    ...(curated.research ? { research: curated.research } : {}),
+  }
+}
+
+function mergedPrice(
+  curated: CuratedModelPrice,
+  input: string,
+  output: string,
+) {
+  return {
+    tokens: curated.tokens,
+    input,
+    output,
+    ...(curated.display ? { display: curated.display } : {}),
+  }
+}
+
+function toFullyCuratedModel(curated: CuratedModel): Model {
+  const {
+    id,
+    name,
+    description,
+    contextLength,
+    maxOutputTokens,
+    modalities,
+  } = curated
+
+  if (
+    name === undefined
+    || description === undefined
+    || contextLength === undefined
+    || maxOutputTokens === undefined
+    || modalities === undefined
+  ) {
+    throw new Error(
+      `Model "${id}" has no models.dev snapshot entry. Run `
+      + '`pnpm run models:fetch`, or curate name, description, '
+      + 'contextLength, maxOutputTokens and modalities for it the way '
+      + 'EXEMPT_IDS models are curated.',
+    )
+  }
+
+  return {
+    id,
+    name,
+    description,
+    contextLength,
+    maxOutputTokens,
+    price: mergedPrice(
+      curated.price,
+      curated.price.input ?? '',
+      curated.price.output ?? '',
+    ),
+    priceTier: resolvePriceTier(curated, undefined),
+    modalities,
+    ...curatedCapabilities(curated),
+  }
+}
+
+/**
+ * Merge one hand-curated model entry with its `models.dev` snapshot entry
+ * into the fully shaped `Model` every consumer reads.
+ *
+ * Curated wins for product decisions (capabilities, tools, defaults, the
+ * structural `price.tokens` divisor, the per-image `price.display` copy) and
+ * for research-agent models, whose name, description and price deliberately
+ * encode per-task billing that no per-token figure can express. Everything
+ * objective — specs, modalities, release date, per-token cost — comes from
+ * the snapshot.
+ * A model with no snapshot entry is fully curated by necessity; see
+ * `EXEMPT_IDS` in `scripts/fetch-models-metadata.mjs`.
+ */
+export function mergeModelMetadata(
+  curated: CuratedModel,
+  snapshot: ModelSnapshotEntry | undefined,
+): Model {
+  if (!snapshot) {
+    return toFullyCuratedModel(curated)
+  }
+
+  const keepCuratedPrice = !!curated.research
+  const keepCuratedName = !!curated.research
+    || isPlaceholderName(snapshot.name, curated.id)
+
+  return {
+    id: curated.id,
+    name: keepCuratedName ? curated.name ?? snapshot.name : snapshot.name,
+    description: curated.research
+      ? curated.description ?? snapshot.description
+      : snapshot.description,
+    contextLength: snapshot.limit.context,
+    maxOutputTokens: snapshot.limit.output,
+    ...(snapshot.releaseDate ? { releaseDate: snapshot.releaseDate } : {}),
+    price: mergedPrice(
+      curated.price,
+      keepCuratedPrice
+        ? curated.price.input ?? ''
+        : formatPrice(snapshot.cost.input, snapshot.tieredPricing),
+      keepCuratedPrice
+        ? curated.price.output ?? ''
+        : formatPrice(snapshot.cost.output, snapshot.tieredPricing),
+    ),
+    priceTier: resolvePriceTier(curated, snapshot),
+    modalities: snapshot.modalities,
+    ...curatedCapabilities(curated),
+  }
+}
+
+export function mergeProvider(
+  curated: CuratedProvider,
+  snapshot: ModelSnapshot,
+): Provider {
+  return {
+    id: curated.id,
+    name: curated.name,
+    models: curated.models.map((model) => {
+      return mergeModelMetadata(model, snapshot[model.id])
+    }),
+  }
+}

--- a/providers/merge.ts
+++ b/providers/merge.ts
@@ -41,6 +41,7 @@ export interface ModelSnapshotEntry {
   name: string
   description: string
   releaseDate?: string
+  status?: 'deprecated' | 'beta' | 'alpha'
   limit: {
     context: number
     output: number
@@ -251,8 +252,8 @@ function toFullyCuratedModel(curated: CuratedModel): Model {
  * structural `price.tokens` divisor, the per-image `price.display` copy) and
  * for research-agent models, whose name, description and price deliberately
  * encode per-task billing that no per-token figure can express. Everything
- * objective — specs, modalities, release date, per-token cost — comes from
- * the snapshot.
+ * objective — specs, modalities, release date, status, per-token cost —
+ * comes from the snapshot.
  * A model with no snapshot entry is fully curated by necessity; see
  * `EXEMPT_IDS` in `scripts/fetch-models-metadata.mjs`.
  */
@@ -277,6 +278,7 @@ export function mergeModelMetadata(
     contextLength: snapshot.limit.context,
     maxOutputTokens: snapshot.limit.output,
     ...(snapshot.releaseDate ? { releaseDate: snapshot.releaseDate } : {}),
+    ...(snapshot.status ? { status: snapshot.status } : {}),
     price: mergedPrice(
       curated.price,
       keepCuratedPrice

--- a/providers/openai.ts
+++ b/providers/openai.ts
@@ -53,6 +53,50 @@ export default {
       },
     },
     {
+      id: 'gpt-5.6',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search', 'image_generation'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
+      id: 'gpt-5.6-terra',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search', 'image_generation'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
+      id: 'gpt-5.6-luna',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search', 'image_generation'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
+      id: 'gpt-5.5',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search', 'image_generation'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
       id: 'gpt-5.4',
       price: {
         tokens: 1_000_000,

--- a/providers/openai.ts
+++ b/providers/openai.ts
@@ -1,3 +1,5 @@
+import type { CuratedProvider } from './merge'
+
 export default {
   id: 'openai',
   name: 'OpenAI',
@@ -52,18 +54,8 @@ export default {
     },
     {
       id: 'gpt-5.4',
-      name: 'GPT-5.4',
-      description: 'Best intelligence at scale for agentic, coding, and professional workflows',
-      contextLength: 1_050_000,
-      maxOutputTokens: 128_000,
       price: {
         tokens: 1_000_000,
-        input: '$2.50',
-        output: '$15.00',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text'],
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -73,18 +65,8 @@ export default {
     },
     {
       id: 'gpt-5.4-mini',
-      name: 'GPT-5.4 mini',
-      description: 'Strongest mini model yet for coding, computer use, and subagents',
-      contextLength: 400_000,
-      maxOutputTokens: 128_000,
       price: {
         tokens: 1_000_000,
-        input: '$0.75',
-        output: '$4.50',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text'],
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -94,18 +76,8 @@ export default {
     },
     {
       id: 'gpt-5.4-nano',
-      name: 'GPT-5.4 nano',
-      description: 'Cheapest GPT-5.4-class model for simple high-volume tasks',
-      contextLength: 400_000,
-      maxOutputTokens: 128_000,
       price: {
         tokens: 1_000_000,
-        input: '$0.2',
-        output: '$1.25',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text'],
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -116,18 +88,8 @@ export default {
     },
     {
       id: 'gpt-5.2',
-      name: 'GPT-5.2',
-      description: 'The best model for coding and agentic tasks across industries',
-      contextLength: 400_000,
-      maxOutputTokens: 128_000,
       price: {
         tokens: 1_000_000,
-        input: '$1.75',
-        output: '$14.00',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text'],
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -137,18 +99,8 @@ export default {
     },
     {
       id: 'gpt-5.1',
-      name: 'GPT-5.1',
-      description: 'The best model for coding and agentic tasks with configurable reasoning effort',
-      contextLength: 400_000,
-      maxOutputTokens: 128_000,
       price: {
         tokens: 1_000_000,
-        input: '$1.25',
-        output: '$10.00',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text'],
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -158,18 +110,8 @@ export default {
     },
     {
       id: 'gpt-5',
-      name: 'GPT-5',
-      description: 'The best model for coding and agentic tasks across domains',
-      contextLength: 400_000,
-      maxOutputTokens: 128_000,
       price: {
         tokens: 1_000_000,
-        input: '$1.25',
-        output: '$10.00',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text'],
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -179,18 +121,8 @@ export default {
     },
     {
       id: 'gpt-5-mini',
-      name: 'GPT-5 mini',
-      description: 'A faster, more cost-efficient version of GPT-5 for well-defined tasks',
-      contextLength: 400_000,
-      maxOutputTokens: 128_000,
       price: {
         tokens: 1_000_000,
-        input: '$0.25',
-        output: '$2.00',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text'],
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {
@@ -200,18 +132,8 @@ export default {
     },
     {
       id: 'gpt-5-nano',
-      name: 'GPT-5 nano',
-      description: 'Fastest, most cost-efficient version of GPT-5',
-      contextLength: 1_047_576,
-      maxOutputTokens: 128_000,
       price: {
         tokens: 1_000_000,
-        input: '$0.05',
-        output: '$0.40',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['text'],
       },
       tools: ['image_generation'],
       reasoning: {
@@ -222,18 +144,9 @@ export default {
     {
       id: 'gpt-image-2',
       name: 'GPT Image 2',
-      description: 'State-of-the-art image generation and editing with flexible sizes and high-fidelity image inputs',
-      contextLength: 0,
-      maxOutputTokens: 0,
       price: {
         tokens: 1,
-        input: '',
-        output: '',
         display: '$0.041–$0.053 / medium image, plus input',
-      },
-      modalities: {
-        input: ['text', 'image'],
-        output: ['image'],
       },
       tools: [],
       imageGeneration: {
@@ -241,4 +154,4 @@ export default {
       },
     },
   ],
-}
+} satisfies CuratedProvider

--- a/providers/openai.ts
+++ b/providers/openai.ts
@@ -53,7 +53,7 @@ export default {
       },
     },
     {
-      id: 'gpt-5.6',
+      id: 'gpt-5.6-sol',
       price: {
         tokens: 1_000_000,
       },

--- a/scripts/audit-curated-models.mjs
+++ b/scripts/audit-curated-models.mjs
@@ -1,0 +1,84 @@
+/**
+ * Pure diff logic behind the "uncurated models" report printed by
+ * scripts/fetch-models-metadata.mjs. Kept in its own module (no top-level
+ * network calls or file writes) so it can be unit tested directly instead
+ * of through the fetch script, which fetches models.dev and writes the
+ * snapshot as a side effect of being imported.
+ */
+
+export function findUncuratedModels(remoteModels, curatedIds) {
+  return Object.entries(remoteModels)
+    .filter(([id]) => !curatedIds.has(id))
+    .map(([id, model]) => {
+      return {
+        id,
+        name: model.name,
+        releaseDate: model.release_date,
+      }
+    })
+    .sort((a, b) => {
+      if (!a.releaseDate) {
+        return 1
+      }
+
+      if (!b.releaseDate) {
+        return -1
+      }
+
+      return b.releaseDate.localeCompare(a.releaseDate)
+    })
+}
+
+export function formatUncuratedModelsReport(providerReports) {
+  const lines = [
+    'Models available on models.dev but not curated (informational, not a '
+    + 'failure — review and add to providers/*.ts if relevant):',
+  ]
+
+  for (const { providerId, models } of providerReports) {
+    lines.push(`  ${providerId} (${models.length} not curated):`)
+    lines.push(...models.map((model) => {
+      return `    - ${model.id} (${model.name}, released ${model.releaseDate})`
+    }))
+  }
+
+  return lines.join('\n')
+}
+
+export function findDeprecatedCuratedModels(remoteModels, curatedIds) {
+  return Object.entries(remoteModels)
+    .filter(([id, model]) => {
+      return curatedIds.has(id) && model.status === 'deprecated'
+    })
+    .map(([id, model]) => {
+      return { id, name: model.name }
+    })
+}
+
+/**
+ * Unlike `formatUncuratedModelsReport()`, this returns `null` when there is
+ * nothing to warn about, so the caller can skip printing an empty section —
+ * a currently-curated model going deprecated upstream is rare enough that
+ * silence is the common case.
+ */
+export function formatDeprecatedCuratedModelsWarning(providerReports) {
+  const deprecatedModels = providerReports.flatMap(({ providerId, models }) => {
+    return models.map(model => ({ providerId, ...model }))
+  })
+
+  if (deprecatedModels.length === 0) {
+    return null
+  }
+
+  const lines = [
+    '⚠ DEPRECATED: curated model(s) below are flagged deprecated on '
+    + 'models.dev right now — review whether to swap or retire them in '
+    + 'providers/*.ts:',
+  ]
+
+  lines.push(...deprecatedModels.map((model) => {
+    return `  - ${model.providerId}/${model.id} (${model.name})`
+  }))
+
+  return lines.join('\n')
+}

--- a/scripts/fetch-models-metadata.mjs
+++ b/scripts/fetch-models-metadata.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+/**
+ * Regenerates providers/data/models-dev-snapshot.json from models.dev, the
+ * objective half of the model catalog: display name, description, release
+ * date, context and output limits, modalities and per-million-token cost.
+ * The curated
+ * half — which tools, reasoning, research and image-generation capabilities
+ * a model is offered with — stays hand-written in providers/google.ts and
+ * providers/openai.ts and is never touched here.
+ *
+ * The join only ever looks curated ids UP in models.dev; it never iterates
+ * the remote catalog outward, so embedding, video, music, TTS and realtime
+ * models that models.dev also lists can never leak into the app.
+ *
+ * This is a manual maintenance step, like `pnpm run db:generate`. The build
+ * and the Cloudflare deploy stay offline: they read the committed snapshot.
+ *
+ * A curated id that models.dev no longer publishes is a hard failure rather
+ * than a silent fallback to stale values — that is the whole point of
+ * fetching. Retiring or renaming such a model is a deliberate edit to the
+ * curated file (or to EXEMPT_IDS below).
+ *
+ * Usage:
+ *   pnpm run models:fetch
+ *   git diff providers/data/models-dev-snapshot.json
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import google from '../providers/google.ts'
+import openai from '../providers/openai.ts'
+
+const CATALOG_URL = 'https://models.dev/api.json'
+const FETCH_TIMEOUT_MS = 60_000
+const SNAPSHOT_PATH = fileURLToPath(
+  new URL('../providers/data/models-dev-snapshot.json', import.meta.url),
+)
+
+// OpenAI bills Deep Research as its own model snapshots, which models.dev
+// does not track separately (it lists only the bare o3 / o4-mini). These two
+// stay fully curated in providers/openai.ts.
+const EXEMPT_IDS = ['o3-deep-research', 'o4-mini-deep-research']
+
+const curatedProviders = [google, openai]
+
+const catalog = await fetchCatalog()
+const snapshot = {}
+const missingIds = []
+const incompleteIds = []
+
+for (const provider of curatedProviders) {
+  const remoteModels = catalog[provider.id]?.models
+
+  if (!remoteModels) {
+    console.error(
+      `models.dev has no "${provider.id}" provider. Its top-level keys are `
+      + 'provider ids; check whether it was renamed.',
+    )
+    process.exit(1)
+  }
+
+  for (const model of provider.models) {
+    if (EXEMPT_IDS.includes(model.id)) {
+      continue
+    }
+
+    const remoteModel = remoteModels[model.id]
+
+    if (!remoteModel) {
+      missingIds.push(`${provider.id}/${model.id}`)
+
+      continue
+    }
+
+    const entry = toSnapshotEntry(remoteModel)
+
+    if (!entry) {
+      incompleteIds.push(`${provider.id}/${model.id}`)
+
+      continue
+    }
+
+    snapshot[model.id] = entry
+  }
+}
+
+if (missingIds.length > 0) {
+  console.error(
+    `models.dev no longer lists ${missingIds.length} curated model(s):`,
+  )
+  console.error(missingIds.map(id => `  - ${id}`).join('\n'))
+  console.error(
+    'Remove or replace them in providers/*.ts, or add them to EXEMPT_IDS '
+    + 'and curate their metadata by hand. Snapshot NOT written.',
+  )
+  process.exit(1)
+}
+
+if (incompleteIds.length > 0) {
+  console.error(
+    `models.dev is missing required fields for ${incompleteIds.length} `
+    + 'curated model(s):',
+  )
+  console.error(incompleteIds.map(id => `  - ${id}`).join('\n'))
+  console.error('Snapshot NOT written.')
+  process.exit(1)
+}
+
+await mkdir(dirname(SNAPSHOT_PATH), { recursive: true })
+await writeFile(SNAPSHOT_PATH, `${JSON.stringify(snapshot, null, 2)}\n`)
+
+console.log(
+  `Wrote ${Object.keys(snapshot).length} models to ${SNAPSHOT_PATH}`,
+)
+console.log(
+  `Exempt (curated by hand): ${EXEMPT_IDS.join(', ')}`,
+)
+
+async function fetchCatalog() {
+  try {
+    const response = await fetch(CATALOG_URL, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+
+    if (!response.ok) {
+      console.error(
+        `${CATALOG_URL} responded ${response.status} ${response.statusText}`,
+      )
+      process.exit(1)
+    }
+
+    return await response.json()
+  } catch (exception) {
+    console.error(`Could not fetch ${CATALOG_URL}: ${exception.message}`)
+    process.exit(1)
+  }
+}
+
+function toSnapshotEntry(model) {
+  const hasRequiredFields = typeof model.name === 'string'
+    && typeof model.description === 'string'
+    && typeof model.limit?.context === 'number'
+    && typeof model.limit?.output === 'number'
+    && Array.isArray(model.modalities?.input)
+    && Array.isArray(model.modalities?.output)
+    && typeof model.cost?.input === 'number'
+    && typeof model.cost?.output === 'number'
+
+  if (!hasRequiredFields) {
+    return null
+  }
+
+  const entry = {
+    name: model.name,
+    description: model.description,
+    ...(typeof model.release_date === 'string'
+      ? { releaseDate: model.release_date }
+      : {}),
+    limit: {
+      context: model.limit.context,
+      output: model.limit.output,
+    },
+    modalities: {
+      input: model.modalities.input,
+      output: model.modalities.output,
+    },
+    cost: {
+      input: model.cost.input,
+      output: model.cost.output,
+    },
+  }
+
+  if (Array.isArray(model.cost.tiers) && model.cost.tiers.length > 0) {
+    entry.tieredPricing = true
+  }
+
+  return entry
+}

--- a/scripts/fetch-models-metadata.mjs
+++ b/scripts/fetch-models-metadata.mjs
@@ -29,6 +29,12 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import {
+  findDeprecatedCuratedModels,
+  findUncuratedModels,
+  formatDeprecatedCuratedModelsWarning,
+  formatUncuratedModelsReport,
+} from './audit-curated-models.mjs'
 import google from '../providers/google.ts'
 import openai from '../providers/openai.ts'
 
@@ -42,6 +48,8 @@ const SNAPSHOT_PATH = fileURLToPath(
 // does not track separately (it lists only the bare o3 / o4-mini). These two
 // stay fully curated in providers/openai.ts.
 const EXEMPT_IDS = ['o3-deep-research', 'o4-mini-deep-research']
+
+const KNOWN_MODEL_STATUSES = ['deprecated', 'beta', 'alpha']
 
 const curatedProviders = [google, openai]
 
@@ -118,6 +126,41 @@ console.log(
   `Exempt (curated by hand): ${EXEMPT_IDS.join(', ')}`,
 )
 
+const providerReports = curatedProviders.map((provider) => {
+  const curatedIds = new Set(provider.models.map(model => model.id))
+  const remoteModels = catalog[provider.id].models
+
+  return {
+    providerId: provider.id,
+    curatedIds,
+    remoteModels,
+  }
+})
+
+const deprecatedCuratedWarning = formatDeprecatedCuratedModelsWarning(
+  providerReports.map(({ providerId, curatedIds, remoteModels }) => {
+    return {
+      providerId,
+      models: findDeprecatedCuratedModels(remoteModels, curatedIds),
+    }
+  }),
+)
+
+if (deprecatedCuratedWarning) {
+  console.log()
+  console.log(deprecatedCuratedWarning)
+}
+
+console.log()
+console.log(formatUncuratedModelsReport(
+  providerReports.map(({ providerId, curatedIds, remoteModels }) => {
+    return {
+      providerId,
+      models: findUncuratedModels(remoteModels, curatedIds),
+    }
+  }),
+))
+
 async function fetchCatalog() {
   try {
     const response = await fetch(CATALOG_URL, {
@@ -157,6 +200,9 @@ function toSnapshotEntry(model) {
     description: model.description,
     ...(typeof model.release_date === 'string'
       ? { releaseDate: model.release_date }
+      : {}),
+    ...(KNOWN_MODEL_STATUSES.includes(model.status)
+      ? { status: model.status }
       : {}),
     limit: {
       context: model.limit.context,

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -101,6 +101,7 @@ export function getAffectedTests(changedFiles) {
   ]
   const modelCatalogTests = [
     'tests/unit/providers/merge.spec.ts',
+    'tests/unit/scripts/audit-curated-models.spec.ts',
     'tests/unit/utils/model.spec.ts',
     'tests/unit/utils/cost-map.spec.ts',
     ...modelsTriggerTests,
@@ -279,7 +280,7 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern:
-        /^(providers\/(index|merge|google|openai)\.ts|providers\/data\/models-dev-snapshot\.json|scripts\/fetch-models-metadata\.mjs|shared\/types\/providers\.d\.ts)$/,
+        /^(providers\/(index|merge|google|openai)\.ts|providers\/data\/models-dev-snapshot\.json|scripts\/(fetch-models-metadata|audit-curated-models)\.mjs|shared\/types\/providers\.d\.ts)$/,
       tests: modelCatalogTests,
     },
     {

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -87,6 +87,25 @@ export function getAffectedTests(changedFiles) {
     'tests/integration/server/assistant-files.spec.ts',
     'tests/integration/api/chats-message-id-stream.spec.ts',
   ]
+  const modelsTriggerPattern
+    = /^(app\/components\/ChatInput\/ModelsTrigger(\.vue|\/.+\.vue)|app\/utils\/models-picker\.ts|app\/types\/models-picker\.d\.ts)$/
+  const modelsTriggerTests = [
+    'tests/unit/components/ChatInput/ModelsTrigger.spec.ts',
+    'tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts',
+    'tests/unit/components/ChatInput/ModelsTrigger/Search.spec.ts',
+    'tests/unit/components/ChatInput/ModelsTrigger/ProviderRail.spec.ts',
+    'tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts',
+    'tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts',
+    'tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts',
+    'tests/unit/utils/models-picker.spec.ts',
+  ]
+  const modelCatalogTests = [
+    'tests/unit/providers/merge.spec.ts',
+    'tests/unit/utils/model.spec.ts',
+    'tests/unit/utils/cost-map.spec.ts',
+    ...modelsTriggerTests,
+    'tests/e2e/chat/scroll-spacer.spec.ts',
+  ]
   const chatStreamBranchTests = [
     'tests/unit/composables/chat.spec.ts',
     'tests/unit/utils/filter-ui-message-stream.spec.ts',
@@ -235,6 +254,7 @@ export function getAffectedTests(changedFiles) {
     'tests/unit/components/Chat/DeepResearchPending.spec.ts',
     'tests/unit/components/ChatInput/DeepResearchTrigger.spec.ts',
     'tests/unit/components/ChatInput/ModelsTrigger.spec.ts',
+    'tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts',
     'tests/unit/components/prose/A.spec.ts',
     'tests/unit/composables/chat-research.spec.ts',
     'tests/unit/composables/chat-input.spec.ts',
@@ -258,6 +278,11 @@ export function getAffectedTests(changedFiles) {
       tests: messageUsageTests,
     },
     {
+      pattern:
+        /^(providers\/(index|merge|google|openai)\.ts|providers\/data\/models-dev-snapshot\.json|scripts\/fetch-models-metadata\.mjs|shared\/types\/providers\.d\.ts)$/,
+      tests: modelCatalogTests,
+    },
+    {
       pattern: /^server\/utils\/chats\/request-schema\.ts$/,
       tests: [
         'tests/integration/api/chats-message-id-stream.spec.ts',
@@ -273,10 +298,8 @@ export function getAffectedTests(changedFiles) {
       tests: ['tests/unit/components/Chat/ImagePreview.client.spec.ts'],
     },
     {
-      pattern: /^app\/components\/ChatInput\/ModelsTrigger\.vue$/,
-      tests: [
-        'tests/unit/components/ChatInput/ModelsTrigger.spec.ts',
-      ],
+      pattern: modelsTriggerPattern,
+      tests: modelsTriggerTests,
     },
     {
       pattern: /^app\/utils\/generated-images\.ts$/,
@@ -529,7 +552,7 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern:
-        /^(app\/components\/(Chat|ChatInput)\/DeepResearch.*\.vue|app\/components\/ChatInput\/ModelsTrigger\.vue|app\/composables\/(chat-research|chat-input|research-links)\.ts)$/,
+        /^(app\/components\/(Chat|ChatInput)\/DeepResearch.*\.vue|app\/components\/ChatInput\/ModelsTrigger(\.vue|\/.+\.vue)|app\/composables\/(chat-research|chat-input|research-links)\.ts)$/,
       tests: deepResearchTests,
     },
     {

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -580,6 +580,15 @@ export function getAffectedTests(changedFiles) {
       tests: chatStreamBranchTests,
     },
     {
+      pattern: /^server\/utils\/chats\/provider\.ts$/,
+      tests: [
+        'tests/unit/utils/chats/provider.spec.ts',
+        ...chatStreamBranchTests,
+        'tests/integration/api/chats-title.spec.ts',
+        'tests/integration/api/chats-research-clarify.spec.ts',
+      ],
+    },
+    {
       pattern: /^app\/composables\/(history|projects|project-chats)\.ts$/,
       tests: historyProjectsTests,
     },

--- a/server/api/v1/profiles/settings/index.get.ts
+++ b/server/api/v1/profiles/settings/index.get.ts
@@ -15,6 +15,7 @@ export default defineEventHandler(async () => {
       allowExternalLinks: true,
       notificationPromptState: true,
       sidebarPinned: true,
+      favoriteModels: true,
     },
   })
 
@@ -24,5 +25,6 @@ export default defineEventHandler(async () => {
     allowExternalLinks: settings?.allowExternalLinks ?? null,
     notificationPromptState: settings?.notificationPromptState ?? null,
     sidebarPinned: settings?.sidebarPinned ?? false,
+    favoriteModels: settings?.favoriteModels ?? [],
   }
 })

--- a/server/api/v1/profiles/settings/index.patch.ts
+++ b/server/api/v1/profiles/settings/index.patch.ts
@@ -14,6 +14,7 @@ export default defineEventHandler(async (event) => {
     allowExternalLinks: z.boolean().nullable().optional(),
     notificationPromptState: z.boolean().nullable().optional(),
     sidebarPinned: z.boolean().optional(),
+    favoriteModels: z.array(z.string().max(100)).max(50).optional(),
   }).safeParse)
 
   if (body.error) {
@@ -41,6 +42,7 @@ export default defineEventHandler(async (event) => {
     allowExternalLinks?: boolean | null
     notificationPromptState?: boolean | null
     sidebarPinned?: boolean
+    favoriteModels?: string[]
   } = {}
 
   if (body.data.reasoningExpanded !== undefined) {
@@ -62,6 +64,10 @@ export default defineEventHandler(async (event) => {
 
   if (body.data.sidebarPinned !== undefined) {
     fieldUpdates.sidebarPinned = body.data.sidebarPinned
+  }
+
+  if (body.data.favoriteModels !== undefined) {
+    fieldUpdates.favoriteModels = [...new Set(body.data.favoriteModels)]
   }
 
   if (Object.keys(fieldUpdates).length === 0) {

--- a/server/db/schemas/user-settings.ts
+++ b/server/db/schemas/user-settings.ts
@@ -1,6 +1,7 @@
 import {
   snakeCase,
   integer,
+  text,
   uniqueIndex,
 } from 'drizzle-orm/sqlite-core'
 import { defaultSchemaTimestamps } from '../../utils/schema'
@@ -23,6 +24,7 @@ export const userSettings = snakeCase.table(
     allowExternalLinks: integer({ mode: 'boolean' }),
     notificationPromptState: integer({ mode: 'boolean' }),
     sidebarPinned: integer({ mode: 'boolean' }),
+    favoriteModels: text({ mode: 'json' }).$type<string[]>(),
   },
   table => [
     uniqueIndex('uq_user_settings_user').on(table.userId),

--- a/server/utils/chats/provider.ts
+++ b/server/utils/chats/provider.ts
@@ -1,4 +1,5 @@
 import type { Provider, Model } from '#shared/types/providers.d'
+import { createError as createEvlogError } from 'evlog'
 
 export function useChatProvider(
   userModel: string,
@@ -21,6 +22,16 @@ export function useChatProvider(
       statusCode: 400,
       statusMessage:
         'Current model is not supported by any provider. Please select a different model.',
+    })
+  }
+
+  if (model.status === 'deprecated') {
+    throw createEvlogError({
+      message: 'This model is no longer available.',
+      status: 400,
+      why: `${model.name} is deprecated and can no longer be used for new`
+        + ' requests.',
+      fix: 'Choose a different model from the picker.',
     })
   }
 

--- a/shared/types/providers.d.ts
+++ b/shared/types/providers.d.ts
@@ -7,6 +7,8 @@ export interface ModelImageGenerationCapability {
   controllerModel: string
 }
 
+export type ModelPriceTier = '$' | '$$' | '$$$' | '$$$+'
+
 export interface Model {
   id: string
   name: string
@@ -15,12 +17,14 @@ export interface Model {
   description: string
   contextLength: number
   maxOutputTokens: number
+  releaseDate?: string
   price: {
     tokens: number
     input: string
     output: string
     display?: string
   }
+  priceTier: ModelPriceTier
   modalities: {
     input: string[]
     output: string[]

--- a/shared/types/providers.d.ts
+++ b/shared/types/providers.d.ts
@@ -18,6 +18,7 @@ export interface Model {
   contextLength: number
   maxOutputTokens: number
   releaseDate?: string
+  status?: 'deprecated' | 'beta' | 'alpha'
   price: {
     tokens: number
     input: string

--- a/tests/e2e/chat/scroll-spacer.spec.ts
+++ b/tests/e2e/chat/scroll-spacer.spec.ts
@@ -526,7 +526,7 @@ async function expectStableImageTurnPin(
   await openCase(page, url)
 
   await page.locator('[data-testid="current-model-trigger"]').click()
-  await page.getByRole('button', { name: 'Choose Gemini 2.5 Flash Image' })
+  await page.getByRole('button', { name: 'Choose Nano Banana', exact: true })
     .click()
   await page.locator('textarea').fill('A scottish fold cat by a fireplace')
   await page.getByRole('button', { name: 'Send Message' }).click()

--- a/tests/integration/api/chats-message-id-stream.spec.ts
+++ b/tests/integration/api/chats-message-id-stream.spec.ts
@@ -537,6 +537,41 @@ describe('chat stream message ids', () => {
     expect(mocks.generatedMessageIds).toHaveLength(0)
   })
 
+  it('rejects a deprecated model before any provider call is attempted', async () => {
+    const handler = await getHandler()
+    const { db, insertValues } = createDb()
+    const useOpenAiMock = vi.fn(async () => ({
+      instance: {},
+      tools: {},
+      providerOptions: {},
+    }))
+
+    vi.stubGlobal('useDb', () => db)
+    vi.stubGlobal('useOpenAI', useOpenAiMock)
+    vi.stubGlobal('useChatProvider', vi.fn(() => {
+      throw Object.assign(new Error('This model is no longer available.'), {
+        status: 400,
+        why: 'Gemini 3 Pro Preview is deprecated and can no longer be used'
+          + ' for new requests.',
+        fix: 'Choose a different model from the picker.',
+      })
+    }))
+
+    await expect(handler({
+      params: { slug: '01ARZ3NDEKTSV4RRFFQ69G5FAV' },
+      body: {
+        model: 'gemini-3-pro-preview',
+        tools: [],
+        reasoning: 'off',
+        messages: [createMessage('Hello')],
+      },
+    } as any)).rejects.toThrow('This model is no longer available.')
+
+    expect(insertValues).not.toHaveBeenCalled()
+    expect(useOpenAiMock).not.toHaveBeenCalled()
+    expect(mocks.generatedMessageIds).toHaveLength(0)
+  })
+
   it('sends a push notification via waitUntil after a successful generation', async () => {
     const handler = await getHandler()
     const { db } = createDb()

--- a/tests/integration/api/profile-settings.spec.ts
+++ b/tests/integration/api/profile-settings.spec.ts
@@ -7,6 +7,7 @@ interface SettingsRecord {
   allowExternalLinks: boolean | null
   notificationPromptState: boolean | null
   sidebarPinned: boolean
+  favoriteModels: string[] | null
 }
 
 function createDbMock() {
@@ -22,6 +23,7 @@ function createDbMock() {
     allowExternalLinks?: boolean | null
     notificationPromptState?: boolean | null
     sidebarPinned?: boolean
+    favoriteModels?: string[]
   }) => {
     currentSettings = {
       id: 1,
@@ -30,6 +32,7 @@ function createDbMock() {
       allowExternalLinks: values.allowExternalLinks ?? null,
       notificationPromptState: values.notificationPromptState ?? null,
       sidebarPinned: values.sidebarPinned ?? false,
+      favoriteModels: values.favoriteModels ?? null,
     }
   })
   const insert = vi.fn(() => ({
@@ -44,6 +47,7 @@ function createDbMock() {
     allowExternalLinks?: boolean | null
     notificationPromptState?: boolean | null
     sidebarPinned?: boolean
+    favoriteModels?: string[]
   }) => {
     currentSettings = {
       id: 1,
@@ -62,6 +66,9 @@ function createDbMock() {
       sidebarPinned: values.sidebarPinned
         ?? currentSettings?.sidebarPinned
         ?? false,
+      favoriteModels: values.favoriteModels
+        ?? currentSettings?.favoriteModels
+        ?? null,
     }
 
     return {
@@ -175,6 +182,7 @@ describe('profile settings API', () => {
       allowExternalLinks: null,
       notificationPromptState: null,
       sidebarPinned: false,
+      favoriteModels: [],
     })
   })
 
@@ -220,6 +228,7 @@ describe('profile settings API', () => {
       allowExternalLinks: null,
       notificationPromptState: null,
       sidebarPinned: false,
+      favoriteModels: [],
     })
   })
 
@@ -253,6 +262,7 @@ describe('profile settings API', () => {
       allowExternalLinks: null,
       notificationPromptState: null,
       sidebarPinned: false,
+      favoriteModels: [],
     })
   })
 
@@ -286,6 +296,7 @@ describe('profile settings API', () => {
       allowExternalLinks: true,
       notificationPromptState: null,
       sidebarPinned: false,
+      favoriteModels: [],
     })
   })
 
@@ -319,6 +330,7 @@ describe('profile settings API', () => {
       allowExternalLinks: null,
       notificationPromptState: false,
       sidebarPinned: false,
+      favoriteModels: [],
     })
   })
 
@@ -352,8 +364,86 @@ describe('profile settings API', () => {
       allowExternalLinks: null,
       notificationPromptState: null,
       sidebarPinned: true,
+      favoriteModels: [],
     })
   })
+
+  it('saves deduped favoriteModels and returns them', async () => {
+    const getHandler = await getSettingsHandler()
+    const patchHandler = await patchSettingsHandler()
+    const dbMock = createDbMock()
+
+    vi.stubGlobal('useDb', () => dbMock.db)
+    vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue({
+      user: {
+        id: '1',
+      },
+    }))
+
+    const patchResponse = await patchHandler({
+      body: {
+        favoriteModels: ['gpt-5.4', 'gemini-2.5-flash', 'gpt-5.4'],
+      },
+    } as any)
+
+    expect(patchResponse).toEqual({
+      favoriteModels: ['gpt-5.4', 'gemini-2.5-flash'],
+    })
+
+    const getResponse = await getHandler({} as any)
+
+    expect(getResponse).toEqual({
+      reasoningExpanded: false,
+      reasoningAutoHide: true,
+      allowExternalLinks: null,
+      notificationPromptState: null,
+      sidebarPinned: false,
+      favoriteModels: ['gpt-5.4', 'gemini-2.5-flash'],
+    })
+  })
+
+  it('rejects a favoriteModels list over the cap', async () => {
+    const patchHandler = await patchSettingsHandler()
+    const dbMock = createDbMock()
+
+    vi.stubGlobal('useDb', () => dbMock.db)
+    vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue({
+      user: {
+        id: '1',
+      },
+    }))
+
+    await expect(patchHandler({
+      body: {
+        favoriteModels: Array.from({ length: 51 }, (_value, index) => {
+          return `model-${index}`
+        }),
+      },
+    } as any)).rejects.toMatchObject({
+      statusCode: 400,
+    })
+  })
+
+  it('rejects a favoriteModels entry over the per-string length cap',
+    async () => {
+      const patchHandler = await patchSettingsHandler()
+      const dbMock = createDbMock()
+
+      vi.stubGlobal('useDb', () => dbMock.db)
+      vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue({
+        user: {
+          id: '1',
+        },
+      }))
+
+      await expect(patchHandler({
+        body: {
+          favoriteModels: ['a'.repeat(101)],
+        },
+      } as any)).rejects.toMatchObject({
+        statusCode: 400,
+      })
+    })
 
   it('returns 400 for invalid patch payload', async () => {
     const patchHandler = await patchSettingsHandler()

--- a/tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts
@@ -49,7 +49,7 @@ describe('ChatInput/ModelsTrigger', () => {
     expect(
       researchButton
         ?.get('[data-testid="model-price-tier"]')
-        .attributes('title'),
+        .attributes('data-tip'),
     ).toBe('~$1 / task · 5–15 min')
   })
 
@@ -60,7 +60,7 @@ describe('ChatInput/ModelsTrigger', () => {
     expect(
       regularButton
         ?.get('[data-testid="model-price-tier"]')
-        .attributes('title'),
+        .attributes('data-tip'),
     ).toBe('from $2.50 / from $15.00')
     expect(
       regularButton?.find('[data-tip="Deep research"]').exists(),

--- a/tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts
@@ -72,7 +72,7 @@ describe('ChatInput/ModelsTrigger', () => {
     expect(findModelButton(wrapper, 'GPT-5.4')).toBeTruthy()
 
     await wrapper.get('[data-testid="models-picker-filter-research"]')
-      .setValue(true)
+      .trigger('click')
 
     expect(findModelButton(wrapper, 'GPT-5.4')).toBeUndefined()
     expect(findModelButton(wrapper, 'o4-mini Deep Research')).toBeTruthy()

--- a/tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts
@@ -1,19 +1,41 @@
-import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { describe, expect, it } from 'vitest'
+import { shallowRef } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import type { VueWrapper } from '@vue/test-utils'
 import ModelsTrigger from '../../../../app/components/ChatInput/ModelsTrigger.vue'
+
+const mocks = vi.hoisted(() => ({
+  useUserSetting: vi.fn(() => ({
+    favoriteModels: shallowRef<string[]>([]),
+    toggleFavoriteModel: vi.fn(),
+  })),
+}))
+
+mockNuxtImport('useUserSetting', () => mocks.useUserSetting)
+
+async function openPicker() {
+  const wrapper = await mountSuspended(ModelsTrigger, {
+    props: {
+      isWebSearchEnabled: false,
+      isReasoningEnabled: false,
+    },
+  })
+
+  await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+
+  return wrapper
+}
+
+function findModelButton(wrapper: VueWrapper, modelName: string) {
+  return wrapper.findAll('button').find((button) => {
+    return button.attributes('aria-label') === `Choose ${modelName}`
+  })
+}
 
 describe('ChatInput/ModelsTrigger', () => {
   it('renders the deep research badge and cost/time tooltip for a research model', async () => {
-    const wrapper = await mountSuspended(ModelsTrigger, {
-      props: {
-        isWebSearchEnabled: false,
-        isReasoningEnabled: false,
-      },
-    })
-
-    const researchButton = wrapper.findAll('button').find((button) => {
-      return button.attributes('aria-label') === 'Choose o4-mini Deep Research'
-    })
+    const wrapper = await openPicker()
+    const researchButton = findModelButton(wrapper, 'o4-mini Deep Research')
 
     expect(researchButton).toBeTruthy()
 
@@ -23,26 +45,51 @@ describe('ChatInput/ModelsTrigger', () => {
     expect(badge?.classes()).toContain('bg-[color-mix(in_oklab,var(--color-success)_15%,var(--color-base-100))]')
     expect(badge?.classes()).not.toContain('bg-success/15')
     expect(badge?.classes()).not.toContain('bg-success-content')
-    expect(researchButton?.attributes('data-tip')).toBe(
-      '~$1 / task · 5–15 min',
-    )
+    expect(
+      researchButton
+        ?.get('[data-testid="model-price-tier"]')
+        .attributes('title'),
+    ).toBe('~$1 / task · 5–15 min')
   })
 
   it('shows the input/output token price tip for a regular model', async () => {
-    const wrapper = await mountSuspended(ModelsTrigger, {
-      props: {
-        isWebSearchEnabled: false,
-        isReasoningEnabled: false,
-      },
-    })
+    const wrapper = await openPicker()
+    const regularButton = findModelButton(wrapper, 'GPT-5.4')
 
-    const regularButton = wrapper.findAll('button').find((button) => {
-      return button.attributes('aria-label') === 'Choose GPT-5.4'
-    })
-
-    expect(regularButton?.attributes('data-tip')).toBe('$2.50 / $15.00')
+    expect(
+      regularButton
+        ?.get('[data-testid="model-price-tier"]')
+        .attributes('title'),
+    ).toBe('from $2.50 / from $15.00')
     expect(
       regularButton?.find('[data-tip="Deep research"]').exists(),
     ).toBe(false)
+  })
+
+  it('narrows the list to a single category through the filter dropdown', async () => {
+    const wrapper = await openPicker()
+
+    expect(findModelButton(wrapper, 'GPT-5.4')).toBeTruthy()
+
+    await wrapper.get('[data-testid="models-picker-filter-research"]')
+      .setValue(true)
+
+    expect(findModelButton(wrapper, 'GPT-5.4')).toBeUndefined()
+    expect(findModelButton(wrapper, 'o4-mini Deep Research')).toBeTruthy()
+  })
+
+  it('narrows the list to a single provider through the rail', async () => {
+    const wrapper = await openPicker()
+
+    await wrapper.get('[data-testid="models-picker-rail-openai"]')
+      .trigger('click')
+
+    expect(findModelButton(wrapper, 'GPT-5.4')).toBeTruthy()
+    expect(findModelButton(wrapper, 'Nano Banana')).toBeUndefined()
+
+    await wrapper.get('[data-testid="models-picker-rail-openai"]')
+      .trigger('click')
+
+    expect(findModelButton(wrapper, 'Nano Banana')).toBeTruthy()
   })
 })

--- a/tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts
@@ -42,7 +42,8 @@ describe('ChatInput/ModelsTrigger', () => {
     const badge = researchButton?.find('[data-tip="Deep research"]')
 
     expect(badge?.exists()).toBe(true)
-    expect(badge?.classes()).toContain('bg-[color-mix(in_oklab,var(--color-success)_15%,var(--color-base-100))]')
+    expect(badge?.classes()).toContain('capability-chip')
+    expect(badge?.classes()).toContain('text-success')
     expect(badge?.classes()).not.toContain('bg-success/15')
     expect(badge?.classes()).not.toContain('bg-success-content')
     expect(

--- a/tests/unit/components/ChatInput/ModelsTrigger.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.spec.ts
@@ -52,12 +52,19 @@ const legacyModel = {
   status: 'deprecated',
 }
 
+const secondModel = {
+  ...imageModel,
+  id: 'second-model',
+  name: 'Second model',
+  description: 'Also selectable',
+}
+
 function useLegacyCatalog() {
   mocks.getProviders.mockReturnValue({
     providers: [{
       id: 'google',
       name: 'Google AI Studio',
-      models: [imageModel, legacyModel],
+      models: [imageModel, secondModel, legacyModel],
     }],
   })
 }
@@ -287,6 +294,11 @@ describe('ChatInput/ModelsTrigger', () => {
       .toBe('model-option-image-model')
     expect(listbox.find('#model-option-image-model').exists()).toBe(true)
     expect(listbox.find('#model-option-legacy-model').exists()).toBe(false)
+
+    await search.trigger('keydown', { key: 'ArrowDown' })
+
+    expect(search.attributes('aria-activedescendant'))
+      .toBe('model-option-second-model')
 
     await search.trigger('keydown', { key: 'ArrowDown' })
 

--- a/tests/unit/components/ChatInput/ModelsTrigger.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.spec.ts
@@ -43,6 +43,25 @@ const imageModel = {
   reasoning: false,
 }
 
+const legacyModel = {
+  ...imageModel,
+  id: 'legacy-model',
+  name: 'Legacy model',
+  description: 'Retired upstream',
+  tools: [],
+  status: 'deprecated',
+}
+
+function useLegacyCatalog() {
+  mocks.getProviders.mockReturnValue({
+    providers: [{
+      id: 'google',
+      name: 'Google AI Studio',
+      models: [imageModel, legacyModel],
+    }],
+  })
+}
+
 function mountPicker() {
   return mountSuspended(ModelsTrigger, {
     props: {
@@ -174,6 +193,130 @@ describe('ChatInput/ModelsTrigger', () => {
     expect(wrapper.get('[data-testid="models-picker-empty"]').text())
       .toContain('No models match')
     expect(wrapper.find('[data-testid="models-picker-clear-filters"]').exists())
+      .toBe(false)
+  })
+
+  it('keeps deprecated models out of the selectable list', async () => {
+    useLegacyCatalog()
+
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+
+    expect(wrapper.find('button[aria-label="Choose Legacy model"]').exists())
+      .toBe(false)
+    expect(wrapper.find('button[aria-label="Choose Image model"]').exists())
+      .toBe(true)
+  })
+
+  it('collapses the legacy section by default and counts its models', async () => {
+    useLegacyCatalog()
+
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+
+    const toggle = wrapper.get('[data-testid="models-picker-legacy-toggle"]')
+
+    expect(toggle.text()).toContain('1 legacy model')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    expect(wrapper.get('[data-testid="models-picker-legacy-list"]')
+      .attributes('style')).toBe('display: none;')
+  })
+
+  it('reveals the non-selectable legacy rows once expanded', async () => {
+    useLegacyCatalog()
+
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+    await wrapper.get('[data-testid="models-picker-legacy-toggle"]')
+      .trigger('click')
+
+    const toggle = wrapper.get('[data-testid="models-picker-legacy-toggle"]')
+    const row = wrapper.get('#model-option-legacy-model')
+
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.get('[data-testid="models-picker-legacy-list"]')
+      .attributes('style')).toBeUndefined()
+    expect(row.attributes('aria-disabled')).toBe('true')
+    expect(row.find('button[aria-label="Choose Legacy model"]').exists())
+      .toBe(false)
+    expect(row.find('[data-testid="model-favorite-toggle"]').exists())
+      .toBe(false)
+
+    await toggle.trigger('click')
+
+    expect(wrapper.get('[data-testid="models-picker-legacy-toggle"]')
+      .attributes('aria-expanded')).toBe('false')
+  })
+
+  it('opens the detail panel from a legacy row info button', async () => {
+    useLegacyCatalog()
+
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+    await wrapper.get('[data-testid="models-picker-legacy-toggle"]')
+      .trigger('click')
+    await wrapper.get('#model-option-legacy-model')
+      .get('[data-testid="model-info-trigger"]')
+      .trigger('mouseenter')
+
+    const panel = wrapper.get('[data-testid="model-detail-panel"]')
+
+    expect(panel.attributes('id')).toBe('model-detail-legacy-model')
+    expect(wrapper.get('[data-testid="model-detail-deprecated-notice"]').text())
+      .toContain('no longer be selected')
+  })
+
+  it('never aims the keyboard highlight at a deprecated selection', async () => {
+    useLegacyCatalog()
+    mocks.useUserModel.mockReturnValue({
+      userModel: shallowRef<string>('legacy-model'),
+    })
+
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+
+    const search = wrapper.get('[data-testid="models-picker-search"]')
+    const listbox = wrapper.get('[role="listbox"][aria-label="Models"]')
+
+    expect(search.attributes('aria-activedescendant'))
+      .toBe('model-option-image-model')
+    expect(listbox.find('#model-option-image-model').exists()).toBe(true)
+    expect(listbox.find('#model-option-legacy-model').exists()).toBe(false)
+
+    await search.trigger('keydown', { key: 'ArrowDown' })
+
+    expect(search.attributes('aria-activedescendant'))
+      .toBe('model-option-image-model')
+
+    await search.trigger('keydown', { key: 'Enter' })
+
+    expect(wrapper.emitted()).toBeTruthy()
+  })
+
+  it('hides the legacy section when no model is deprecated', async () => {
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="models-picker-legacy"]').exists())
+      .toBe(false)
+  })
+
+  it('keeps the listbox free of the legacy section', async () => {
+    useLegacyCatalog()
+
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+
+    const listbox = wrapper.get('[role="listbox"][aria-label="Models"]')
+
+    expect(listbox.find('[data-testid="models-picker-legacy"]').exists())
       .toBe(false)
   })
 

--- a/tests/unit/components/ChatInput/ModelsTrigger.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.spec.ts
@@ -162,7 +162,9 @@ describe('ChatInput/ModelsTrigger', () => {
     expect(modelButton.find('[data-tip="Reasoning"]').exists()).toBe(false)
     expect(modelButton.find('[data-tip="Web search"]').exists()).toBe(false)
     expect(
-      modelButton.get('[data-testid="model-price-tier"]').attributes('title'),
+      modelButton
+        .get('[data-testid="model-price-tier"]')
+        .attributes('data-tip'),
     ).toBe('$0.039 / image')
   })
 
@@ -268,7 +270,7 @@ describe('ChatInput/ModelsTrigger', () => {
       .trigger('click')
     await wrapper.get('#model-option-legacy-model')
       .get('[data-testid="model-info-trigger"]')
-      .trigger('mouseenter')
+      .trigger('click')
 
     const panel = wrapper.get('[data-testid="model-detail-panel"]')
 

--- a/tests/unit/components/ChatInput/ModelsTrigger.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.spec.ts
@@ -9,8 +9,9 @@ const mocks = vi.hoisted(() => ({
   getProviders: vi.fn(),
   onClickOutside: vi.fn(),
   useDevice: vi.fn(),
-  useElementHover: vi.fn(),
   useUserModel: vi.fn(),
+  useUserSetting: vi.fn(),
+  toggleFavoriteModel: vi.fn(),
 }))
 
 mockNuxtImport('getModel', () => mocks.getModel)
@@ -18,8 +19,46 @@ mockNuxtImport('getModelName', () => mocks.getModelName)
 mockNuxtImport('getProviders', () => mocks.getProviders)
 mockNuxtImport('onClickOutside', () => mocks.onClickOutside)
 mockNuxtImport('useDevice', () => mocks.useDevice)
-mockNuxtImport('useElementHover', () => mocks.useElementHover)
 mockNuxtImport('useUserModel', () => mocks.useUserModel)
+mockNuxtImport('useUserSetting', () => mocks.useUserSetting)
+
+const imageModel = {
+  id: 'image-model',
+  name: 'Image model',
+  description: 'Creates images',
+  contextLength: 32_768,
+  maxOutputTokens: 32_768,
+  priceTier: '$$',
+  price: {
+    tokens: 1,
+    input: '$0.30',
+    output: '$30.00',
+    display: '$0.039 / image',
+  },
+  modalities: {
+    input: ['text'],
+    output: ['image'],
+  },
+  tools: ['image_generation'],
+  reasoning: false,
+}
+
+function mountPicker() {
+  return mountSuspended(ModelsTrigger, {
+    props: {
+      isWebSearchEnabled: false,
+      isImageGenerationEnabled: true,
+      isReasoningEnabled: false,
+    },
+    global: {
+      stubs: {
+        ClientOnly: {
+          template: '<slot />',
+        },
+      },
+    },
+  })
+}
 
 describe('ChatInput/ModelsTrigger', () => {
   beforeEach(() => {
@@ -31,40 +70,25 @@ describe('ChatInput/ModelsTrigger', () => {
       providers: [{
         id: 'google',
         name: 'Google AI Studio',
-        models: [{
-          id: 'image-model',
-          name: 'Image model',
-          tools: ['image_generation'],
-          reasoning: false,
-        }],
+        models: [imageModel],
       }],
     })
     mocks.useDevice.mockReturnValue({
       isIos: false,
       isAndroid: false,
+      isDesktop: true,
     })
-    mocks.useElementHover.mockReturnValue(shallowRef<boolean>(false))
     mocks.useUserModel.mockReturnValue({
       userModel: shallowRef<string>('image-model'),
+    })
+    mocks.useUserSetting.mockReturnValue({
+      favoriteModels: shallowRef<string[]>([]),
+      toggleFavoriteModel: mocks.toggleFavoriteModel,
     })
   })
 
   it('keeps image capability in the list but not the selected model trigger', async () => {
-    const wrapper = await mountSuspended(ModelsTrigger, {
-      props: {
-        isWebSearchEnabled: false,
-        isImageGenerationEnabled: true,
-        isReasoningEnabled: false,
-      },
-      global: {
-        stubs: {
-          ClientOnly: {
-            template: '<slot />',
-          },
-        },
-      },
-    })
-
+    const wrapper = await mountPicker()
     const selectedModel = wrapper.get(
       '[data-testid="current-model-trigger"]',
     )
@@ -73,6 +97,13 @@ describe('ChatInput/ModelsTrigger', () => {
     expect(selectedModel.find(
       '[data-testid="model-image-generation-capability"]',
     ).exists()).toBe(false)
+    expect(wrapper.find('[data-testid="models-picker-panel"]').exists())
+      .toBe(false)
+
+    await selectedModel.trigger('click')
+
+    expect(wrapper.find('[data-testid="models-picker-panel"]').exists())
+      .toBe(true)
     expect(wrapper.findAll(
       '[data-testid="model-image-generation-capability"]',
     )).toHaveLength(1)
@@ -84,34 +115,19 @@ describe('ChatInput/ModelsTrigger', () => {
         id: 'google',
         name: 'Google AI Studio',
         models: [{
-          id: 'image-model',
-          name: 'Image model',
+          ...imageModel,
           tools: [],
-          reasoning: false,
           imageGeneration: {
             controllerModel: 'controller-model',
-          },
-          price: {
-            display: '$0.039 / image',
           },
         }],
       }],
     })
 
-    const wrapper = await mountSuspended(ModelsTrigger, {
-      props: {
-        isWebSearchEnabled: false,
-        isImageGenerationEnabled: true,
-        isReasoningEnabled: false,
-      },
-      global: {
-        stubs: {
-          ClientOnly: {
-            template: '<slot />',
-          },
-        },
-      },
-    })
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+
     const modelButton = wrapper.get('button[aria-label="Choose Image model"]')
 
     expect(modelButton.find(
@@ -119,6 +135,54 @@ describe('ChatInput/ModelsTrigger', () => {
     ).exists()).toBe(true)
     expect(modelButton.find('[data-tip="Reasoning"]').exists()).toBe(false)
     expect(modelButton.find('[data-tip="Web search"]').exists()).toBe(false)
-    expect(modelButton.attributes('data-tip')).toBe('$0.039 / image')
+    expect(
+      modelButton.get('[data-testid="model-price-tier"]').attributes('title'),
+    ).toBe('$0.039 / image')
+  })
+
+  it('selects a model and closes the picker', async () => {
+    const userModel = shallowRef<string>('other-model')
+
+    mocks.useUserModel.mockReturnValue({ userModel })
+
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+    await wrapper.get('button[aria-label="Choose Image model"]')
+      .trigger('click')
+
+    expect(userModel.value).toBe('image-model')
+    await vi.waitFor(() => {
+      expect(wrapper.find('[data-testid="models-picker-panel"]').exists())
+        .toBe(false)
+    })
+  })
+
+  it('filters the list by search query and hides the provider rail', async () => {
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="models-picker-rail"]').exists())
+      .toBe(true)
+
+    await wrapper.get('[data-testid="models-picker-search"]')
+      .setValue('nothing here')
+
+    expect(wrapper.find('[data-testid="models-picker-rail"]').exists())
+      .toBe(false)
+    expect(wrapper.get('[data-testid="models-picker-empty"]').text())
+      .toContain('No models match')
+    expect(wrapper.find('[data-testid="models-picker-clear-filters"]').exists())
+      .toBe(false)
+  })
+
+  it('toggles a favorite through the user settings composable', async () => {
+    const wrapper = await mountPicker()
+
+    await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+    await wrapper.get('[data-testid="model-favorite-toggle"]').trigger('click')
+
+    expect(mocks.toggleFavoriteModel).toHaveBeenCalledWith('image-model')
   })
 })

--- a/tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts
@@ -133,6 +133,30 @@ describe('ChatInput/ModelsTrigger/FilterDropdown', () => {
     expect(dropdown.element.open).toBe(false)
   })
 
+  it('disables the clear action until a category is selected', async () => {
+    const wrapper = await mountFilterDropdown()
+    const clear = wrapper.get('[data-testid="models-picker-filter-clear"]')
+
+    expect(clear.classes()).toContain('menu-disabled')
+    expect(clear.get('button').attributes('disabled')).toBeDefined()
+  })
+
+  it('clears the selected category and closes the dropdown', async () => {
+    const wrapper = await mountFilterDropdown('chat')
+    const dropdown = wrapper.get('details')
+    const clear = wrapper.get('[data-testid="models-picker-filter-clear"]')
+
+    dropdown.element.open = true
+
+    expect(clear.classes()).not.toContain('menu-disabled')
+    expect(clear.get('button').attributes('disabled')).toBeUndefined()
+
+    await clear.get('button').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([null])
+    expect(dropdown.element.open).toBe(false)
+  })
+
   it('closes the open dropdown on an outside click', async () => {
     const wrapper = await mountFilterDropdown()
     const dropdown = wrapper.get('details')

--- a/tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts
@@ -60,6 +60,8 @@ describe('ChatInput/ModelsTrigger/FilterDropdown', () => {
 
     expect(research.attributes('aria-selected')).toBe('true')
     expect(chat.attributes('aria-selected')).toBe('false')
+    expect(research.get('button').attributes('aria-pressed')).toBe('true')
+    expect(chat.get('button').attributes('aria-pressed')).toBe('false')
   })
 
   it('selects a category on click and clears it on a second click', async () => {

--- a/tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts
@@ -10,11 +10,11 @@ const mocks = vi.hoisted(() => ({
 
 mockNuxtImport('onClickOutside', () => mocks.onClickOutside)
 
-async function mountFilterDropdown(selected: ModelCategory[] = []) {
+async function mountFilterDropdown(selected: ModelCategory | null = null) {
   const wrapper = await mountSuspended(FilterDropdown, {
     props: {
       'modelValue': selected,
-      'onUpdate:modelValue': (value: ModelCategory[]) => {
+      'onUpdate:modelValue': (value: ModelCategory | null) => {
         wrapper.setProps({ modelValue: value })
       },
     },
@@ -32,7 +32,7 @@ function getClickOutsideHandler() {
 }
 
 describe('ChatInput/ModelsTrigger/FilterDropdown', () => {
-  it('renders a checkbox for every model category', async () => {
+  it('renders an option for every model category', async () => {
     const wrapper = await mountFilterDropdown()
     const menu = wrapper.get('[data-testid="models-picker-filter-menu"]')
 
@@ -51,40 +51,52 @@ describe('ChatInput/ModelsTrigger/FilterDropdown', () => {
     ).toBe(true)
   })
 
-  it('checks only the selected categories', async () => {
-    const wrapper = await mountFilterDropdown(['research'])
-    const research = wrapper.get<HTMLInputElement>(
+  it('marks only the selected category', async () => {
+    const wrapper = await mountFilterDropdown('research')
+    const research = wrapper.get(
       '[data-testid="models-picker-filter-research"]',
     )
-    const chat = wrapper.get<HTMLInputElement>(
-      '[data-testid="models-picker-filter-chat"]',
-    )
+    const chat = wrapper.get('[data-testid="models-picker-filter-chat"]')
 
-    expect(research.element.checked).toBe(true)
-    expect(chat.element.checked).toBe(false)
+    expect(research.attributes('aria-selected')).toBe('true')
+    expect(chat.attributes('aria-selected')).toBe('false')
   })
 
-  it('adds a category on the first change and removes it on the second', async () => {
+  it('selects a category on click and clears it on a second click', async () => {
     const wrapper = await mountFilterDropdown()
     const chat = wrapper.get('[data-testid="models-picker-filter-chat"]')
 
-    await chat.setValue(true)
+    await chat.trigger('click')
 
-    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['chat']])
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['chat'])
 
-    await chat.setValue(false)
+    await wrapper.setProps({ modelValue: 'chat' })
+    await wrapper.get('[data-testid="models-picker-filter-chat"]')
+      .trigger('click')
 
-    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([[]])
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([null])
   })
 
-  it('keeps existing categories when another one is added', async () => {
-    const wrapper = await mountFilterDropdown(['chat'])
+  it('replaces the active category when another one is selected', async () => {
+    const wrapper = await mountFilterDropdown('chat')
 
     await wrapper.get('[data-testid="models-picker-filter-image-generation"]')
-      .setValue(true)
+      .trigger('click')
 
     expect(wrapper.emitted('update:modelValue')?.at(-1))
-      .toEqual([['chat', 'image-generation']])
+      .toEqual(['image-generation'])
+  })
+
+  it('closes the dropdown when a category is selected', async () => {
+    const wrapper = await mountFilterDropdown()
+    const dropdown = wrapper.get('details')
+
+    dropdown.element.open = true
+
+    await wrapper.get('[data-testid="models-picker-filter-chat"]')
+      .trigger('click')
+
+    expect(dropdown.element.open).toBe(false)
   })
 
   it('leaves the trigger unbadged while no filter is applied', async () => {
@@ -98,14 +110,14 @@ describe('ChatInput/ModelsTrigger/FilterDropdown', () => {
     expect(trigger.find('.badge').exists()).toBe(false)
   })
 
-  it('badges the trigger with the number of applied filters', async () => {
-    const wrapper = await mountFilterDropdown(['chat', 'research'])
+  it('badges the trigger while a category is applied', async () => {
+    const wrapper = await mountFilterDropdown('chat')
     const trigger = wrapper.get(
       '[data-testid="models-picker-filter-trigger"]',
     )
 
     expect(trigger.classes()).toContain('text-accent')
-    expect(trigger.get('.badge').text()).toBe('2')
+    expect(trigger.find('.badge').exists()).toBe(true)
   })
 
   it('closes the open dropdown on escape', async () => {

--- a/tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts
@@ -1,0 +1,140 @@
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import type { ModelCategory } from '~/types/models-picker'
+import FilterDropdown
+  from '../../../../../app/components/ChatInput/ModelsTrigger/FilterDropdown.vue'
+
+const mocks = vi.hoisted(() => ({
+  onClickOutside: vi.fn(),
+}))
+
+mockNuxtImport('onClickOutside', () => mocks.onClickOutside)
+
+async function mountFilterDropdown(selected: ModelCategory[] = []) {
+  const wrapper = await mountSuspended(FilterDropdown, {
+    props: {
+      'modelValue': selected,
+      'onUpdate:modelValue': (value: ModelCategory[]) => {
+        wrapper.setProps({ modelValue: value })
+      },
+    },
+  })
+
+  return wrapper
+}
+
+function getClickOutsideHandler() {
+  const handler = mocks.onClickOutside.mock.calls.at(-1)?.[1]
+
+  expect(handler).toBeTypeOf('function')
+
+  return handler as () => void
+}
+
+describe('ChatInput/ModelsTrigger/FilterDropdown', () => {
+  it('renders a checkbox for every model category', async () => {
+    const wrapper = await mountFilterDropdown()
+    const menu = wrapper.get('[data-testid="models-picker-filter-menu"]')
+
+    expect(menu.text()).toContain('Chat')
+    expect(menu.text()).toContain('Deep research')
+    expect(menu.text()).toContain('Image generation')
+    expect(wrapper.find('[data-testid="models-picker-filter-chat"]').exists())
+      .toBe(true)
+    expect(
+      wrapper.find('[data-testid="models-picker-filter-research"]').exists(),
+    ).toBe(true)
+    expect(
+      wrapper.find(
+        '[data-testid="models-picker-filter-image-generation"]',
+      ).exists(),
+    ).toBe(true)
+  })
+
+  it('checks only the selected categories', async () => {
+    const wrapper = await mountFilterDropdown(['research'])
+    const research = wrapper.get<HTMLInputElement>(
+      '[data-testid="models-picker-filter-research"]',
+    )
+    const chat = wrapper.get<HTMLInputElement>(
+      '[data-testid="models-picker-filter-chat"]',
+    )
+
+    expect(research.element.checked).toBe(true)
+    expect(chat.element.checked).toBe(false)
+  })
+
+  it('adds a category on the first change and removes it on the second', async () => {
+    const wrapper = await mountFilterDropdown()
+    const chat = wrapper.get('[data-testid="models-picker-filter-chat"]')
+
+    await chat.setValue(true)
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['chat']])
+
+    await chat.setValue(false)
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([[]])
+  })
+
+  it('keeps existing categories when another one is added', async () => {
+    const wrapper = await mountFilterDropdown(['chat'])
+
+    await wrapper.get('[data-testid="models-picker-filter-image-generation"]')
+      .setValue(true)
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1))
+      .toEqual([['chat', 'image-generation']])
+  })
+
+  it('leaves the trigger unbadged while no filter is applied', async () => {
+    const wrapper = await mountFilterDropdown()
+    const trigger = wrapper.get(
+      '[data-testid="models-picker-filter-trigger"]',
+    )
+
+    expect(trigger.attributes('aria-label')).toBe('Filter models by category')
+    expect(trigger.classes()).not.toContain('text-accent')
+    expect(trigger.find('.badge').exists()).toBe(false)
+  })
+
+  it('badges the trigger with the number of applied filters', async () => {
+    const wrapper = await mountFilterDropdown(['chat', 'research'])
+    const trigger = wrapper.get(
+      '[data-testid="models-picker-filter-trigger"]',
+    )
+
+    expect(trigger.classes()).toContain('text-accent')
+    expect(trigger.get('.badge').text()).toBe('2')
+  })
+
+  it('closes the open dropdown on escape', async () => {
+    const wrapper = await mountFilterDropdown()
+    const dropdown = wrapper.get('details')
+
+    dropdown.element.open = true
+
+    await dropdown.trigger('keydown', { key: 'Escape' })
+
+    expect(dropdown.element.open).toBe(false)
+  })
+
+  it('closes the open dropdown on an outside click', async () => {
+    const wrapper = await mountFilterDropdown()
+    const dropdown = wrapper.get('details')
+
+    dropdown.element.open = true
+    getClickOutsideHandler()()
+
+    expect(dropdown.element.open).toBe(false)
+  })
+
+  it('leaves an already closed dropdown alone on an outside click', async () => {
+    const wrapper = await mountFilterDropdown()
+    const dropdown = wrapper.get('details')
+
+    getClickOutsideHandler()()
+
+    expect(dropdown.element.open).toBe(false)
+  })
+})

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
@@ -1,0 +1,249 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import type { VueWrapper } from '@vue/test-utils'
+import type { Model } from '#shared/types/providers.d'
+import ModelDetail
+  from '../../../../../app/components/ChatInput/ModelsTrigger/ModelDetail.vue'
+
+function createModel(overrides: Partial<Model> = {}): Model {
+  return {
+    id: 'gpt-5.4',
+    name: 'GPT-5.4',
+    description: 'Flagship chat model',
+    contextLength: 400_000,
+    maxOutputTokens: 128_000,
+    releaseDate: '2026-05-01',
+    price: {
+      tokens: 1_000_000,
+      input: 'from $2.50',
+      output: 'from $15.00',
+    },
+    priceTier: '$$',
+    modalities: {
+      input: ['text', 'image'],
+      output: ['text'],
+    },
+    tools: [],
+    ...overrides,
+  }
+}
+
+function mountDetail(
+  model: Model = createModel(),
+  props: Partial<{ providerName: string, isInteractive: boolean }> = {},
+) {
+  return mountSuspended(ModelDetail, {
+    props: {
+      model,
+      providerName: 'OpenAI',
+      isInteractive: false,
+      ...props,
+    },
+  })
+}
+
+function readSpecs(wrapper: VueWrapper): Record<string, string> {
+  const specs = wrapper.get('[data-testid="model-detail-specs"]')
+  const values = specs.findAll('dd')
+
+  return Object.fromEntries(specs.findAll('dt').map((label, index) => {
+    return [label.text(), values[index]?.text() ?? '']
+  }))
+}
+
+function readSpecLabels(wrapper: VueWrapper): string[] {
+  return wrapper.get('[data-testid="model-detail-specs"]')
+    .findAll('dt')
+    .map((label) => {
+      return label.text()
+    })
+}
+
+describe('ChatInput/ModelsTrigger/ModelDetail', () => {
+  it('exposes the panel as a region keyed by the model id', async () => {
+    const wrapper = await mountDetail()
+    const panel = wrapper.get('[data-testid="model-detail-panel"]')
+
+    expect(panel.attributes('id')).toBe('model-detail-gpt-5.4')
+    expect(panel.attributes('role')).toBe('region')
+    expect(panel.attributes('aria-label')).toBe('GPT-5.4 details')
+  })
+
+  it('renders the name, description and price tier badge', async () => {
+    const wrapper = await mountDetail()
+
+    expect(wrapper.get('h3').text()).toBe('GPT-5.4')
+    expect(wrapper.text()).toContain('Flagship chat model')
+    expect(wrapper.get('.badge-ghost').text()).toBe('$$')
+  })
+
+  it('omits the description paragraph when the model has none', async () => {
+    const wrapper = await mountDetail(createModel({ description: '' }))
+
+    expect(wrapper.find('p').exists()).toBe(false)
+  })
+
+  it('renders a capability badge for each declared capability', async () => {
+    const model = createModel({
+      tools: ['web_search', 'image_generation'],
+      reasoning: { mode: 'toggle' },
+      research: {
+        tier: 'quick',
+        assistModel: 'gpt-5.4-nano',
+        costEstimate: '~$1 / task',
+        timeEstimate: '5–15 min',
+      },
+    })
+    const wrapper = await mountDetail(model)
+    const badges = wrapper.findAll('.badge-soft').map((badge) => {
+      return badge.text()
+    })
+
+    expect(badges).toEqual([
+      'Reasoning',
+      'Web search',
+      'Image generation',
+      'Deep research',
+    ])
+  })
+
+  it('renders no capability badges for a plain model', async () => {
+    const wrapper = await mountDetail()
+
+    expect(wrapper.findAll('.badge-soft')).toHaveLength(0)
+  })
+
+  it('lists the full spec table for a regular model', async () => {
+    const wrapper = await mountDetail()
+
+    expect(readSpecs(wrapper)).toEqual({
+      'Provider': 'OpenAI',
+      'Context': '400,000 tokens',
+      'Max output': '128,000 tokens',
+      'Input': 'text, image',
+      'Output': 'text',
+      'Price': 'from $2.50 in / from $15.00 out per 1M tokens',
+      'Added on': 'May 2026',
+    })
+  })
+
+  it('drops the token rows for a model that reports zero limits', async () => {
+    const model = createModel({
+      id: 'gpt-image-2',
+      name: 'GPT Image 2',
+      contextLength: 0,
+      maxOutputTokens: 0,
+      imageGeneration: { controllerModel: 'gpt-5-nano' },
+      price: {
+        tokens: 1_000_000,
+        input: '$10.00',
+        output: '$40.00',
+        display: '$0.04 / medium image',
+      },
+      modalities: { input: ['text', 'image'], output: ['image'] },
+    })
+    const wrapper = await mountDetail(model)
+    const labels = readSpecLabels(wrapper)
+
+    expect(labels).not.toContain('Context')
+    expect(labels).not.toContain('Max output')
+    expect(readSpecs(wrapper).Price).toBe('$0.04 / medium image')
+  })
+
+  it('drops the release row for a model without a release date', async () => {
+    const wrapper = await mountDetail(createModel({ releaseDate: undefined }))
+
+    expect(readSpecLabels(wrapper)).not.toContain('Added on')
+  })
+
+  it('drops the modality rows when the model declares none', async () => {
+    const wrapper = await mountDetail(createModel({
+      modalities: { input: [], output: [] },
+    }))
+    const labels = readSpecLabels(wrapper)
+
+    expect(labels).not.toContain('Input')
+    expect(labels).not.toContain('Output')
+  })
+
+  it('falls back to the input price alone when there is no output price', async () => {
+    const wrapper = await mountDetail(createModel({
+      price: { tokens: 1_000_000, input: '$0.10', output: '' },
+    }))
+
+    expect(readSpecs(wrapper).Price).toBe('$0.10')
+  })
+
+  it('renders a dash when the model has no price at all', async () => {
+    const wrapper = await mountDetail(createModel({
+      price: { tokens: 1_000_000, input: '', output: '' },
+    }))
+
+    expect(readSpecs(wrapper).Price).toBe('—')
+  })
+
+  it('lists the reasoning levels for a model that exposes them', async () => {
+    const wrapper = await mountDetail(createModel({
+      reasoning: { mode: 'levels', levels: ['low', 'medium', 'high'] },
+    }))
+
+    expect(readSpecs(wrapper)['Reasoning levels']).toBe('low, medium, high')
+  })
+
+  it('omits the reasoning levels row for a toggle-only model', async () => {
+    const wrapper = await mountDetail(createModel({
+      reasoning: { mode: 'toggle' },
+    }))
+
+    expect(readSpecLabels(wrapper)).not.toContain('Reasoning levels')
+  })
+
+  it('lists the research cost and time estimates', async () => {
+    const wrapper = await mountDetail(createModel({
+      research: {
+        tier: 'thorough',
+        assistModel: 'gpt-5.4-nano',
+        costEstimate: '~$5 / task',
+        timeEstimate: '20–40 min',
+      },
+    }))
+    const specs = readSpecs(wrapper)
+
+    expect(specs['Research cost']).toBe('~$5 / task')
+    expect(specs['Research time']).toBe('20–40 min')
+  })
+
+  it('opens the detail on hover while the panel is not interactive', async () => {
+    const wrapper = await mountDetail()
+    const panel = wrapper.get('[data-testid="model-detail-panel"]')
+
+    expect(wrapper.find('button[aria-label="Close model details"]').exists())
+      .toBe(false)
+
+    await panel.trigger('mouseenter')
+
+    expect(wrapper.emitted('showDetail')).toHaveLength(1)
+    expect(wrapper.emitted('hideDetail')).toBeUndefined()
+
+    await panel.trigger('mouseleave')
+
+    expect(wrapper.emitted('hideDetail')).toHaveLength(1)
+    expect(wrapper.emitted('showDetail')).toHaveLength(1)
+  })
+
+  it('offers a close button and ignores hover when interactive', async () => {
+    const wrapper = await mountDetail(createModel(), { isInteractive: true })
+    const panel = wrapper.get('[data-testid="model-detail-panel"]')
+
+    await panel.trigger('mouseenter')
+    await panel.trigger('mouseleave')
+
+    expect(wrapper.emitted('showDetail')).toBeUndefined()
+    expect(wrapper.emitted('hideDetail')).toBeUndefined()
+
+    await wrapper.get('button[aria-label="Close model details"]')
+      .trigger('click')
+
+    expect(wrapper.emitted('close')).toEqual([[]])
+  })
+})

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
@@ -74,7 +74,7 @@ describe('ChatInput/ModelsTrigger/ModelDetail', () => {
 
     expect(wrapper.get('h3').text()).toBe('GPT-5.4')
     expect(wrapper.text()).toContain('Flagship chat model')
-    expect(wrapper.get('.badge-ghost').text()).toBe('$$')
+    expect(wrapper.get('.badge-info').text()).toBe('$$')
   })
 
   it('omits the description paragraph when the model has none', async () => {

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
@@ -78,7 +78,6 @@ describe('ChatInput/ModelsTrigger/ModelDetail', () => {
     expect(priceTier.classes()).toContain('tooltip')
     expect(priceTier.classes()).toContain('tooltip-soft')
     expect(priceTier.classes()).toContain('tooltip-bottom')
-    expect(priceTier.classes()).toContain('tooltip-info')
     expect(priceTier.attributes('data-tip')).toBe('from $2.50 / from $15.00')
   })
 

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
@@ -60,13 +60,12 @@ function readSpecLabels(wrapper: VueWrapper): string[] {
 }
 
 describe('ChatInput/ModelsTrigger/ModelDetail', () => {
-  it('exposes the panel as a region keyed by the model id', async () => {
+  it('keys the panel by the model id without claiming a landmark role', async () => {
     const wrapper = await mountDetail()
     const panel = wrapper.get('[data-testid="model-detail-panel"]')
 
     expect(panel.attributes('id')).toBe('model-detail-gpt-5.4')
-    expect(panel.attributes('role')).toBe('region')
-    expect(panel.attributes('aria-label')).toBe('GPT-5.4 details')
+    expect(panel.attributes('role')).toBeUndefined()
   })
 
   it('renders the name, description and price tier badge', async () => {
@@ -77,18 +76,19 @@ describe('ChatInput/ModelsTrigger/ModelDetail', () => {
     expect(wrapper.get('.badge-info').text()).toBe('$$')
   })
 
-  it('badges a deprecated model in the header', async () => {
+  it('explains why a deprecated model should not be used', async () => {
     const wrapper = await mountDetail(createModel({ status: 'deprecated' }))
-    const badge = wrapper.get('[data-testid="model-detail-deprecated-badge"]')
+    const notice = wrapper.get('[data-testid="model-detail-deprecated-notice"]')
 
-    expect(badge.text()).toBe('Deprecated')
+    expect(notice.text()).toContain('deprecated this model')
+    expect(notice.text()).toContain('no longer be selected')
   })
 
-  it('omits the deprecated badge for a supported model', async () => {
+  it('omits the deprecation notice for a supported model', async () => {
     const wrapper = await mountDetail()
 
     expect(
-      wrapper.find('[data-testid="model-detail-deprecated-badge"]').exists(),
+      wrapper.find('[data-testid="model-detail-deprecated-notice"]').exists(),
     ).toBe(false)
   })
 

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
@@ -30,13 +30,12 @@ function createModel(overrides: Partial<Model> = {}): Model {
 
 function mountDetail(
   model: Model = createModel(),
-  props: Partial<{ providerName: string, isInteractive: boolean }> = {},
+  props: Partial<{ providerName: string }> = {},
 ) {
   return mountSuspended(ModelDetail, {
     props: {
       model,
       providerName: 'OpenAI',
-      isInteractive: false,
       ...props,
     },
   })
@@ -68,12 +67,19 @@ describe('ChatInput/ModelsTrigger/ModelDetail', () => {
     expect(panel.attributes('role')).toBeUndefined()
   })
 
-  it('renders the name, description and price tier badge', async () => {
+  it('renders the name, description and price tier badge with a tooltip', async () => {
     const wrapper = await mountDetail()
+    const priceTier = wrapper.get('[data-testid="model-detail-price-tier"]')
 
     expect(wrapper.get('h3').text()).toBe('GPT-5.4')
     expect(wrapper.text()).toContain('Flagship chat model')
-    expect(wrapper.get('.badge-info').text()).toBe('$$')
+    expect(priceTier.text()).toContain('$$')
+    expect(priceTier.classes()).toContain('badge-info')
+    expect(priceTier.classes()).toContain('tooltip')
+    expect(priceTier.classes()).toContain('tooltip-soft')
+    expect(priceTier.classes()).toContain('tooltip-bottom')
+    expect(priceTier.classes()).toContain('tooltip-info')
+    expect(priceTier.attributes('data-tip')).toBe('from $2.50 / from $15.00')
   })
 
   it('explains why a deprecated model should not be used', async () => {
@@ -240,33 +246,15 @@ describe('ChatInput/ModelsTrigger/ModelDetail', () => {
     expect(specs['Research time']).toBe('20–40 min')
   })
 
-  it('opens the detail on hover while the panel is not interactive', async () => {
+  it('always offers a close button and ignores hover on the panel', async () => {
     const wrapper = await mountDetail()
     const panel = wrapper.get('[data-testid="model-detail-panel"]')
 
+    await panel.trigger('mouseenter')
+    await panel.trigger('mouseleave')
+
     expect(wrapper.find('button[aria-label="Close model details"]').exists())
-      .toBe(false)
-
-    await panel.trigger('mouseenter')
-
-    expect(wrapper.emitted('showDetail')).toHaveLength(1)
-    expect(wrapper.emitted('hideDetail')).toBeUndefined()
-
-    await panel.trigger('mouseleave')
-
-    expect(wrapper.emitted('hideDetail')).toHaveLength(1)
-    expect(wrapper.emitted('showDetail')).toHaveLength(1)
-  })
-
-  it('offers a close button and ignores hover when interactive', async () => {
-    const wrapper = await mountDetail(createModel(), { isInteractive: true })
-    const panel = wrapper.get('[data-testid="model-detail-panel"]')
-
-    await panel.trigger('mouseenter')
-    await panel.trigger('mouseleave')
-
-    expect(wrapper.emitted('showDetail')).toBeUndefined()
-    expect(wrapper.emitted('hideDetail')).toBeUndefined()
+      .toBe(true)
 
     await wrapper.get('button[aria-label="Close model details"]')
       .trigger('click')

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
@@ -77,6 +77,29 @@ describe('ChatInput/ModelsTrigger/ModelDetail', () => {
     expect(wrapper.get('.badge-info').text()).toBe('$$')
   })
 
+  it('badges a deprecated model in the header', async () => {
+    const wrapper = await mountDetail(createModel({ status: 'deprecated' }))
+    const badge = wrapper.get('[data-testid="model-detail-deprecated-badge"]')
+
+    expect(badge.text()).toBe('Deprecated')
+  })
+
+  it('omits the deprecated badge for a supported model', async () => {
+    const wrapper = await mountDetail()
+
+    expect(
+      wrapper.find('[data-testid="model-detail-deprecated-badge"]').exists(),
+    ).toBe(false)
+  })
+
+  it('flows inline instead of overlaying the model list', async () => {
+    const wrapper = await mountDetail()
+    const panel = wrapper.get('[data-testid="model-detail-panel"]')
+
+    expect(panel.classes()).not.toContain('absolute')
+    expect(panel.classes()).not.toContain('bottom-0')
+  })
+
   it('omits the description paragraph when the model has none', async () => {
     const wrapper = await mountDetail(createModel({ description: '' }))
 
@@ -95,9 +118,12 @@ describe('ChatInput/ModelsTrigger/ModelDetail', () => {
       },
     })
     const wrapper = await mountDetail(model)
-    const badges = wrapper.findAll('.badge-soft').map((badge) => {
-      return badge.text()
-    })
+    const badges = wrapper
+      .get('[data-testid="model-detail-capabilities"]')
+      .findAll('.badge-soft')
+      .map((badge) => {
+        return badge.text()
+      })
 
     expect(badges).toEqual([
       'Reasoning',
@@ -110,7 +136,8 @@ describe('ChatInput/ModelsTrigger/ModelDetail', () => {
   it('renders no capability badges for a plain model', async () => {
     const wrapper = await mountDetail()
 
-    expect(wrapper.findAll('.badge-soft')).toHaveLength(0)
+    expect(wrapper.find('[data-testid="model-detail-capabilities"]').exists())
+      .toBe(false)
   })
 
   it('lists the full spec table for a regular model', async () => {

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
@@ -263,6 +263,7 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     expect(info.attributes('aria-controls')).toBe('model-detail-gpt-5.4')
     expect(info.attributes('aria-describedby')).toBe('model-detail-gpt-5.4')
     expect(info.attributes('aria-expanded')).toBe('true')
+    expect(info.classes()).toContain('btn-active')
   })
 
   it('ignores hover and focus and only toggles the detail on click on desktop', async () => {

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
@@ -79,13 +79,18 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     expect(wrapper.get('li').attributes('aria-selected')).toBe('true')
   })
 
-  it('renders the name and price tier with its tooltip', async () => {
+  it('renders the name and price tier with a color-matched tooltip', async () => {
     const wrapper = await mountModelItem()
     const priceTier = wrapper.get('[data-testid="model-price-tier"]')
 
     expect(wrapper.text()).toContain('GPT-5.4')
     expect(priceTier.text()).toContain('$$')
-    expect(priceTier.attributes('title')).toBe('from $2.50 / from $15.00')
+    expect(priceTier.classes()).toContain('badge-info')
+    expect(priceTier.classes()).toContain('tooltip')
+    expect(priceTier.classes()).toContain('tooltip-soft')
+    expect(priceTier.classes()).toContain('tooltip-bottom')
+    expect(priceTier.classes()).toContain('tooltip-info')
+    expect(priceTier.attributes('data-tip')).toBe('from $2.50 / from $15.00')
     expect(priceTier.get('.sr-only').text()).toBe('from $2.50 / from $15.00')
   })
 
@@ -129,9 +134,9 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     )
     const info = wrapper.get('[data-testid="model-info-trigger"]')
 
-    await info.trigger('mouseenter')
+    await info.trigger('click')
 
-    expect(wrapper.emitted('showDetail')).toHaveLength(1)
+    expect(wrapper.emitted('toggleDetail')).toHaveLength(1)
     expect(wrapper.emitted('select')).toBeUndefined()
   })
 
@@ -218,6 +223,14 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     expect(favorite.attributes('aria-label'))
       .toBe('Add GPT-5.4 to favorites')
     expect(favorite.attributes('aria-pressed')).toBe('false')
+    expect(favorite.attributes('data-tip')).toBe('Add to favorites')
+    expect(favorite.classes()).toContain('tooltip')
+    expect(favorite.classes()).toContain('tooltip-left')
+    expect(favorite.classes()).not.toContain('tooltip-soft')
+    expect(favorite.classes()).not.toContain('tooltip-success')
+    expect(favorite.classes()).not.toContain('tooltip-info')
+    expect(favorite.classes()).not.toContain('tooltip-warning')
+    expect(favorite.classes()).not.toContain('tooltip-error')
 
     await favorite.trigger('click')
 
@@ -231,6 +244,7 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     expect(favorite.attributes('aria-label'))
       .toBe('Remove GPT-5.4 from favorites')
     expect(favorite.attributes('aria-pressed')).toBe('true')
+    expect(favorite.attributes('data-tip')).toBe('Remove from favorites')
   })
 
   it('omits the detail panel id while the detail panel is closed', async () => {
@@ -252,39 +266,23 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     expect(info.attributes('aria-expanded')).toBe('true')
   })
 
-  it('opens and closes the detail on pointer and focus on desktop', async () => {
+  it('ignores hover and focus and only toggles the detail on click on desktop', async () => {
     const wrapper = await mountModelItem()
     const info = wrapper.get('[data-testid="model-info-trigger"]')
 
     await info.trigger('mouseenter')
-
-    expect(wrapper.emitted('showDetail')).toHaveLength(1)
-    expect(wrapper.emitted('hideDetail')).toBeUndefined()
-
-    await info.trigger('mouseleave')
-
-    expect(wrapper.emitted('hideDetail')).toHaveLength(1)
-
     await info.trigger('focus')
-
-    expect(wrapper.emitted('showDetail')).toHaveLength(2)
-
+    await info.trigger('mouseleave')
     await info.trigger('blur')
 
-    expect(wrapper.emitted('hideDetail')).toHaveLength(2)
     expect(wrapper.emitted('toggleDetail')).toBeUndefined()
+
+    await info.trigger('click')
+
+    expect(wrapper.emitted('toggleDetail')).toHaveLength(1)
   })
 
-  it('ignores a desktop click so hover keeps ownership of the detail', async () => {
-    const wrapper = await mountModelItem()
-
-    await wrapper.get('[data-testid="model-info-trigger"]').trigger('click')
-
-    expect(wrapper.emitted('toggleDetail')).toBeUndefined()
-    expect(wrapper.emitted('showDetail')).toBeUndefined()
-  })
-
-  it('toggles the detail on tap and ignores pointer events on touch', async () => {
+  it('ignores hover and focus and only toggles the detail on tap on touch', async () => {
     mocks.useDevice.mockReturnValue({
       isIos: true,
       isAndroid: false,
@@ -297,12 +295,11 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     await info.trigger('focus')
     await info.trigger('mouseenter')
 
-    expect(wrapper.emitted('showDetail')).toBeUndefined()
+    expect(wrapper.emitted('toggleDetail')).toBeUndefined()
 
     await info.trigger('click')
 
     expect(wrapper.emitted('toggleDetail')).toHaveLength(1)
-    expect(wrapper.emitted('hideDetail')).toBeUndefined()
   })
 
   it('highlights the keyboard-focused row without the selected styling', async () => {

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
@@ -79,26 +79,54 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     expect(wrapper.get('li').attributes('aria-selected')).toBe('true')
   })
 
-  it('renders the name, description and price tier with its tooltip', async () => {
+  it('renders the name and price tier with its tooltip', async () => {
     const wrapper = await mountModelItem()
     const priceTier = wrapper.get('[data-testid="model-price-tier"]')
 
     expect(wrapper.text()).toContain('GPT-5.4')
-    expect(wrapper.text()).toContain('Flagship chat model')
     expect(priceTier.text()).toContain('$$')
     expect(priceTier.attributes('title')).toBe('from $2.50 / from $15.00')
     expect(priceTier.get('.sr-only').text()).toBe('from $2.50 / from $15.00')
   })
 
-  it('omits the description line when the model has none', async () => {
-    const wrapper = await mountModelItem(createModel({ description: '' }))
+  it('keeps the description out of the compact row', async () => {
+    const wrapper = await mountModelItem()
 
     expect(wrapper.text()).not.toContain('Flagship chat model')
+  })
+
+  it('omits the deprecated badge for a supported model', async () => {
+    const wrapper = await mountModelItem()
+
+    expect(wrapper.find('[data-testid="model-deprecated-badge"]').exists())
+      .toBe(false)
+    expect(wrapper.get('button[aria-label="Choose GPT-5.4"]').exists())
+      .toBe(true)
+  })
+
+  it('flags a deprecated model in the badge and the select label', async () => {
+    const wrapper = await mountModelItem(createModel({
+      status: 'deprecated',
+    }))
+
+    expect(wrapper.get('[data-testid="model-deprecated-badge"]').text())
+      .toBe('Deprecated')
+    expect(wrapper.find('button[aria-label="Choose GPT-5.4, deprecated"]')
+      .exists()).toBe(true)
+  })
+
+  it('leaves beta and alpha models unbadged', async () => {
+    const wrapper = await mountModelItem(createModel({ status: 'beta' }))
+
+    expect(wrapper.find('[data-testid="model-deprecated-badge"]').exists())
+      .toBe(false)
   })
 
   it('renders no capability icons for a plain model', async () => {
     const wrapper = await mountModelItem()
 
+    expect(wrapper.find('[data-testid="model-capabilities"]').exists())
+      .toBe(false)
     expect(wrapper.find('[data-tip="Reasoning"]').exists()).toBe(false)
     expect(wrapper.find('[data-tip="Web search"]').exists()).toBe(false)
     expect(wrapper.find('[data-tip="Deep research"]').exists()).toBe(false)
@@ -120,6 +148,8 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     })
     const wrapper = await mountModelItem(model)
 
+    expect(wrapper.find('[data-testid="model-capabilities"]').exists())
+      .toBe(true)
     expect(wrapper.find('[data-tip="Reasoning"]').exists()).toBe(true)
     expect(wrapper.find('[data-tip="Web search"]').exists()).toBe(true)
     expect(wrapper.find('[data-tip="Deep research"]').exists()).toBe(true)
@@ -146,6 +176,18 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     await wrapper.get('button[aria-label="Choose GPT-5.4"]').trigger('click')
 
     expect(wrapper.emitted('select')).toHaveLength(1)
+  })
+
+  it('places the favorite toggle past the info button', async () => {
+    const wrapper = await mountModelItem()
+    const actions = wrapper
+      .get('[data-testid="model-actions"]')
+      .findAll('button')
+      .map((button) => {
+        return button.attributes('data-testid')
+      })
+
+    expect(actions).toEqual(['model-info-trigger', 'model-favorite-toggle'])
   })
 
   it('emits toggleFavorite and labels the button for adding a favorite', async () => {

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
@@ -95,8 +95,10 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     expect(wrapper.text()).not.toContain('Flagship chat model')
   })
 
-  it('omits the deprecated badge for a supported model', async () => {
-    const wrapper = await mountModelItem()
+  it('never renders an inline deprecated badge', async () => {
+    const wrapper = await mountModelItem(createModel({
+      status: 'deprecated',
+    }))
 
     expect(wrapper.find('[data-testid="model-deprecated-badge"]').exists())
       .toBe(false)
@@ -104,22 +106,41 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
       .toBe(true)
   })
 
-  it('flags a deprecated model in the badge and the select label', async () => {
-    const wrapper = await mountModelItem(createModel({
-      status: 'deprecated',
-    }))
+  it('offers no selectable control for a legacy row', async () => {
+    const wrapper = await mountModelItem(
+      createModel({ status: 'deprecated' }),
+      { isLegacy: true },
+    )
+    const option = wrapper.get('li')
 
-    expect(wrapper.get('[data-testid="model-deprecated-badge"]').text())
-      .toBe('Deprecated')
-    expect(wrapper.find('button[aria-label="Choose GPT-5.4, deprecated"]')
-      .exists()).toBe(true)
+    expect(wrapper.find('button[aria-label="Choose GPT-5.4"]').exists())
+      .toBe(false)
+    expect(wrapper.find('[data-testid="model-favorite-toggle"]').exists())
+      .toBe(false)
+    expect(option.attributes('aria-disabled')).toBe('true')
+    expect(option.attributes('aria-selected')).toBe('false')
+    expect(wrapper.text()).toContain('Deprecated, no longer selectable.')
   })
 
-  it('leaves beta and alpha models unbadged', async () => {
-    const wrapper = await mountModelItem(createModel({ status: 'beta' }))
+  it('keeps the info button working on a legacy row', async () => {
+    const wrapper = await mountModelItem(
+      createModel({ status: 'deprecated' }),
+      { isLegacy: true },
+    )
+    const info = wrapper.get('[data-testid="model-info-trigger"]')
 
-    expect(wrapper.find('[data-testid="model-deprecated-badge"]').exists())
-      .toBe(false)
+    await info.trigger('mouseenter')
+
+    expect(wrapper.emitted('showDetail')).toHaveLength(1)
+    expect(wrapper.emitted('select')).toBeUndefined()
+  })
+
+  it('still marks a non-legacy row as selectable and selected', async () => {
+    const wrapper = await mountModelItem(createModel(), { isSelected: true })
+    const option = wrapper.get('li')
+
+    expect(option.attributes('aria-selected')).toBe('true')
+    expect(option.attributes('aria-disabled')).toBeUndefined()
   })
 
   it('renders no capability icons for a plain model', async () => {

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
@@ -89,7 +89,6 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     expect(priceTier.classes()).toContain('tooltip')
     expect(priceTier.classes()).toContain('tooltip-soft')
     expect(priceTier.classes()).toContain('tooltip-bottom')
-    expect(priceTier.classes()).toContain('tooltip-info')
     expect(priceTier.attributes('data-tip')).toBe('from $2.50 / from $15.00')
     expect(priceTier.get('.sr-only').text()).toBe('from $2.50 / from $15.00')
   })

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
@@ -151,7 +151,7 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     const wrapper = await mountModelItem()
 
     expect(wrapper.find('[data-testid="model-capabilities"]').exists())
-      .toBe(true)
+      .toBe(false)
     expect(wrapper.find('[data-tip="Reasoning"]').exists()).toBe(false)
     expect(wrapper.find('[data-tip="Web search"]').exists()).toBe(false)
     expect(wrapper.find('[data-tip="Deep research"]').exists()).toBe(false)
@@ -160,28 +160,43 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     ).exists()).toBe(false)
   })
 
-  it('omits the capabilities row entirely without a price tier or '
-    + 'capabilities', async () => {
+  it('omits the price-tier badge when the model has no price tier', async () => {
     const wrapper = await mountModelItem(
       createModel({ priceTier: undefined }),
     )
 
-    expect(wrapper.find('[data-testid="model-capabilities"]').exists())
+    expect(wrapper.find('[data-testid="model-price-tier"]').exists())
       .toBe(false)
   })
 
-  it('places the price tier before the capability icons in the '
-    + 'wrapped row', async () => {
+  it('places the price tier as a preceding sibling of the capability '
+    + 'icons, indenting only the icons on mobile', async () => {
     const model = createModel({
       tools: ['web_search'],
       reasoning: { mode: 'toggle' },
     })
     const wrapper = await mountModelItem(model)
+    const priceTier = wrapper.get('[data-testid="model-price-tier"]')
     const capabilities = wrapper.get('[data-testid="model-capabilities"]')
-    const priceTier = capabilities.get('[data-testid="model-price-tier"]')
 
-    expect(capabilities.classes()).toContain('ml-5')
-    expect(capabilities.element.firstElementChild).toBe(priceTier.element)
+    expect(priceTier.classes()).toContain('max-xs:ml-5')
+    expect(capabilities.classes()).toContain('xs:ml-auto')
+    expect(capabilities.classes()).toContain('max-xs:-ml-1')
+    expect(capabilities.classes()).not.toContain('max-xs:ml-5')
+    expect(priceTier.element.nextElementSibling).toBe(capabilities.element)
+  })
+
+  it('indents the capability icons on mobile when there is no price '
+    + 'tier', async () => {
+    const model = createModel({
+      priceTier: undefined,
+      tools: ['web_search'],
+    })
+    const wrapper = await mountModelItem(model)
+    const capabilities = wrapper.get('[data-testid="model-capabilities"]')
+
+    expect(capabilities.classes()).toContain('max-xs:ml-5')
+    expect(capabilities.classes()).not.toContain('max-xs:-ml-1')
   })
 
   it('renders every capability icon a model declares', async () => {

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
@@ -151,13 +151,37 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
     const wrapper = await mountModelItem()
 
     expect(wrapper.find('[data-testid="model-capabilities"]').exists())
-      .toBe(false)
+      .toBe(true)
     expect(wrapper.find('[data-tip="Reasoning"]').exists()).toBe(false)
     expect(wrapper.find('[data-tip="Web search"]').exists()).toBe(false)
     expect(wrapper.find('[data-tip="Deep research"]').exists()).toBe(false)
     expect(wrapper.find(
       '[data-testid="model-image-generation-capability"]',
     ).exists()).toBe(false)
+  })
+
+  it('omits the capabilities row entirely without a price tier or '
+    + 'capabilities', async () => {
+    const wrapper = await mountModelItem(
+      createModel({ priceTier: undefined }),
+    )
+
+    expect(wrapper.find('[data-testid="model-capabilities"]').exists())
+      .toBe(false)
+  })
+
+  it('places the price tier before the capability icons in the '
+    + 'wrapped row', async () => {
+    const model = createModel({
+      tools: ['web_search'],
+      reasoning: { mode: 'toggle' },
+    })
+    const wrapper = await mountModelItem(model)
+    const capabilities = wrapper.get('[data-testid="model-capabilities"]')
+    const priceTier = capabilities.get('[data-testid="model-price-tier"]')
+
+    expect(capabilities.classes()).toContain('ml-5')
+    expect(capabilities.element.firstElementChild).toBe(priceTier.element)
   })
 
   it('renders every capability icon a model declares', async () => {

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
@@ -1,0 +1,265 @@
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Model } from '#shared/types/providers.d'
+import ModelItem
+  from '../../../../../app/components/ChatInput/ModelsTrigger/ModelItem.vue'
+
+const mocks = vi.hoisted(() => ({
+  useDevice: vi.fn(),
+}))
+
+mockNuxtImport('useDevice', () => mocks.useDevice)
+
+function createModel(overrides: Partial<Model> = {}): Model {
+  return {
+    id: 'gpt-5.4',
+    name: 'GPT-5.4',
+    description: 'Flagship chat model',
+    contextLength: 400_000,
+    maxOutputTokens: 128_000,
+    price: {
+      tokens: 1_000_000,
+      input: 'from $2.50',
+      output: 'from $15.00',
+    },
+    priceTier: '$$',
+    modalities: {
+      input: ['text', 'image'],
+      output: ['text'],
+    },
+    tools: [],
+    ...overrides,
+  }
+}
+
+function mountModelItem(
+  model: Model = createModel(),
+  props: Partial<{
+    providerId: string
+    isSelected: boolean
+    isHighlighted: boolean
+    isFavorite: boolean
+    isDetailOpen: boolean
+  }> = {},
+) {
+  return mountSuspended(ModelItem, {
+    props: {
+      model,
+      providerId: 'openai',
+      isSelected: false,
+      isHighlighted: false,
+      isFavorite: false,
+      isDetailOpen: false,
+      ...props,
+    },
+  })
+}
+
+describe('ChatInput/ModelsTrigger/ModelItem', () => {
+  beforeEach(() => {
+    mocks.useDevice.mockReturnValue({
+      isIos: false,
+      isAndroid: false,
+      isDesktop: true,
+    })
+  })
+
+  it('exposes the option as a listbox option keyed by the model id', async () => {
+    const wrapper = await mountModelItem()
+    const option = wrapper.get('li')
+
+    expect(option.attributes('id')).toBe('model-option-gpt-5.4')
+    expect(option.attributes('role')).toBe('option')
+    expect(option.attributes('aria-selected')).toBe('false')
+  })
+
+  it('marks the option as selected for the active model', async () => {
+    const wrapper = await mountModelItem(createModel(), { isSelected: true })
+
+    expect(wrapper.get('li').attributes('aria-selected')).toBe('true')
+  })
+
+  it('renders the name, description and price tier with its tooltip', async () => {
+    const wrapper = await mountModelItem()
+    const priceTier = wrapper.get('[data-testid="model-price-tier"]')
+
+    expect(wrapper.text()).toContain('GPT-5.4')
+    expect(wrapper.text()).toContain('Flagship chat model')
+    expect(priceTier.text()).toContain('$$')
+    expect(priceTier.attributes('title')).toBe('from $2.50 / from $15.00')
+    expect(priceTier.get('.sr-only').text()).toBe('from $2.50 / from $15.00')
+  })
+
+  it('omits the description line when the model has none', async () => {
+    const wrapper = await mountModelItem(createModel({ description: '' }))
+
+    expect(wrapper.text()).not.toContain('Flagship chat model')
+  })
+
+  it('renders no capability icons for a plain model', async () => {
+    const wrapper = await mountModelItem()
+
+    expect(wrapper.find('[data-tip="Reasoning"]').exists()).toBe(false)
+    expect(wrapper.find('[data-tip="Web search"]').exists()).toBe(false)
+    expect(wrapper.find('[data-tip="Deep research"]').exists()).toBe(false)
+    expect(wrapper.find(
+      '[data-testid="model-image-generation-capability"]',
+    ).exists()).toBe(false)
+  })
+
+  it('renders every capability icon a model declares', async () => {
+    const model = createModel({
+      tools: ['web_search', 'image_generation'],
+      reasoning: { mode: 'levels', levels: ['low', 'medium', 'high'] },
+      research: {
+        tier: 'quick',
+        assistModel: 'gpt-5.4-nano',
+        costEstimate: '~$1 / task',
+        timeEstimate: '5–15 min',
+      },
+    })
+    const wrapper = await mountModelItem(model)
+
+    expect(wrapper.find('[data-tip="Reasoning"]').exists()).toBe(true)
+    expect(wrapper.find('[data-tip="Web search"]').exists()).toBe(true)
+    expect(wrapper.find('[data-tip="Deep research"]').exists()).toBe(true)
+    expect(wrapper.find(
+      '[data-testid="model-image-generation-capability"]',
+    ).exists()).toBe(true)
+  })
+
+  it('renders the image generation icon for a purpose-built image model', async () => {
+    const model = createModel({
+      tools: [],
+      imageGeneration: { controllerModel: 'gpt-5-nano' },
+    })
+    const wrapper = await mountModelItem(model)
+
+    expect(wrapper.find(
+      '[data-testid="model-image-generation-capability"]',
+    ).exists()).toBe(true)
+  })
+
+  it('emits select when the model button is clicked', async () => {
+    const wrapper = await mountModelItem()
+
+    await wrapper.get('button[aria-label="Choose GPT-5.4"]').trigger('click')
+
+    expect(wrapper.emitted('select')).toHaveLength(1)
+  })
+
+  it('emits toggleFavorite and labels the button for adding a favorite', async () => {
+    const wrapper = await mountModelItem()
+    const favorite = wrapper.get('[data-testid="model-favorite-toggle"]')
+
+    expect(favorite.attributes('aria-label'))
+      .toBe('Add GPT-5.4 to favorites')
+    expect(favorite.attributes('aria-pressed')).toBe('false')
+
+    await favorite.trigger('click')
+
+    expect(wrapper.emitted('toggleFavorite')).toHaveLength(1)
+  })
+
+  it('labels the button for removing an existing favorite', async () => {
+    const wrapper = await mountModelItem(createModel(), { isFavorite: true })
+    const favorite = wrapper.get('[data-testid="model-favorite-toggle"]')
+
+    expect(favorite.attributes('aria-label'))
+      .toBe('Remove GPT-5.4 from favorites')
+    expect(favorite.attributes('aria-pressed')).toBe('true')
+  })
+
+  it('omits the detail panel id while the detail panel is closed', async () => {
+    const wrapper = await mountModelItem()
+    const info = wrapper.get('[data-testid="model-info-trigger"]')
+
+    expect(info.attributes('aria-label')).toBe('About GPT-5.4')
+    expect(info.attributes('aria-controls')).toBeUndefined()
+    expect(info.attributes('aria-describedby')).toBeUndefined()
+    expect(info.attributes('aria-expanded')).toBe('false')
+  })
+
+  it('points the info button at the detail panel id while it is open', async () => {
+    const wrapper = await mountModelItem(createModel(), { isDetailOpen: true })
+    const info = wrapper.get('[data-testid="model-info-trigger"]')
+
+    expect(info.attributes('aria-controls')).toBe('model-detail-gpt-5.4')
+    expect(info.attributes('aria-describedby')).toBe('model-detail-gpt-5.4')
+    expect(info.attributes('aria-expanded')).toBe('true')
+  })
+
+  it('opens and closes the detail on pointer and focus on desktop', async () => {
+    const wrapper = await mountModelItem()
+    const info = wrapper.get('[data-testid="model-info-trigger"]')
+
+    await info.trigger('mouseenter')
+
+    expect(wrapper.emitted('showDetail')).toHaveLength(1)
+    expect(wrapper.emitted('hideDetail')).toBeUndefined()
+
+    await info.trigger('mouseleave')
+
+    expect(wrapper.emitted('hideDetail')).toHaveLength(1)
+
+    await info.trigger('focus')
+
+    expect(wrapper.emitted('showDetail')).toHaveLength(2)
+
+    await info.trigger('blur')
+
+    expect(wrapper.emitted('hideDetail')).toHaveLength(2)
+    expect(wrapper.emitted('toggleDetail')).toBeUndefined()
+  })
+
+  it('ignores a desktop click so hover keeps ownership of the detail', async () => {
+    const wrapper = await mountModelItem()
+
+    await wrapper.get('[data-testid="model-info-trigger"]').trigger('click')
+
+    expect(wrapper.emitted('toggleDetail')).toBeUndefined()
+    expect(wrapper.emitted('showDetail')).toBeUndefined()
+  })
+
+  it('toggles the detail on tap and ignores pointer events on touch', async () => {
+    mocks.useDevice.mockReturnValue({
+      isIos: true,
+      isAndroid: false,
+      isDesktop: false,
+    })
+
+    const wrapper = await mountModelItem()
+    const info = wrapper.get('[data-testid="model-info-trigger"]')
+
+    await info.trigger('focus')
+    await info.trigger('mouseenter')
+
+    expect(wrapper.emitted('showDetail')).toBeUndefined()
+
+    await info.trigger('click')
+
+    expect(wrapper.emitted('toggleDetail')).toHaveLength(1)
+    expect(wrapper.emitted('hideDetail')).toBeUndefined()
+  })
+
+  it('highlights the keyboard-focused row without the selected styling', async () => {
+    const wrapper = await mountModelItem(createModel(), {
+      isHighlighted: true,
+    })
+    const row = wrapper.get('li > div')
+
+    expect(row.classes()).toContain('bg-base-content/10')
+    expect(row.classes()).not.toContain('bg-accent/15')
+  })
+
+  it('prefers the selected styling over the highlighted styling', async () => {
+    const wrapper = await mountModelItem(createModel(), {
+      isSelected: true,
+      isHighlighted: true,
+    })
+    const row = wrapper.get('li > div')
+
+    expect(row.classes()).toContain('bg-accent/15')
+    expect(row.classes()).not.toContain('bg-base-content/10')
+  })
+})

--- a/tests/unit/components/ChatInput/ModelsTrigger/ProviderRail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ProviderRail.spec.ts
@@ -1,0 +1,136 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import type { Providers } from '#shared/types/providers.d'
+import ProviderRail
+  from '../../../../../app/components/ChatInput/ModelsTrigger/ProviderRail.vue'
+
+const providers: Providers = [
+  { id: 'openai', name: 'OpenAI', models: [] },
+  { id: 'google', name: 'Google AI Studio', models: [] },
+]
+
+function mountRail(
+  props: Partial<{
+    providers: Providers
+    activeProviderId: string | null
+    isFavoritesOnly: boolean
+    hasFavorites: boolean
+  }> = {},
+) {
+  return mountSuspended(ProviderRail, {
+    props: {
+      providers,
+      activeProviderId: null,
+      isFavoritesOnly: false,
+      hasFavorites: false,
+      ...props,
+    },
+  })
+}
+
+describe('ChatInput/ModelsTrigger/ProviderRail', () => {
+  it('renders one labelled button per provider', async () => {
+    const wrapper = await mountRail()
+    const openai = wrapper.get('[data-testid="models-picker-rail-openai"]')
+    const google = wrapper.get('[data-testid="models-picker-rail-google"]')
+
+    expect(openai.attributes('aria-label')).toBe('Show OpenAI models only')
+    expect(openai.attributes('data-tip')).toBe('OpenAI')
+    expect(openai.attributes('aria-pressed')).toBe('false')
+    expect(google.attributes('aria-label'))
+      .toBe('Show Google AI Studio models only')
+    expect(google.attributes('data-tip')).toBe('Google AI Studio')
+  })
+
+  it('hides the favorites filter until the user has a favorite', async () => {
+    const wrapper = await mountRail()
+
+    expect(
+      wrapper.find('[data-testid="models-picker-rail-favorites"]').exists(),
+    ).toBe(false)
+    expect(wrapper.find('.divider').exists()).toBe(false)
+  })
+
+  it('shows the favorites filter once a favorite exists', async () => {
+    const wrapper = await mountRail({ hasFavorites: true })
+    const favorites = wrapper.get(
+      '[data-testid="models-picker-rail-favorites"]',
+    )
+
+    expect(favorites.attributes('aria-label'))
+      .toBe('Show favorite models only')
+    expect(favorites.attributes('data-tip')).toBe('Favorites')
+    expect(favorites.attributes('aria-pressed')).toBe('false')
+    expect(wrapper.find('.divider').exists()).toBe(true)
+  })
+
+  it('marks the favorites filter pressed while it is applied', async () => {
+    const wrapper = await mountRail({
+      hasFavorites: true,
+      isFavoritesOnly: true,
+    })
+    const favorites = wrapper.get(
+      '[data-testid="models-picker-rail-favorites"]',
+    )
+
+    expect(favorites.attributes('aria-pressed')).toBe('true')
+    expect(favorites.classes()).toContain('btn-active')
+    expect(favorites.classes()).toContain('text-warning')
+  })
+
+  it('emits toggleFavorites when the favorites filter is clicked', async () => {
+    const wrapper = await mountRail({ hasFavorites: true })
+
+    await wrapper.get('[data-testid="models-picker-rail-favorites"]')
+      .trigger('click')
+
+    expect(wrapper.emitted('toggleFavorites')).toEqual([[]])
+  })
+
+  it('emits toggleProvider with the clicked provider id', async () => {
+    const wrapper = await mountRail()
+
+    await wrapper.get('[data-testid="models-picker-rail-google"]')
+      .trigger('click')
+
+    expect(wrapper.emitted('toggleProvider')).toEqual([['google']])
+  })
+
+  it('marks only the active provider as pressed', async () => {
+    const wrapper = await mountRail({ activeProviderId: 'openai' })
+    const openai = wrapper.get('[data-testid="models-picker-rail-openai"]')
+    const google = wrapper.get('[data-testid="models-picker-rail-google"]')
+
+    expect(openai.attributes('aria-pressed')).toBe('true')
+    expect(openai.classes()).toContain('btn-active')
+    expect(openai.classes()).toContain('text-accent')
+    expect(google.attributes('aria-pressed')).toBe('false')
+    expect(google.classes()).not.toContain('btn-active')
+  })
+
+  it('renders brand marks for the known providers', async () => {
+    const wrapper = await mountRail()
+
+    expect(
+      wrapper.get('[data-testid="models-picker-rail-openai"]').find('svg')
+        .exists(),
+    ).toBe(true)
+    expect(
+      wrapper.get('[data-testid="models-picker-rail-google"]').find('svg')
+        .exists(),
+    ).toBe(true)
+  })
+
+  it('falls back to the first two letters of an unknown provider', async () => {
+    const wrapper = await mountRail({
+      providers: [{ id: 'anthropic', name: 'Anthropic', models: [] }],
+    })
+    const anthropic = wrapper.get(
+      '[data-testid="models-picker-rail-anthropic"]',
+    )
+
+    expect(anthropic.text()).toBe('An')
+    expect(anthropic.get('span').classes()).toContain('uppercase')
+    expect(anthropic.find('svg').exists()).toBe(false)
+  })
+})

--- a/tests/unit/components/ChatInput/ModelsTrigger/Search.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/Search.spec.ts
@@ -1,0 +1,104 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { enableAutoUnmount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import Search
+  from '../../../../../app/components/ChatInput/ModelsTrigger/Search.vue'
+
+enableAutoUnmount(afterEach)
+
+function mountSearch(
+  props: Partial<{
+    modelValue: string
+    autofocus: boolean
+    controls: string
+    activeDescendant: string
+  }> = {},
+) {
+  return mountSuspended(Search, {
+    attachTo: document.body,
+    props: {
+      modelValue: '',
+      ...props,
+    },
+  })
+}
+
+describe('ChatInput/ModelsTrigger/Search', () => {
+  it('exposes the input as a combobox wired to the model listbox', async () => {
+    const wrapper = await mountSearch({
+      controls: 'models-listbox',
+      activeDescendant: 'model-option-gpt-5.4',
+    })
+    const input = wrapper.get('[data-testid="models-picker-search"]')
+
+    expect(input.attributes('role')).toBe('combobox')
+    expect(input.attributes('aria-label')).toBe('Search models')
+    expect(input.attributes('aria-autocomplete')).toBe('list')
+    expect(input.attributes('aria-expanded')).toBe('true')
+    expect(input.attributes('aria-controls')).toBe('models-listbox')
+    expect(input.attributes('aria-activedescendant'))
+      .toBe('model-option-gpt-5.4')
+  })
+
+  it('omits aria-activedescendant when nothing is highlighted', async () => {
+    const wrapper = await mountSearch({ controls: 'models-listbox' })
+
+    expect(
+      wrapper.get('[data-testid="models-picker-search"]')
+        .attributes('aria-activedescendant'),
+    ).toBeUndefined()
+  })
+
+  it('emits the query as the user types', async () => {
+    const wrapper = await mountSearch()
+
+    await wrapper.get('[data-testid="models-picker-search"]').setValue('gpt')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['gpt']])
+  })
+
+  it('hides the clear button while the query is empty', async () => {
+    const wrapper = await mountSearch()
+
+    expect(wrapper.find('button[aria-label="Clear search"]').exists())
+      .toBe(false)
+  })
+
+  it('clears the query and returns focus to the input', async () => {
+    const wrapper = await mountSearch({ modelValue: 'gpt' })
+    const input = wrapper.get('[data-testid="models-picker-search"]')
+
+    await wrapper.get('button[aria-label="Clear search"]').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['']])
+    expect(document.activeElement).toBe(input.element)
+  })
+
+  it('forwards keydown events to the parent picker', async () => {
+    const wrapper = await mountSearch()
+
+    await wrapper.get('[data-testid="models-picker-search"]')
+      .trigger('keydown', { key: 'ArrowDown' })
+
+    const events = wrapper.emitted('keydown')
+
+    expect(events).toHaveLength(1)
+    expect((events?.[0]?.[0] as KeyboardEvent).key).toBe('ArrowDown')
+  })
+
+  it('focuses the input on mount when autofocus is requested', async () => {
+    const wrapper = await mountSearch({ autofocus: true })
+
+    expect(document.activeElement).toBe(
+      wrapper.get('[data-testid="models-picker-search"]').element,
+    )
+  })
+
+  it('leaves focus alone on mount without autofocus', async () => {
+    const wrapper = await mountSearch()
+
+    expect(document.activeElement).not.toBe(
+      wrapper.get('[data-testid="models-picker-search"]').element,
+    )
+  })
+})

--- a/tests/unit/components/Projects/MemoryCard.spec.ts
+++ b/tests/unit/components/Projects/MemoryCard.spec.ts
@@ -82,7 +82,7 @@ describe('Projects/MemoryCard', () => {
         memoryStatus: 'idle',
         memoryUpdatedAt: null,
         memoryProvider: 'google',
-        memoryModel: 'gemini-3.1-flash-lite-preview',
+        memoryModel: 'gemini-3.1-flash-lite',
         memoryError: null,
         isRefreshing: false,
         isToggling: false,

--- a/tests/unit/composables/user-setting.spec.ts
+++ b/tests/unit/composables/user-setting.spec.ts
@@ -2,16 +2,33 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { useUserSetting } from '../../../app/composables/user-setting'
 
-const { fetchMock } = vi.hoisted(() => ({
+const { fetchMock, getProvidersMock } = vi.hoisted(() => ({
   fetchMock: vi.fn(),
+  getProvidersMock: vi.fn(),
 }))
 
 mockNuxtImport('$fetch', () => fetchMock)
+mockNuxtImport('getProviders', () => getProvidersMock)
 
 describe('useUserSetting', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+
+    getProvidersMock.mockReturnValue({
+      providers: [
+        {
+          id: 'openai',
+          name: 'OpenAI',
+          models: [{ id: 'gpt-5.4' }],
+        },
+        {
+          id: 'google',
+          name: 'Google AI Studio',
+          models: [{ id: 'gemini-2.5-flash' }],
+        },
+      ],
+    })
 
     const { clearUserContext } = useUserSetting()
 
@@ -591,4 +608,208 @@ describe('useUserSetting', () => {
     expect(sidebarPinned.value).toBe(false)
     expect(settingsError.value).not.toBeNull()
   })
+
+  it('uses the local storage fallback for favoriteModels before sync', () => {
+    localStorage.setItem(
+      'settings_favorite_models',
+      JSON.stringify(['gpt-5.4']),
+    )
+
+    const { favoriteModels } = useUserSetting()
+
+    expect(favoriteModels.value).toEqual(['gpt-5.4'])
+  })
+
+  it('falls back to an empty list when stored favorites are corrupt', () => {
+    localStorage.setItem('settings_favorite_models', 'not json')
+
+    const { favoriteModels } = useUserSetting()
+
+    expect(favoriteModels.value).toEqual([])
+  })
+
+  it('uses DB favoriteModels as source of truth after sync', async () => {
+    localStorage.setItem(
+      'settings_favorite_models',
+      JSON.stringify(['gpt-5.4']),
+    )
+
+    fetchMock.mockResolvedValue({
+      reasoningExpanded: false,
+      reasoningAutoHide: true,
+      favoriteModels: ['gemini-2.5-flash'],
+    })
+    const {
+      favoriteModels,
+      syncForUser,
+    } = useUserSetting()
+
+    expect(favoriteModels.value).toEqual(['gpt-5.4'])
+
+    await syncForUser('user-1')
+
+    expect(favoriteModels.value).toEqual(['gemini-2.5-flash'])
+    expect(localStorage.getItem('settings_favorite_models')).toBe(
+      JSON.stringify(['gemini-2.5-flash']),
+    )
+  })
+
+  it('updates local storage without API call for favorites guests', async () => {
+    fetchMock.mockReset()
+    const {
+      favoriteModels,
+      toggleFavoriteModel,
+    } = useUserSetting()
+
+    await toggleFavoriteModel('gpt-5.4')
+
+    expect(favoriteModels.value).toEqual(['gpt-5.4'])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('toggles a favorite off and persists it for authenticated users',
+    async () => {
+      fetchMock.mockReset()
+        .mockResolvedValueOnce({
+          reasoningExpanded: false,
+          reasoningAutoHide: true,
+          favoriteModels: ['gpt-5.4', 'gemini-2.5-flash'],
+        })
+        .mockResolvedValueOnce({
+          favoriteModels: ['gemini-2.5-flash'],
+        })
+      const {
+        syncForUser,
+        favoriteModels,
+        toggleFavoriteModel,
+      } = useUserSetting()
+
+      await syncForUser('user-1')
+      await toggleFavoriteModel('gpt-5.4')
+
+      expect(favoriteModels.value).toEqual(['gemini-2.5-flash'])
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        '/api/v1/profiles/settings',
+        {
+          method: 'PATCH',
+          body: {
+            favoriteModels: ['gemini-2.5-flash'],
+          },
+        },
+      )
+    })
+
+  it('rolls back optimistic favoriteModels when the save fails', async () => {
+    fetchMock.mockReset()
+      .mockResolvedValueOnce({
+        reasoningExpanded: false,
+        reasoningAutoHide: true,
+        favoriteModels: [],
+      })
+      .mockRejectedValueOnce(new Error('Save failed'))
+    const {
+      favoriteModels,
+      settingsError,
+      syncForUser,
+      setFavoriteModels,
+    } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    const savePromise = setFavoriteModels(['gpt-5.4'])
+
+    expect(favoriteModels.value).toEqual(['gpt-5.4'])
+    await savePromise
+
+    expect(favoriteModels.value).toEqual([])
+    expect(settingsError.value).not.toBeNull()
+  })
+
+  it('applies only the latest toggle when responses resolve out of order',
+    async () => {
+      fetchMock.mockReset()
+        .mockResolvedValueOnce({
+          reasoningExpanded: false,
+          reasoningAutoHide: true,
+          favoriteModels: [],
+        })
+      const {
+        syncForUser,
+        favoriteModels,
+        setFavoriteModels,
+      } = useUserSetting()
+
+      await syncForUser('user-1')
+
+      let resolveFirstRequest: (value: unknown) => void = () => {}
+      let resolveSecondRequest: (value: unknown) => void = () => {}
+
+      fetchMock
+        .mockImplementationOnce(() => new Promise((resolve) => {
+          resolveFirstRequest = resolve
+        }))
+        .mockImplementationOnce(() => new Promise((resolve) => {
+          resolveSecondRequest = resolve
+        }))
+
+      const callsBeforeSaves = fetchMock.mock.calls.length
+      const firstSave = setFavoriteModels(['gpt-5.4'])
+      const secondSave = setFavoriteModels(['gemini-2.5-flash'])
+
+      resolveSecondRequest({})
+      await secondSave
+
+      resolveFirstRequest({})
+      await firstSave
+
+      expect(favoriteModels.value).toEqual(['gemini-2.5-flash'])
+      expect(fetchMock.mock.calls.length - callsBeforeSaves).toBe(2)
+    })
+
+  it(
+    'filters stale favorite ids from the derived list but keeps them '
+    + 'in what gets persisted',
+    async () => {
+      fetchMock.mockReset()
+        .mockResolvedValueOnce({
+          reasoningExpanded: false,
+          reasoningAutoHide: true,
+          favoriteModels: ['gpt-5.4', 'legacy-model-removed'],
+        })
+      const {
+        syncForUser,
+        favoriteModels,
+        toggleFavoriteModel,
+      } = useUserSetting()
+
+      await syncForUser('user-1')
+
+      expect(favoriteModels.value).toEqual(['gpt-5.4'])
+
+      fetchMock.mockResolvedValueOnce({
+        favoriteModels: [
+          'gpt-5.4',
+          'legacy-model-removed',
+          'gemini-2.5-flash',
+        ],
+      })
+
+      await toggleFavoriteModel('gemini-2.5-flash')
+
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        '/api/v1/profiles/settings',
+        {
+          method: 'PATCH',
+          body: {
+            favoriteModels: [
+              'gpt-5.4',
+              'legacy-model-removed',
+              'gemini-2.5-flash',
+            ],
+          },
+        },
+      )
+      expect(favoriteModels.value).toEqual(['gpt-5.4', 'gemini-2.5-flash'])
+    },
+  )
 })

--- a/tests/unit/providers/merge.spec.ts
+++ b/tests/unit/providers/merge.spec.ts
@@ -1,0 +1,374 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  CuratedModel,
+  ModelSnapshotEntry,
+} from '../../../providers/merge'
+import { formatPrice, mergeModelMetadata } from '../../../providers/merge'
+import { providers } from '../../../providers'
+import snapshot from '../../../providers/data/models-dev-snapshot.json'
+import { getModelCostMap } from '../../../server/utils/ai/cost-map'
+
+const snapshotEntry: ModelSnapshotEntry = {
+  name: 'Fetched Name',
+  description: 'Fetched description',
+  limit: {
+    context: 400_000,
+    output: 128_000,
+  },
+  modalities: {
+    input: ['text', 'image', 'pdf'],
+    output: ['text'],
+  },
+  cost: {
+    input: 1.25,
+    output: 10,
+  },
+}
+
+const chatModel: CuratedModel = {
+  id: 'test-chat-model',
+  price: {
+    tokens: 1_000_000,
+  },
+  tools: ['web_search'],
+  reasoning: {
+    mode: 'levels',
+    levels: ['low', 'high'],
+  },
+}
+
+describe('mergeModelMetadata', () => {
+  it('takes objective metadata from the snapshot', () => {
+    const model = mergeModelMetadata(chatModel, snapshotEntry)
+
+    expect(model.name).toBe('Fetched Name')
+    expect(model.description).toBe('Fetched description')
+    expect(model.contextLength).toBe(400_000)
+    expect(model.maxOutputTokens).toBe(128_000)
+    expect(model.modalities).toEqual(snapshotEntry.modalities)
+    expect(model.price.input).toBe('$1.25')
+    expect(model.price.output).toBe('$10.00')
+  })
+
+  it('takes the release date from the snapshot', () => {
+    const model = mergeModelMetadata(chatModel, {
+      ...snapshotEntry,
+      releaseDate: '2026-04-21',
+    })
+
+    expect(model.releaseDate).toBe('2026-04-21')
+  })
+
+  it('omits the release date key when the snapshot has none', () => {
+    const model = mergeModelMetadata(chatModel, snapshotEntry)
+
+    expect('releaseDate' in model).toBe(false)
+  })
+
+  it('keeps curated capabilities and the price token divisor', () => {
+    const model = mergeModelMetadata(
+      {
+        ...chatModel,
+        default: true,
+        forProjectMemory: true,
+      },
+      snapshotEntry,
+    )
+
+    expect(model.tools).toEqual(['web_search'])
+    expect(model.reasoning).toEqual({ mode: 'levels', levels: ['low', 'high'] })
+    expect(model.default).toBe(true)
+    expect(model.forProjectMemory).toBe(true)
+    expect(model.price.tokens).toBe(1_000_000)
+  })
+
+  it('keeps curated name, description and price for research models', () => {
+    const model = mergeModelMetadata(
+      {
+        ...chatModel,
+        name: 'Curated Deep Research',
+        description: 'Cited report for $1–3 per task',
+        price: {
+          tokens: 1_000_000,
+          input: '$1–3 / task',
+          output: '',
+        },
+        research: {
+          tier: 'quick',
+          assistModel: 'test-chat-model',
+          costEstimate: '$1–3 / task',
+          timeEstimate: 'under 20 min',
+        },
+      },
+      snapshotEntry,
+    )
+
+    expect(model.name).toBe('Curated Deep Research')
+    expect(model.description).toBe('Cited report for $1–3 per task')
+    expect(model.price.input).toBe('$1–3 / task')
+    expect(model.price.output).toBe('')
+    expect(model.contextLength).toBe(400_000)
+  })
+
+  it('keeps the curated name when the fetched one is the bare model id', () => {
+    const model = mergeModelMetadata(
+      {
+        ...chatModel,
+        name: 'Test Chat Model',
+      },
+      {
+        ...snapshotEntry,
+        name: 'Test-Chat-Model',
+      },
+    )
+
+    expect(model.name).toBe('Test Chat Model')
+    expect(model.description).toBe('Fetched description')
+  })
+
+  it('keeps the curated per-image price display', () => {
+    const model = mergeModelMetadata(
+      {
+        ...chatModel,
+        price: {
+          tokens: 1,
+          display: '$0.039 / 1K image, plus input',
+        },
+        imageGeneration: {
+          controllerModel: 'test-chat-model',
+        },
+      },
+      snapshotEntry,
+    )
+
+    expect(model.price.display).toBe('$0.039 / 1K image, plus input')
+    expect(model.price.tokens).toBe(1)
+    expect(model.price.input).toBe('$1.25')
+  })
+
+  it('marks context-tiered pricing so the number reads as a floor', () => {
+    const model = mergeModelMetadata(chatModel, {
+      ...snapshotEntry,
+      tieredPricing: true,
+    })
+
+    expect(model.price.input).toBe('from $1.25')
+    expect(model.price.output).toBe('from $10.00')
+  })
+
+  it('falls back to a fully curated model without a snapshot entry', () => {
+    const model = mergeModelMetadata(
+      {
+        ...chatModel,
+        name: 'Curated Only',
+        description: 'Not tracked by models.dev',
+        contextLength: 200_000,
+        maxOutputTokens: 100_000,
+        price: {
+          tokens: 1_000_000,
+          input: '$10.00',
+          output: '$40.00',
+        },
+        modalities: {
+          input: ['text'],
+          output: ['text'],
+        },
+      },
+      undefined,
+    )
+
+    expect(model.name).toBe('Curated Only')
+    expect(model.contextLength).toBe(200_000)
+    expect(model.price.input).toBe('$10.00')
+    expect('releaseDate' in model).toBe(false)
+  })
+
+  it('throws when a model has neither a snapshot entry nor full curation', () => {
+    expect(() => mergeModelMetadata(chatModel, undefined))
+      .toThrowError(/test-chat-model/)
+  })
+})
+
+describe('price tiers', () => {
+  it.each([
+    [0.05, '$'],
+    [0.5, '$'],
+    [0.75, '$$'],
+    [2, '$$'],
+    [2.5, '$$$'],
+    [5, '$$$'],
+    [12, '$$$+'],
+  ])('maps $%s per million input tokens to %s', (input, tier) => {
+    const model = mergeModelMetadata(chatModel, {
+      ...snapshotEntry,
+      cost: {
+        input,
+        output: input * 4,
+      },
+    })
+
+    expect(model.priceTier).toBe(tier)
+  })
+
+  it.each([
+    ['~$1 / task', '$$'],
+    ['$1–3 / task', '$$$'],
+    ['$3–7 / task', '$$$'],
+    ['~$10 / task', '$$$+'],
+  ])('maps the %s research estimate to %s', (costEstimate, tier) => {
+    const model = mergeModelMetadata(
+      {
+        ...chatModel,
+        research: {
+          tier: 'quick',
+          assistModel: 'test-chat-model',
+          costEstimate,
+          timeEstimate: 'under 20 min',
+        },
+      },
+      snapshotEntry,
+    )
+
+    expect(model.priceTier).toBe(tier)
+  })
+
+  it.each([
+    ['$0.0336 / 1K image, plus input', '$'],
+    ['$0.039 / 1K image, plus input', '$'],
+    ['$0.041–$0.053 / medium image, plus input', '$$'],
+    ['$0.067 / 1K image, plus input', '$$'],
+    ['$0.134 / 1K or 2K image, plus input', '$$$'],
+  ])(
+    'maps the per-image price display %s to %s regardless of per-token cost',
+    (display, tier) => {
+      const model = mergeModelMetadata(
+        {
+          ...chatModel,
+          price: {
+            tokens: 1,
+            display,
+          },
+          imageGeneration: {
+            controllerModel: 'test-chat-model',
+          },
+        },
+        {
+          ...snapshotEntry,
+          cost: {
+            input: 5,
+            output: 30,
+          },
+        },
+      )
+
+      expect(model.priceTier).toBe(tier)
+    },
+  )
+
+  it('ranks gpt-image-2 cheaper than Nano Banana Pro by per-image price', () => {
+    const gptImage2 = mergeModelMetadata(
+      {
+        ...chatModel,
+        price: {
+          tokens: 1,
+          display: '$0.041–$0.053 / medium image, plus input',
+        },
+        imageGeneration: {
+          controllerModel: 'test-chat-model',
+        },
+      },
+      {
+        ...snapshotEntry,
+        cost: {
+          input: 5,
+          output: 30,
+        },
+      },
+    )
+    const nanoBananaPro = mergeModelMetadata(
+      {
+        ...chatModel,
+        price: {
+          tokens: 1,
+          display: '$0.134 / 1K or 2K image, plus input',
+        },
+        imageGeneration: {
+          controllerModel: 'test-chat-model',
+        },
+      },
+      {
+        ...snapshotEntry,
+        cost: {
+          input: 2,
+          output: 120,
+        },
+      },
+    )
+
+    expect(gptImage2.priceTier).toBe('$$')
+    expect(nanoBananaPro.priceTier).toBe('$$$')
+  })
+})
+
+describe('formatPrice', () => {
+  it('keeps sub-cent precision instead of rounding to two decimals', () => {
+    expect(formatPrice(0.075)).toBe('$0.075')
+    expect(formatPrice(0.005)).toBe('$0.005')
+    expect(formatPrice(0.3)).toBe('$0.30')
+    expect(formatPrice(12)).toBe('$12.00')
+  })
+})
+
+describe('merged catalog', () => {
+  const snapshotEntries: Record<string, { input: number, output: number }>
+    = Object.fromEntries(
+      Object.entries(snapshot).map(([id, entry]) => {
+        return [id, entry.cost]
+      }),
+    )
+
+  it('bills every per-token model at its exact fetched cost', () => {
+    const costMap = getModelCostMap()
+
+    for (const provider of providers) {
+      for (const model of provider.models) {
+        const cost = snapshotEntries[model.id]
+
+        if (!cost || model.research || model.price.tokens !== 1_000_000) {
+          continue
+        }
+
+        expect(costMap[model.id]).toEqual(cost)
+      }
+    }
+  })
+
+  it('carries a release date exactly for snapshot-backed models', () => {
+    for (const provider of providers) {
+      for (const model of provider.models) {
+        const entry = snapshot[model.id as keyof typeof snapshot]
+
+        if (!entry) {
+          expect('releaseDate' in model).toBe(false)
+
+          continue
+        }
+
+        expect(model.releaseDate).toBe(entry.releaseDate)
+        expect(model.releaseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      }
+    }
+  })
+
+  it('gives every model a complete, displayable shape', () => {
+    for (const provider of providers) {
+      for (const model of provider.models) {
+        expect(model.name).toBeTruthy()
+        expect(model.description).toBeTruthy()
+        expect(model.priceTier).toMatch(/^\$+\+?$/)
+        expect(model.modalities.input.length).toBeGreaterThan(0)
+        expect(model.modalities.output.length).toBeGreaterThan(0)
+      }
+    }
+  })
+})

--- a/tests/unit/scripts/audit-curated-models.spec.ts
+++ b/tests/unit/scripts/audit-curated-models.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findDeprecatedCuratedModels,
+  findUncuratedModels,
+  formatDeprecatedCuratedModelsWarning,
+  formatUncuratedModelsReport,
+} from '../../../scripts/audit-curated-models.mjs'
+
+describe('findUncuratedModels', () => {
+  it('excludes curated ids and keeps the rest', () => {
+    const remoteModels = {
+      'gpt-5.6': { name: 'GPT-5.6', release_date: '2026-07-09' },
+      'gpt-5.6-sol': { name: 'GPT-5.6 Sol', release_date: '2026-07-09' },
+      'gpt-4o': { name: 'GPT-4o', release_date: '2024-05-13' },
+    }
+    const curatedIds = new Set(['gpt-5.6'])
+
+    const uncurated = findUncuratedModels(remoteModels, curatedIds)
+
+    expect(uncurated.map(model => model.id)).toEqual([
+      'gpt-5.6-sol',
+      'gpt-4o',
+    ])
+  })
+
+  it('sorts newest release date first', () => {
+    const remoteModels = {
+      old: { name: 'Old', release_date: '2023-01-01' },
+      new: { name: 'New', release_date: '2026-01-01' },
+      mid: { name: 'Mid', release_date: '2025-01-01' },
+    }
+
+    const uncurated = findUncuratedModels(remoteModels, new Set())
+
+    expect(uncurated.map(model => model.id)).toEqual(['new', 'mid', 'old'])
+  })
+
+  it('sorts entries without a release date last', () => {
+    const remoteModels = {
+      dated: { name: 'Dated', release_date: '2025-01-01' },
+      undated: { name: 'Undated' },
+    }
+
+    const uncurated = findUncuratedModels(remoteModels, new Set())
+
+    expect(uncurated.map(model => model.id)).toEqual(['dated', 'undated'])
+  })
+
+  it('returns an empty list when everything is curated', () => {
+    const remoteModels = {
+      'gpt-5.6': { name: 'GPT-5.6', release_date: '2026-07-09' },
+    }
+    const curatedIds = new Set(['gpt-5.6'])
+
+    const uncurated = findUncuratedModels(remoteModels, curatedIds)
+
+    expect(uncurated).toEqual([])
+  })
+})
+
+describe('formatUncuratedModelsReport', () => {
+  it('groups the report by provider with counts and release dates', () => {
+    const report = formatUncuratedModelsReport([
+      {
+        providerId: 'openai',
+        models: [
+          { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', releaseDate: '2026-07-09' },
+        ],
+      },
+      {
+        providerId: 'google',
+        models: [],
+      },
+    ])
+
+    expect(report).toContain('openai (1 not curated):')
+    expect(report).toContain(
+      '    - gpt-5.6-sol (GPT-5.6 Sol, released 2026-07-09)',
+    )
+    expect(report).toContain('google (0 not curated):')
+  })
+})
+
+describe('findDeprecatedCuratedModels', () => {
+  it('flags a curated id whose upstream status is deprecated', () => {
+    const remoteModels = {
+      'gemini-3.1-flash-lite-preview': {
+        name: 'Gemini 3.1 Flash Lite Preview',
+        status: 'deprecated',
+      },
+      'gemini-3.1-pro-preview': {
+        name: 'Gemini 3.1 Pro Preview',
+      },
+    }
+    const curatedIds = new Set([
+      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-pro-preview',
+    ])
+
+    const deprecated = findDeprecatedCuratedModels(remoteModels, curatedIds)
+
+    expect(deprecated).toEqual([
+      {
+        id: 'gemini-3.1-flash-lite-preview',
+        name: 'Gemini 3.1 Flash Lite Preview',
+      },
+    ])
+  })
+
+  it('ignores a deprecated model that is not curated', () => {
+    const remoteModels = {
+      'gpt-4': { name: 'GPT-4', status: 'deprecated' },
+    }
+
+    const deprecated = findDeprecatedCuratedModels(remoteModels, new Set())
+
+    expect(deprecated).toEqual([])
+  })
+
+  it('ignores non-deprecated statuses', () => {
+    const remoteModels = {
+      'veo-3.1-generate-preview': { name: 'Veo 3.1', status: 'beta' },
+    }
+    const curatedIds = new Set(['veo-3.1-generate-preview'])
+
+    const deprecated = findDeprecatedCuratedModels(remoteModels, curatedIds)
+
+    expect(deprecated).toEqual([])
+  })
+})
+
+describe('formatDeprecatedCuratedModelsWarning', () => {
+  it('returns null when nothing is deprecated', () => {
+    const warning = formatDeprecatedCuratedModelsWarning([
+      { providerId: 'openai', models: [] },
+      { providerId: 'google', models: [] },
+    ])
+
+    expect(warning).toBeNull()
+  })
+
+  it('formats a distinct warning grouped by provider/id', () => {
+    const warning = formatDeprecatedCuratedModelsWarning([
+      {
+        providerId: 'google',
+        models: [{
+          id: 'gemini-3.1-flash-lite-preview',
+          name: 'Gemini 3.1 Flash Lite Preview',
+        }],
+      },
+    ])
+
+    expect(warning).toContain('⚠ DEPRECATED')
+    expect(warning).toContain(
+      '  - google/gemini-3.1-flash-lite-preview '
+      + '(Gemini 3.1 Flash Lite Preview)',
+    )
+  })
+})

--- a/tests/unit/utils/chats/provider.spec.ts
+++ b/tests/unit/utils/chats/provider.spec.ts
@@ -1,0 +1,152 @@
+import type { Model, Provider } from '#shared/types/providers.d'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getModel: vi.fn(),
+}))
+
+vi.mock('#shared/utils/model', () => ({
+  getModel: mocks.getModel,
+}))
+
+async function importProvider() {
+  return import('../../../../server/utils/chats/provider')
+}
+
+function createModel(overrides: Partial<Model> = {}): Model {
+  return {
+    id: 'gpt-5-mini',
+    name: 'GPT-5 mini',
+    description: 'Fast general-purpose model',
+    contextLength: 128_000,
+    maxOutputTokens: 16_000,
+    price: {
+      tokens: 1_000_000,
+      input: '0.15',
+      output: '0.6',
+    },
+    priceTier: '$',
+    modalities: {
+      input: ['text'],
+      output: ['text'],
+    },
+    tools: [],
+    ...overrides,
+  }
+}
+
+function createProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    id: 'openai',
+    name: 'OpenAI',
+    models: [],
+    ...overrides,
+  }
+}
+
+describe('useChatProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects an empty model id without resolving the catalog', async () => {
+    const { useChatProvider } = await importProvider()
+
+    expect(() => useChatProvider('')).toThrow(
+      'Please select a model to continue.',
+    )
+    expect(mocks.getModel).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown model id with the existing 400', async () => {
+    mocks.getModel.mockReturnValue({
+      model: null,
+      provider: null,
+      modelName: 'Select Model',
+    })
+
+    const { useChatProvider } = await importProvider()
+
+    let caughtError: any
+
+    try {
+      useChatProvider('not-a-real-model')
+    } catch (exception) {
+      caughtError = exception
+    }
+
+    expect(caughtError.statusCode).toBe(400)
+    expect(caughtError.statusMessage).toBe(
+      'Current model is not supported by any provider. Please select a'
+      + ' different model.',
+    )
+  })
+
+  it('rejects a deprecated model with a structured 400', async () => {
+    const deprecatedModel = createModel({
+      id: 'gemini-3-pro-preview',
+      name: 'Gemini 3 Pro Preview',
+      status: 'deprecated',
+    })
+    const provider = createProvider({ id: 'google', name: 'Google' })
+
+    mocks.getModel.mockReturnValue({
+      model: deprecatedModel,
+      provider,
+      modelName: deprecatedModel.name,
+    })
+
+    const { useChatProvider } = await importProvider()
+
+    let caughtError: any
+
+    try {
+      useChatProvider('gemini-3-pro-preview')
+    } catch (exception) {
+      caughtError = exception
+    }
+
+    expect(caughtError.status).toBe(400)
+    expect(caughtError.message).toBe('This model is no longer available.')
+    expect(caughtError.why).toContain('Gemini 3 Pro Preview')
+    expect(caughtError.fix).toBe('Choose a different model from the picker.')
+  })
+
+  it('resolves a non-deprecated model normally', async () => {
+    const model = createModel()
+    const provider = createProvider()
+
+    mocks.getModel.mockReturnValue({
+      model,
+      provider,
+      modelName: model.name,
+    })
+
+    const { useChatProvider } = await importProvider()
+
+    const result = useChatProvider('gpt-5-mini')
+
+    expect(result.model).toBe(model)
+    expect(result.provider).toBe(provider)
+    expect(result.modelName).toBe(model.name)
+    expect(mocks.getModel).toHaveBeenCalledWith('gpt-5-mini')
+  })
+
+  it('does not reject models carrying a non-deprecated status', async () => {
+    const betaModel = createModel({
+      id: 'gemini-3.6-flash',
+      name: 'Gemini 3.6 Flash',
+      status: 'beta',
+    })
+
+    mocks.getModel.mockReturnValue({
+      model: betaModel,
+      provider: createProvider({ id: 'google', name: 'Google' }),
+      modelName: betaModel.name,
+    })
+
+    const { useChatProvider } = await importProvider()
+
+    expect(() => useChatProvider('gemini-3.6-flash')).not.toThrow()
+  })
+})

--- a/tests/unit/utils/model.spec.ts
+++ b/tests/unit/utils/model.spec.ts
@@ -2,6 +2,7 @@ import type { Model } from '#shared/types/providers.d'
 import { describe, expect, it } from 'vitest'
 import google from '../../../providers/google'
 import openai from '../../../providers/openai'
+import { providers } from '../../../providers'
 import {
   getControllerModelId,
   getImageGenerationModelId,
@@ -17,15 +18,16 @@ const googleImageModelIds = [
 ]
 
 function getConfiguredModel(modelId: string): Model {
-  const model = [...openai.models, ...google.models].find((candidate) => {
-    return candidate.id === modelId
-  })
+  const model = providers.flatMap(provider => provider.models)
+    .find((candidate) => {
+      return candidate.id === modelId
+    })
 
   if (!model) {
     throw new Error(`Missing model ${modelId}`)
   }
 
-  return model as Model
+  return model
 }
 
 describe('image generation models', () => {

--- a/tests/unit/utils/models-picker.spec.ts
+++ b/tests/unit/utils/models-picker.spec.ts
@@ -107,16 +107,16 @@ describe('hasImageGenerationCapability', () => {
 })
 
 describe('getPriceTierClass', () => {
-  it('maps every price tier to an increasingly opaque badge', () => {
-    expect(getPriceTierClass('$')).toBe('badge-ghost text-base-content/50')
-    expect(getPriceTierClass('$$')).toBe('badge-ghost text-base-content/65')
-    expect(getPriceTierClass('$$$')).toBe('badge-ghost text-base-content/80')
-    expect(getPriceTierClass('$$$+')).toBe('badge-ghost text-base-content/95')
+  it('maps every price tier to a semantic badge color', () => {
+    expect(getPriceTierClass('$')).toBe('badge-success')
+    expect(getPriceTierClass('$$')).toBe('badge-info')
+    expect(getPriceTierClass('$$$')).toBe('badge-warning')
+    expect(getPriceTierClass('$$$+')).toBe('badge-error')
   })
 
   it('falls back to the cheapest badge for an unmapped tier', () => {
     expect(getPriceTierClass('$$$$' as ModelPriceTier))
-      .toBe('badge-ghost text-base-content/50')
+      .toBe('badge-success')
   })
 })
 

--- a/tests/unit/utils/models-picker.spec.ts
+++ b/tests/unit/utils/models-picker.spec.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest'
+import type { Model, ModelPriceTier } from '#shared/types/providers.d'
+import {
+  formatModelTokenLimit,
+  formatReleaseDate,
+  getModelCategory,
+  getModelPriceTip,
+  getPriceTierClass,
+  hasImageGenerationCapability,
+  modelCategoryOptions,
+} from '../../../app/utils/models-picker'
+
+function createModel(overrides: Partial<Model> = {}): Model {
+  return {
+    id: 'gpt-5.4',
+    name: 'GPT-5.4',
+    description: 'Flagship chat model',
+    contextLength: 400_000,
+    maxOutputTokens: 128_000,
+    price: {
+      tokens: 1_000_000,
+      input: 'from $2.50',
+      output: 'from $15.00',
+    },
+    priceTier: '$$',
+    modalities: {
+      input: ['text', 'image'],
+      output: ['text'],
+    },
+    tools: ['web_search'],
+    ...overrides,
+  }
+}
+
+const research = {
+  tier: 'quick',
+  assistModel: 'gpt-5.4-nano',
+  costEstimate: '~$1 / task',
+  timeEstimate: '5–15 min',
+} as const
+
+describe('getModelCategory', () => {
+  it('categorises a plain chat model as chat', () => {
+    expect(getModelCategory(createModel())).toBe('chat')
+  })
+
+  it('categorises a research model as research', () => {
+    const model = createModel({ research })
+
+    expect(getModelCategory(model)).toBe('research')
+  })
+
+  it('categorises a model with the imageGeneration field as image generation', () => {
+    const model = createModel({
+      tools: [],
+      imageGeneration: { controllerModel: 'gpt-5-nano' },
+    })
+
+    expect(getModelCategory(model)).toBe('image-generation')
+  })
+
+  it('keeps a chat model that merely offers the image_generation tool in chat', () => {
+    const model = createModel({ tools: ['image_generation'] })
+
+    expect(getModelCategory(model)).toBe('chat')
+    expect(hasImageGenerationCapability(model)).toBe(true)
+  })
+
+  it('prefers research over image generation when both are set', () => {
+    const model = createModel({
+      research,
+      imageGeneration: { controllerModel: 'gpt-5-nano' },
+    })
+
+    expect(getModelCategory(model)).toBe('research')
+  })
+})
+
+describe('hasImageGenerationCapability', () => {
+  it('is true for a chat model that exposes the image_generation tool', () => {
+    const model = createModel({ tools: ['image_generation'] })
+
+    expect(hasImageGenerationCapability(model)).toBe(true)
+  })
+
+  it('is true for a purpose-built image model without the tool', () => {
+    const model = createModel({
+      tools: [],
+      imageGeneration: { controllerModel: 'gemini-2.5-flash-lite' },
+    })
+
+    expect(hasImageGenerationCapability(model)).toBe(true)
+  })
+
+  it('is true when the tool and the imageGeneration field are both set', () => {
+    const model = createModel({
+      tools: ['image_generation'],
+      imageGeneration: { controllerModel: 'gemini-2.5-flash-lite' },
+    })
+
+    expect(hasImageGenerationCapability(model)).toBe(true)
+  })
+
+  it('is false when neither the tool nor the field is present', () => {
+    expect(hasImageGenerationCapability(createModel())).toBe(false)
+  })
+})
+
+describe('getPriceTierClass', () => {
+  it('maps every price tier to an increasingly opaque badge', () => {
+    expect(getPriceTierClass('$')).toBe('badge-ghost text-base-content/50')
+    expect(getPriceTierClass('$$')).toBe('badge-ghost text-base-content/65')
+    expect(getPriceTierClass('$$$')).toBe('badge-ghost text-base-content/80')
+    expect(getPriceTierClass('$$$+')).toBe('badge-ghost text-base-content/95')
+  })
+
+  it('falls back to the cheapest badge for an unmapped tier', () => {
+    expect(getPriceTierClass('$$$$' as ModelPriceTier))
+      .toBe('badge-ghost text-base-content/50')
+  })
+})
+
+describe('getModelPriceTip', () => {
+  it('joins the research cost and time estimates', () => {
+    const model = createModel({ research })
+
+    expect(getModelPriceTip(model)).toBe('~$1 / task · 5–15 min')
+  })
+
+  it('prefers the research estimate over a price display string', () => {
+    const model = createModel({
+      research,
+      price: { tokens: 1, input: '$1', output: '$2', display: '$3 / image' },
+    })
+
+    expect(getModelPriceTip(model)).toBe('~$1 / task · 5–15 min')
+  })
+
+  it('uses the price display string when there is one', () => {
+    const model = createModel({
+      price: {
+        tokens: 1,
+        input: '$0.30',
+        output: '$30.00',
+        display: '$0.039 / image',
+      },
+    })
+
+    expect(getModelPriceTip(model)).toBe('$0.039 / image')
+  })
+
+  it('joins input and output prices when both are set', () => {
+    expect(getModelPriceTip(createModel()))
+      .toBe('from $2.50 / from $15.00')
+  })
+
+  it('returns only the input price when there is no output price', () => {
+    const model = createModel({
+      price: { tokens: 1_000_000, input: '$0.10', output: '' },
+    })
+
+    expect(getModelPriceTip(model)).toBe('$0.10')
+  })
+
+  it('returns undefined when neither price is set', () => {
+    const model = createModel({
+      price: { tokens: 1_000_000, input: '', output: '' },
+    })
+
+    expect(getModelPriceTip(model)).toBeUndefined()
+  })
+})
+
+describe('formatModelTokenLimit', () => {
+  it('groups thousands and appends the unit', () => {
+    expect(formatModelTokenLimit(1_048_576)).toBe('1,048,576 tokens')
+    expect(formatModelTokenLimit(32_768)).toBe('32,768 tokens')
+    expect(formatModelTokenLimit(1)).toBe('1 tokens')
+  })
+
+  it('returns an empty string for a zero limit so callers drop the row', () => {
+    expect(formatModelTokenLimit(0)).toBe('')
+  })
+})
+
+describe('formatReleaseDate', () => {
+  it('formats an ISO date as a short month and year', () => {
+    expect(formatReleaseDate('2026-05-01')).toBe('May 2026')
+    expect(formatReleaseDate('2026-12-31')).toBe('Dec 2026')
+  })
+
+  it('keeps the first of the month in its own month across timezones', () => {
+    expect(formatReleaseDate('2026-01-01')).toBe('Jan 2026')
+  })
+
+  it('formats a year-month value without a day', () => {
+    expect(formatReleaseDate('2026-07')).toBe('Jul 2026')
+  })
+
+  it('returns the input unchanged when the month is out of range', () => {
+    expect(formatReleaseDate('2026-13-01')).toBe('2026-13-01')
+    expect(formatReleaseDate('2026-00-01')).toBe('2026-00-01')
+  })
+
+  it('returns the input unchanged when it is not a date', () => {
+    expect(formatReleaseDate('not-a-date')).toBe('not-a-date')
+    expect(formatReleaseDate('')).toBe('')
+  })
+})
+
+describe('modelCategoryOptions', () => {
+  it('lists chat, deep research and image generation in that order', () => {
+    expect(modelCategoryOptions).toEqual([
+      { value: 'chat', label: 'Chat', icon: 'lucide:message-square' },
+      { value: 'research', label: 'Deep research', icon: 'lucide:telescope' },
+      {
+        value: 'image-generation',
+        label: 'Image generation',
+        icon: 'lucide:image-plus',
+      },
+    ])
+  })
+
+  it('offers a filter option for every category getModelCategory returns', () => {
+    const categories = [
+      getModelCategory(createModel()),
+      getModelCategory(createModel({ research })),
+      getModelCategory(createModel({
+        imageGeneration: { controllerModel: 'gpt-5-nano' },
+      })),
+    ]
+    const optionValues = modelCategoryOptions.map((option) => {
+      return option.value
+    })
+
+    for (const category of categories) {
+      expect(optionValues).toContain(category)
+    }
+  })
+})

--- a/tests/unit/utils/models-picker.spec.ts
+++ b/tests/unit/utils/models-picker.spec.ts
@@ -6,6 +6,7 @@ import {
   getModelCategory,
   getModelPriceTip,
   getPriceTierClass,
+  getPriceTierTooltipClass,
   hasImageGenerationCapability,
   modelCategoryOptions,
 } from '../../../app/utils/models-picker'
@@ -117,6 +118,32 @@ describe('getPriceTierClass', () => {
   it('falls back to the cheapest badge for an unmapped tier', () => {
     expect(getPriceTierClass('$$$$' as ModelPriceTier))
       .toBe('badge-success')
+  })
+})
+
+describe('getPriceTierTooltipClass', () => {
+  it('maps every price tier to a semantic tooltip color', () => {
+    expect(getPriceTierTooltipClass('$')).toBe('tooltip-success')
+    expect(getPriceTierTooltipClass('$$')).toBe('tooltip-info')
+    expect(getPriceTierTooltipClass('$$$')).toBe('tooltip-warning')
+    expect(getPriceTierTooltipClass('$$$+')).toBe('tooltip-error')
+  })
+
+  it('falls back to the cheapest tooltip color for an unmapped tier', () => {
+    expect(getPriceTierTooltipClass('$$$$' as ModelPriceTier))
+      .toBe('tooltip-success')
+  })
+
+  it('keeps the tooltip color in lockstep with the badge color', () => {
+    const tiers: ModelPriceTier[] = ['$', '$$', '$$$', '$$$+']
+
+    for (const tier of tiers) {
+      const badgeColor = getPriceTierClass(tier).replace('badge-', '')
+      const tooltipColor = getPriceTierTooltipClass(tier)
+        .replace('tooltip-', '')
+
+      expect(tooltipColor).toBe(badgeColor)
+    }
   })
 })
 

--- a/tests/unit/utils/models-picker.spec.ts
+++ b/tests/unit/utils/models-picker.spec.ts
@@ -6,7 +6,6 @@ import {
   getModelCategory,
   getModelPriceTip,
   getPriceTierClass,
-  getPriceTierTooltipClass,
   hasImageGenerationCapability,
   modelCategoryOptions,
 } from '../../../app/utils/models-picker'
@@ -118,32 +117,6 @@ describe('getPriceTierClass', () => {
   it('falls back to the cheapest badge for an unmapped tier', () => {
     expect(getPriceTierClass('$$$$' as ModelPriceTier))
       .toBe('badge-success')
-  })
-})
-
-describe('getPriceTierTooltipClass', () => {
-  it('maps every price tier to a semantic tooltip color', () => {
-    expect(getPriceTierTooltipClass('$')).toBe('tooltip-success')
-    expect(getPriceTierTooltipClass('$$')).toBe('tooltip-info')
-    expect(getPriceTierTooltipClass('$$$')).toBe('tooltip-warning')
-    expect(getPriceTierTooltipClass('$$$+')).toBe('tooltip-error')
-  })
-
-  it('falls back to the cheapest tooltip color for an unmapped tier', () => {
-    expect(getPriceTierTooltipClass('$$$$' as ModelPriceTier))
-      .toBe('tooltip-success')
-  })
-
-  it('keeps the tooltip color in lockstep with the badge color', () => {
-    const tiers: ModelPriceTier[] = ['$', '$$', '$$$', '$$$+']
-
-    for (const tier of tiers) {
-      const badgeColor = getPriceTierClass(tier).replace('badge-', '')
-      const tooltipColor = getPriceTierTooltipClass(tier)
-        .replace('tooltip-', '')
-
-      expect(tooltipColor).toBe(badgeColor)
-    }
   })
 })
 

--- a/tests/unit/utils/project-memory.spec.ts
+++ b/tests/unit/utils/project-memory.spec.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import googleProvider from '../../../providers/google'
-import openaiProvider from '../../../providers/openai'
+import { providers } from '../../../providers'
 
 const mocks = vi.hoisted(() => ({
   generateText: vi.fn(),
@@ -10,13 +9,16 @@ vi.mock('ai', () => ({
   generateText: mocks.generateText,
 }))
 
-const googleProjectMemoryModel = googleProvider.models.find((model) => {
-  return model.forProjectMemory
-})
+function findProjectMemoryModel(providerId: string) {
+  return providers.find((provider) => {
+    return provider.id === providerId
+  })?.models.find((model) => {
+    return model.forProjectMemory
+  })
+}
 
-const openAIProjectMemoryModel = openaiProvider.models.find((model) => {
-  return model.forProjectMemory
-})
+const googleProjectMemoryModel = findProjectMemoryModel('google')
+const openAIProjectMemoryModel = findProjectMemoryModel('openai')
 
 if (!googleProjectMemoryModel || !openAIProjectMemoryModel) {
   throw new Error('Project memory models must be configured in providers')


### PR DESCRIPTION
## Summary

- Replaces the simple provider-grouped dropdown model picker with a searchable one: a search field, a left provider-icon rail (favorites star + providers, click to filter), rows with a price-tier badge/favorite toggle/capability icons/description, a unified info detail panel, and a Chat/Deep Research/Image Generation filter dropdown. Popover is click-toggled (not hover) with a capped max-height and its own internal scroll, and uses a proper ARIA combobox/listbox pattern (keyboard nav, roving highlight) instead of `role="dialog"`.
- Model *metadata* (name, description, context length, max output tokens, modalities, price) is no longer hand-typed forever — it's fetched from [models.dev](https://models.dev) and merged at import time with a small curated file that only holds product decisions (which tools/reasoning/research a model supports). Model *capabilities* stay 100% curated since no external source can know Besidka's own integration decisions.
- Favorites are DB-persisted (`user_settings.favoriteModels`, additive migration) so they sync across devices, not localStorage-only.
- Side task: **Nano Banana / Nano Banana 2 / Nano Banana 2 Lite / Nano Banana Pro are a rename, not new models.** They're the four Gemini native image models that already existed in `providers/google.ts` (`gemini-2.5-flash-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`, `gemini-3-pro-image`) — confirmed via models.dev's own `name` field for each and now surfaced under their real branded names.

## Why a curated-id-driven join, not a generated `providers/*.ts`

The join only ever looks curated ids **up** in models.dev's catalog; it never iterates the remote catalog outward. That's why junk that also lives in models.dev's `google`/`openai` slices — open-weights Gemma models, embeddings, TTS, Veo (video), Lyria (music), live/realtime variants, `gpt-3.5-turbo`/`gpt-4` — can never reach this app no matter how large models.dev's catalog grows, regardless of BYOK provider. Curated `.ts` + generated `.json` snapshot (merged at import time) was chosen over generating `providers/*.ts` directly, because a generated `.ts` would destroy the curated/fetched separation and make the per-field merge policy unreviewable in diffs.

Two provider-native list-models endpoints (OpenAI, Google) were checked as an alternative/supplement and both require a real API key (verified empirically — 401/403 with none). No maintainer-side provider credential was added: this project is 100% BYOK with zero server-side provider keys today, the models.dev hard-fail on a retired model already catches what a live key-check would, and one key's entitlement can't prove availability for other users' keys anyway. Documented as an optional manual spot-check in `docs/models-data-fetching.md`, not a script dependency.

Full architecture, the merge policy table, and an owner action checklist are in `docs/models-data-fetching.md`.

## Process

Built and reviewed with a multi-phase agent pipeline: data-layer implementation → UI implementation → a 5-dimension review fan-out (design/UX, correctness, security, style, accessibility), each finding adversarially verified before fixing → two rounds of fixes → new test coverage for the 5 new subcomponents → full `pnpm run test:all`.

## Test plan

- [x] `pnpm run format` / `pnpm run typecheck` clean
- [x] Full unit suite: 1274/1274 passing
- [x] Full integration suite: 351/351 passing
- [x] Full e2e suite: 72/72 passing (including the image-generation flow through the new picker)
- [x] Verified the generated snapshot for real (ran the fetch script against the live models.dev API, not a mock)
- [x] Verified the additive DB migration contains only `ALTER TABLE ... ADD COLUMN`, no `DROP TABLE`