### PR TITLE
feat(providers): add Anthropic Claude as a third LLM provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"bench:files-index": "node scripts/bench/files-user-id-index.mjs"
 	},
 	"dependencies": {
+		"@ai-sdk/anthropic": "^4.0.27",
 		"@ai-sdk/google": "^4.0.24",
 		"@ai-sdk/openai": "^4.0.20",
 		"@ai-sdk/provider": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^4.0.27
+        version: 4.0.27(zod@4.4.3)
       '@ai-sdk/google':
         specifier: ^4.0.24
         version: 4.0.24(zod@4.4.3)
@@ -299,6 +302,12 @@ importers:
 
 packages:
 
+  '@ai-sdk/anthropic@4.0.27':
+    resolution: {integrity: sha512-ecrPWkYf+sHDLHErHAU/yjJfNevUzT0i6TuoQLb58oadnquSHcLQ5NMLLWjbr6d1rxYdzI7ftulIJ03VH9yM3w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.155':
     resolution: {integrity: sha512-gP2i/z8gYqJNONZgUkfSe0u9iEvz+HJ/r+MKxmnJjSluPD9K9wwTs65KYyFl7pX8AEujnPny4Lq4l1ytPQD5TA==}
     engines: {node: '>=18'}
@@ -335,12 +344,22 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.18':
+    resolution: {integrity: sha512-UBNCrkxS5llgN2/RXLBRkjCFTIuL6YB1Goq5c+yRecnznhtX4XPjTwLHz2hrsTltTVZ0rqVegtnwFXdPBkjDHA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.14':
     resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@4.0.3':
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
     engines: {node: '>=22'}
 
   '@ai-sdk/vue@3.0.233':
@@ -9437,6 +9456,12 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/gateway@3.0.155(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
@@ -9478,11 +9503,24 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@5.0.18(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.28.0
+      zod: 4.4.3
+
   '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.4':
     dependencies:
       json-schema: 0.4.0
 

--- a/providers/anthropic.ts
+++ b/providers/anthropic.ts
@@ -28,6 +28,7 @@ export default {
     },
     {
       id: 'claude-haiku-4-5',
+      name: 'Claude Haiku 4.5',
       price: {
         tokens: 1_000_000,
       },

--- a/providers/anthropic.ts
+++ b/providers/anthropic.ts
@@ -1,23 +1,41 @@
+import type { CuratedProvider } from './merge'
+
 export default {
   id: 'anthropic',
   name: 'Anthropic',
   models: [
     {
-      id: 'claude-3-haiku-latest',
-      name: 'Claude Haiku 3',
-      description: 'The fastest model. Intelligence at blazing speeds.',
-      contextLength: 200_000,
-      maxOutputTokens: 8_192,
+      id: 'claude-opus-5',
       price: {
         tokens: 1_000_000,
-        input: '$0.25',
-        output: '$1.25',
-      },
-      modalities: {
-        input: ['text', 'image', 'video', 'audio'],
-        output: ['text'],
       },
       tools: ['web_search'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
+      id: 'claude-sonnet-5',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
+      id: 'claude-haiku-4-5',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
     },
   ],
-}
+} satisfies CuratedProvider

--- a/providers/data/models-dev-snapshot.json
+++ b/providers/data/models-dev-snapshot.json
@@ -1,4 +1,73 @@
 {
+  "claude-opus-5": {
+    "name": "Claude Opus 5",
+    "description": "Strongest Claude Opus model for coding, agents, and professional work",
+    "releaseDate": "2026-07-24",
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 25
+    }
+  },
+  "claude-sonnet-5": {
+    "name": "Claude Sonnet 5",
+    "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+    "releaseDate": "2026-06-29",
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 2,
+      "output": 10
+    }
+  },
+  "claude-haiku-4-5": {
+    "name": "Claude Haiku 4.5 (latest)",
+    "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
+    "releaseDate": "2025-10-15",
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 1,
+      "output": 5
+    }
+  },
   "deep-research-max-preview-04-2026": {
     "name": "Deep Research Max Preview (Apr-21-2026)",
     "description": "Maximum-comprehensiveness agentic researcher for multi-step investigation, synthesis, and cited reports",

--- a/providers/index.ts
+++ b/providers/index.ts
@@ -2,13 +2,12 @@ import type { Providers } from '../shared/types/providers.d'
 import type { ModelSnapshot } from './merge'
 import snapshot from './data/models-dev-snapshot.json'
 import { mergeProvider } from './merge'
-// import anthropic from './anthropic'
+import anthropic from './anthropic'
 import google from './google'
 import openai from './openai'
 
 const curatedProviders = [
-  // @TODO Anthropic is under development yet
-  // anthropic,
+  anthropic,
   google,
   openai,
 ]

--- a/providers/merge.ts
+++ b/providers/merge.ts
@@ -126,15 +126,6 @@ export function formatPrice(amount: number, tiered?: boolean): string {
   return tiered ? `from $${formatted}` : `$${formatted}`
 }
 
-/**
- * models.dev falls back to the bare model id when a provider publishes no
- * marketing name (`gpt-image-2`). Such an entry is worse than the curated
- * name, so it never wins the merge.
- */
-function isPlaceholderName(name: string, modelId: string): boolean {
-  return name.toLowerCase() === modelId.toLowerCase()
-}
-
 function resolvePriceTier(
   curated: CuratedModel,
   snapshot: ModelSnapshotEntry | undefined,
@@ -253,7 +244,10 @@ function toFullyCuratedModel(curated: CuratedModel): Model {
  * for research-agent models, whose name, description and price deliberately
  * encode per-task billing that no per-token figure can express. Everything
  * objective — specs, modalities, release date, status, per-token cost —
- * comes from the snapshot.
+ * comes from the snapshot, unless a curated `name` is explicitly set, which
+ * always wins: it means models.dev's name is worse than the curated one
+ * (a placeholder equal to the bare id, a stale alias suffix like
+ * `(latest)`), not that the model itself is curated content.
  * A model with no snapshot entry is fully curated by necessity; see
  * `EXEMPT_IDS` in `scripts/fetch-models-metadata.mjs`.
  */
@@ -266,12 +260,10 @@ export function mergeModelMetadata(
   }
 
   const keepCuratedPrice = !!curated.research
-  const keepCuratedName = !!curated.research
-    || isPlaceholderName(snapshot.name, curated.id)
 
   return {
     id: curated.id,
-    name: keepCuratedName ? curated.name ?? snapshot.name : snapshot.name,
+    name: curated.name ?? snapshot.name,
     description: curated.research
       ? curated.description ?? snapshot.description
       : snapshot.description,

--- a/scripts/fetch-models-metadata.mjs
+++ b/scripts/fetch-models-metadata.mjs
@@ -6,8 +6,8 @@
  * date, context and output limits, modalities and per-million-token cost.
  * The curated
  * half — which tools, reasoning, research and image-generation capabilities
- * a model is offered with — stays hand-written in providers/google.ts and
- * providers/openai.ts and is never touched here.
+ * a model is offered with — stays hand-written in providers/anthropic.ts,
+ * providers/google.ts and providers/openai.ts and is never touched here.
  *
  * The join only ever looks curated ids UP in models.dev; it never iterates
  * the remote catalog outward, so embedding, video, music, TTS and realtime
@@ -35,6 +35,7 @@ import {
   formatDeprecatedCuratedModelsWarning,
   formatUncuratedModelsReport,
 } from './audit-curated-models.mjs'
+import anthropic from '../providers/anthropic.ts'
 import google from '../providers/google.ts'
 import openai from '../providers/openai.ts'
 
@@ -51,7 +52,7 @@ const EXEMPT_IDS = ['o3-deep-research', 'o4-mini-deep-research']
 
 const KNOWN_MODEL_STATUSES = ['deprecated', 'beta', 'alpha']
 
-const curatedProviders = [google, openai]
+const curatedProviders = [anthropic, google, openai]
 
 const catalog = await fetchCatalog()
 const snapshot = {}

--- a/server/api/v1/chats/[slug]/index.post.ts
+++ b/server/api/v1/chats/[slug]/index.post.ts
@@ -480,6 +480,28 @@ export default defineEventHandler(async (event) => {
 
         break
       }
+      case 'anthropic': {
+        const {
+          instance: anthropicInstance,
+          tools: anthropicTools,
+          providerOptions: anthropicProviderOptions,
+          reasoning: anthropicReasoning,
+        } = await useAnthropic(
+          session.user.id,
+          model.id,
+          requestedTools,
+          body.data.reasoning,
+        )
+
+        instance = anthropicInstance
+        parsedTools = anthropicTools
+        reasoningEffort = anthropicReasoning
+        Object.assign(providerOptions, {
+          anthropic: anthropicProviderOptions,
+        })
+
+        break
+      }
       case 'google': {
         const {
           instance: googleInstance,
@@ -1039,7 +1061,7 @@ async function persistAssistantMessageFromStream(input: {
   db: ReturnType<typeof useDb>
   event: H3Event
   providerId: string
-  supportedProviderId: 'openai' | 'google' | undefined
+  supportedProviderId: 'openai' | 'google' | 'anthropic' | undefined
   userId: number
   chatId: string
   projectId: string | null
@@ -1257,10 +1279,11 @@ function buildChatInstructions(
 
 function toSupportedProviderId(
   providerId: string,
-): 'openai' | 'google' | undefined {
+): 'openai' | 'google' | 'anthropic' | undefined {
   if (
     providerId !== 'openai'
     && providerId !== 'google'
+    && providerId !== 'anthropic'
   ) {
     return undefined
   }

--- a/server/api/v1/chats/[slug]/title.patch.ts
+++ b/server/api/v1/chats/[slug]/title.patch.ts
@@ -115,6 +115,17 @@ export default defineEventHandler(async (event) => {
         title = await generateChatTitle(initialMessages)
         break
       }
+      case 'anthropic': {
+        const { generateChatTitle } = await useAnthropic(
+          session.user.id,
+          titleModelId,
+          [],
+          'off',
+        )
+
+        title = await generateChatTitle(initialMessages)
+        break
+      }
     }
   }
 

--- a/server/api/v1/profiles/keys/anthropic/index.delete.ts
+++ b/server/api/v1/profiles/keys/anthropic/index.delete.ts
@@ -1,0 +1,19 @@
+import { and, eq } from 'drizzle-orm'
+import * as schema from '~~/server/db/schema'
+
+export default defineEventHandler(async (event) => {
+  const session = await useUserSession()
+
+  if (!session) {
+    return useUnauthorizedError()
+  }
+
+  await useDb()
+    .delete(schema.keys)
+    .where(and(
+      eq(schema.keys.userId, parseInt(session.user.id)),
+      eq(schema.keys.provider, 'anthropic'),
+    ))
+
+  return setResponseStatus(event, 204, 'API key deleted successfully')
+})

--- a/server/api/v1/profiles/keys/anthropic/index.get.ts
+++ b/server/api/v1/profiles/keys/anthropic/index.get.ts
@@ -1,0 +1,21 @@
+export default defineEventHandler(async () => {
+  const session = await useUserSession()
+
+  if (!session) {
+    return useUnauthorizedError()
+  }
+
+  const data = await useDb().query.keys.findFirst({
+    where: {
+      userId: parseInt(session.user.id),
+      provider: 'anthropic',
+    },
+    columns: {
+      apiKey: true,
+    },
+  })
+
+  return data?.apiKey
+    ? await useDecryptText(data.apiKey)
+    : ''
+})

--- a/server/api/v1/profiles/keys/anthropic/index.post.ts
+++ b/server/api/v1/profiles/keys/anthropic/index.post.ts
@@ -1,0 +1,52 @@
+import { and, eq } from 'drizzle-orm'
+import * as schema from '~~/server/db/schema'
+
+export default defineEventHandler(async (event) => {
+  const body = await readValidatedBody(event, z.object({
+    apiKey: z.string().nonempty(),
+  }).safeParse)
+
+  if (body.error) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid request body',
+      data: body.error,
+    })
+  }
+
+  const session = await useUserSession()
+
+  if (!session) {
+    return useUnauthorizedError()
+  }
+
+  const db = useDb()
+
+  const existingKey = await db.query.keys.findFirst({
+    where: {
+      userId: parseInt(session.user.id),
+      provider: 'anthropic',
+    },
+  })
+
+  const apiKey = await useEncryptText(body.data.apiKey)
+
+  if (existingKey) {
+    await db.update(schema.keys).set({
+      apiKey,
+    }).where(and(
+      eq(schema.keys.userId, parseInt(session.user.id)),
+      eq(schema.keys.provider, 'anthropic'),
+    ))
+
+    return setResponseStatus(event, 204, 'Key updated successfully')
+  }
+
+  await db.insert(schema.keys).values({
+    userId: parseInt(session.user.id),
+    provider: 'anthropic',
+    apiKey,
+  })
+
+  return setResponseStatus(event, 201, 'Key created successfully')
+})

--- a/server/utils/chats/errors.ts
+++ b/server/utils/chats/errors.ts
@@ -29,7 +29,7 @@ const chatErrorCodes: ChatErrorCode[] = [
 interface NormalizeChatErrorInput {
   error: unknown
   event?: H3Event
-  providerId?: 'openai' | 'google'
+  providerId?: 'openai' | 'google' | 'anthropic'
   code?: ChatErrorCode
   message?: string
   why?: string

--- a/server/utils/projects/memory.ts
+++ b/server/utils/projects/memory.ts
@@ -8,7 +8,7 @@ import { providers } from '~~/providers'
 import * as schema from '~~/server/db/schema'
 
 interface ProjectMemoryModelSelection {
-  providerId: 'google' | 'openai'
+  providerId: 'google' | 'openai' | 'anthropic'
   modelId: string
   modelName: string
 }
@@ -71,7 +71,7 @@ export async function resolveProjectMemoryModel(
     }
 
     return {
-      providerId: provider.id as 'google' | 'openai',
+      providerId: provider.id as 'google' | 'openai' | 'anthropic',
       modelId: memoryModel.id,
       modelName: memoryModel.name,
     }
@@ -250,6 +250,12 @@ async function getProjectMemoryModelInstance(
 
   if (providerId === 'openai') {
     const { instance } = await useOpenAI(userId, modelId, [], 'off')
+
+    return instance
+  }
+
+  if (providerId === 'anthropic') {
+    const { instance } = await useAnthropic(userId, modelId, [], 'off')
 
     return instance
   }

--- a/server/utils/providers/anthropic.ts
+++ b/server/utils/providers/anthropic.ts
@@ -1,0 +1,106 @@
+import type { SharedV2ProviderOptions } from '@ai-sdk/provider'
+import type { Tools } from '#shared/types/chats.d'
+import type { ReasoningLevel } from '#shared/types/reasoning.d'
+import type { FormattedTools } from '~~/server/types/tools.d'
+import { createAnthropic } from '@ai-sdk/anthropic'
+import {
+  resolveReasoningLevelForModel,
+  toReasoningEffort,
+} from './reasoning'
+
+export async function useAnthropic(
+  userId: string,
+  model: string,
+  requestedTools: Tools,
+  requestedReasoning: ReasoningLevel,
+) {
+  const data = await useDb().query.keys.findFirst({
+    where: {
+      userId: parseInt(userId),
+      provider: 'anthropic',
+    },
+    columns: {
+      apiKey: true,
+    },
+  })
+
+  if (!data?.apiKey) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Anthropic API key not found. Please set it up in the settings.',
+    })
+  }
+
+  const anthropic = createAnthropic({
+    apiKey: await useDecryptText(data.apiKey),
+  })
+  const { model: modelData } = getModel(model)
+
+  if (!modelData) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Unsupported model.',
+    })
+  }
+
+  const controllerModelId = getControllerModelId(modelData)
+
+  function getInstance() {
+    return anthropic(controllerModelId)
+  }
+
+  async function generateChatTitle(message: string) {
+    return await useChatTitle(
+      getInstance(),
+      message,
+    )
+  }
+
+  function getTools(): FormattedTools {
+    if (!requestedTools?.length) {
+      return {}
+    }
+
+    const result: FormattedTools = {}
+
+    if (requestedTools.includes('web_search')) {
+      if (!result.tools) {
+        result.tools = {}
+      }
+
+      result.tools['web_search_preview'] = anthropic.tools.webSearch_20250305({})
+
+      result.toolChoice = {
+        type: 'tool',
+        toolName: 'web_search_preview',
+      }
+    }
+
+    return result
+  }
+
+  const reasoningLevel = resolveReasoningLevelForModel(
+    modelData,
+    requestedReasoning,
+  )
+
+  /**
+   * Deliberately empty. Unlike OpenAI and Google, the Anthropic provider
+   * derives `thinking`/`effort` (or `thinking.budgetTokens` for models
+   * without adaptive thinking) itself from the top-level `reasoning`
+   * option, and explicit providerOptions take precedence over that
+   * derived value. Writing a `thinking` or `effort` block here would
+   * clobber the SDK's per-model mapping rather than add to it.
+   */
+  function getProviderOptions(): SharedV2ProviderOptions {
+    return {}
+  }
+
+  return {
+    instance: getInstance(),
+    generateChatTitle,
+    tools: getTools(),
+    providerOptions: getProviderOptions(),
+    reasoning: toReasoningEffort(reasoningLevel),
+  }
+}

--- a/server/utils/providers/anthropic.ts
+++ b/server/utils/providers/anthropic.ts
@@ -70,9 +70,18 @@ export async function useAnthropic(
 
       result.tools['web_search_preview'] = anthropic.tools.webSearch_20250305({})
 
-      result.toolChoice = {
-        type: 'tool',
-        toolName: 'web_search_preview',
+      /**
+       * Anthropic rejects a forced tool_choice while extended thinking is
+       * enabled ("Thinking may not be enabled when tool_choice forces tool
+       * use"), so the tool is only forced when reasoning is off. With
+       * reasoning on, leaving tool_choice unset (provider default `auto`)
+       * keeps web search usable instead of hard-failing the request.
+       */
+      if (reasoningLevel === 'off') {
+        result.toolChoice = {
+          type: 'tool',
+          toolName: 'web_search_preview',
+        }
       }
     }
 

--- a/shared/types/chat-errors.d.ts
+++ b/shared/types/chat-errors.d.ts
@@ -26,6 +26,6 @@ export interface ChatErrorPayload {
   fix?: string
   status?: number
   requestId?: string
-  providerId?: 'openai' | 'google'
+  providerId?: 'openai' | 'google' | 'anthropic'
   providerRequestId?: string
 }

--- a/shared/utils/chat-test-errors.ts
+++ b/shared/utils/chat-test-errors.ts
@@ -34,7 +34,7 @@ export interface ChatTestErrorConfig {
   message: string
   why?: string
   fix?: string
-  providerId?: 'openai' | 'google'
+  providerId?: 'openai' | 'google' | 'anthropic'
   providerRequestId?: string
 }
 

--- a/tests/unit/providers/merge.spec.ts
+++ b/tests/unit/providers/merge.spec.ts
@@ -126,6 +126,31 @@ describe('mergeModelMetadata', () => {
     expect(model.description).toBe('Fetched description')
   })
 
+  it('keeps an explicit curated name over a distinct fetched name', () => {
+    const model = mergeModelMetadata(
+      {
+        ...chatModel,
+        name: 'Claude Haiku 4.5',
+      },
+      {
+        ...snapshotEntry,
+        name: 'Claude Haiku 4.5 (latest)',
+      },
+    )
+
+    expect(model.name).toBe('Claude Haiku 4.5')
+    expect(model.description).toBe('Fetched description')
+  })
+
+  it('falls back to the fetched name when curated sets none', () => {
+    const model = mergeModelMetadata(chatModel, {
+      ...snapshotEntry,
+      name: 'Fetched Only',
+    })
+
+    expect(model.name).toBe('Fetched Only')
+  })
+
   it('keeps the curated per-image price display', () => {
     const model = mergeModelMetadata(
       {
@@ -368,6 +393,14 @@ describe('merged catalog', () => {
         expect(model.priceTier).toMatch(/^\$+\+?$/)
         expect(model.modalities.input.length).toBeGreaterThan(0)
         expect(model.modalities.output.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('never displays a models.dev alias-tracking suffix like "(latest)"', () => {
+    for (const provider of providers) {
+      for (const model of provider.models) {
+        expect(model.name).not.toMatch(/\(latest\)/i)
       }
     }
   })


### PR DESCRIPTION
### 📚 Description

Adds Anthropic as a third BYOK LLM provider alongside OpenAI and Google AI Studio: **claude-opus-5**, **claude-sonnet-5**, and **claude-haiku-4-5**, curated the same way as the existing providers (hand-picked capability flags merged with objective metadata fetched from models.dev).

**Reasoning**: passed straight through as the AI SDK's unified top-level `reasoning` option (`low`/`medium`/`high`), same as the OpenAI/Google integrations. `@ai-sdk/anthropic` derives the right per-model shape itself — adaptive thinking + `effort` for Opus 5/Sonnet 5, `thinking.budgetTokens` (computed automatically as a percentage of max output tokens) for Haiku 4.5 — so no manual budget mapping was needed anywhere, verified by reading the installed SDK source directly.

**Tools**: web search only, via `anthropic.tools.webSearch_20250305({})`. No image generation or deep-research support — Anthropic has no first-party model for either, so `ResearchProviderId` and `ImageGenerationProvider` deliberately stay unchanged.

**Fix included**: Anthropic rejects a forced `tool_choice` while extended thinking is enabled, so combining reasoning with web search on any curated Claude model would otherwise hard-fail every request. The web-search tool is now only force-selected when reasoning is off.

Also widens the `providerId` unions used by chat error typing and project memory to include `'anthropic'`, adds the chat-title generation branch, and adds the `server/api/v1/profiles/keys/anthropic/*` endpoints. No D1 migration needed — the `keys` table's provider enum already included `'anthropic'`.

### ✅ Checklist

- [x] `pnpm run format && pnpm run typecheck` pass
- [x] Full unit suite passes (1315/1315 at the top of the stack)
- [x] `pnpm run models:fetch` regenerated the snapshot with real models.dev data for all three models