### PR TITLE
docs(legal): disclose Anthropic as a supported AI provider

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -9,7 +9,7 @@ benefits:
     body: Your conversations live in your Cloudflare D1 database. Cancel, self-host, or switch deployments — your data moves with you, no export required.
   - icon: lucide:shuffle
     title: Pick the best model for each job
-    body: GPT-5 for creative work, Gemini Flash for quick drafts, a nano model for high-volume tasks — switch freely across providers in the same interface.
+    body: Claude Opus for hard reasoning, GPT-5 for creative work, Gemini Flash for quick drafts, a nano model for high-volume tasks — switch freely across providers in the same interface.
 carousel:
   - src: /preview-light-desktop.svg
     alt: Besidka chat interface in light theme — a conversation using GPT-5 showing a markdown response with syntax-highlighted code.
@@ -18,7 +18,7 @@ carousel:
     alt: Besidka chat interface in dark theme — file attachments panel open with a PDF selected for the current chat.
     caption: Dark theme — desktop
   - src: /preview-light-mobile.svg
-    alt: Besidka chat interface on a mobile device — model selector open, switching between GPT and Gemini flagship models.
+    alt: Besidka chat interface on a mobile device — model selector open, switching between Claude, GPT and Gemini flagship models.
     caption: Mobile — model switcher
 comparison:
   caption: How Besidka compares to popular AI chat subscriptions
@@ -108,12 +108,12 @@ comparison:
         - no
   note: A typical casual user sends around 100 messages per month — roughly 50 k input tokens and 50 k output tokens. On a flagship model that works out to well under $1/mo. A heavy user sending 1,000 messages stays in the $5–7/mo range, paying the provider directly with no Besidka markup. Image generation is billed separately at the provider's published image rates.
   priceDate: June 2026
-description: Besidka is an open-source, self-hostable AI chat app. Bring your own OpenAI or Google API key and pay the provider directly. No subscriptions, no markup, no lock-in.
+description: Besidka is an open-source, self-hostable AI chat app. Bring your own Anthropic, OpenAI or Google API key and pay the provider directly. No subscriptions, no markup, no lock-in.
 faqs:
   - question: What does BYOK mean?
-    answer: BYOK stands for "Bring Your Own Key." Instead of paying Besidka a monthly subscription, you connect your own API key from OpenAI or Google AI Studio directly. You pay the provider at their published rates — Besidka adds no markup.
+    answer: BYOK stands for "Bring Your Own Key." Instead of paying Besidka a monthly subscription, you connect your own API key from Anthropic, OpenAI or Google AI Studio directly. You pay the provider at their published rates — Besidka adds no markup.
   - question: Which AI providers are supported?
-    answer: Currently OpenAI (GPT-5 and the full GPT model family) and Google AI Studio (Gemini models including Gemini 2.5 Pro and Gemini 3 series). More providers are planned. Check the GitHub repository for the latest list.
+    answer: Currently Anthropic (Claude Opus 5, Claude Sonnet 5 and Claude Haiku 4.5), OpenAI (GPT-5 and the full GPT model family), and Google AI Studio (Gemini models including Gemini 2.5 Pro and the Gemini 3 series). More providers are planned. Check the GitHub repository for the latest list.
   - question: Can Besidka generate images and documents?
     answer: Yes for images. Select Create image with a supported OpenAI or Google chat model, and Besidka generates one image per request. The image is stored privately in your file library, counts toward your storage quota, and remains available to download. Besidka does not generate PDF, PPTX, or XLSX files yet.
   - question: Do you store my API keys?
@@ -125,9 +125,9 @@ faqs:
   - question: Can I share a chat?
     answer: Yes. Any chat can be shared via a public, unguessable link — recipients view a read-only copy without needing an account, and can branch it into their own chats. You control per-share options like link expiry, search-engine indexing, and whether images, file names, message details, or your avatar are visible, and you can revoke a share at any time. Shared files are served through short-lived, revocable tokens rather than a public bucket.
   - question: Does Besidka support deep research like ChatGPT?
-    answer: Yes. Besidka supports deep research the same way ChatGPT and Gemini do, running on dedicated research-agent models — OpenAI's o3-deep-research and o4-mini-deep-research, or Google's Gemini Deep Research. Instead of a single quick reply, the agent autonomously browses the web, cross-checks multiple sources, and writes a fully cited report on the topic you give it. It runs on your own OpenAI or Google API key like every other model, so a typical report costs roughly $1 to $10 depending on the model and depth you pick, with no Besidka markup. You get a push notification the moment the report is ready, so you do not need to keep the tab open while it works.
+    answer: Yes. Besidka supports deep research the same way ChatGPT and Gemini do, running on dedicated research-agent models — OpenAI's o3-deep-research and o4-mini-deep-research, or Google's Gemini Deep Research. Instead of a single quick reply, the agent autonomously browses the web, cross-checks multiple sources, and writes a fully cited report on the topic you give it. It runs on your own OpenAI or Google API key, so a typical report costs roughly $1 to $10 depending on the model and depth you pick, with no Besidka markup. Anthropic does not currently offer a dedicated deep-research agent model, so this is not available on a Claude key. You get a push notification the moment the report is ready, so you do not need to keep the tab open while it works.
   - question: How is pricing calculated?
-    answer: Besidka itself is free to use and open-source. You pay the AI provider (OpenAI or Google) directly at its published API rates, including token usage and any image-generation charges. There is no monthly fee, no seat charge, and no Besidka markup. You pay only when you use a provider-backed feature.
+    answer: Besidka itself is free to use and open-source. You pay the AI provider (Anthropic, OpenAI or Google) directly at its published API rates, including token usage and any image-generation charges. There is no monthly fee, no seat charge, and no Besidka markup. You pay only when you use a provider-backed feature.
   - question: How to pronounce Besidka?
     answer: |-
       Besidka is pronounced “beh-SEED-kah”.
@@ -138,7 +138,7 @@ faqs:
 features:
   - icon: lucide:layers
     title: Multiple AI models
-    body: Switch between the latest GPT and Gemini models in one place without creating separate accounts.
+    body: Switch between the latest Claude, GPT and Gemini models in one place without creating separate accounts.
   - icon: lucide:globe
     title: Web search
     body: Ground AI answers with real-time web context. Besidka can search the web and cite sources inline.
@@ -166,7 +166,7 @@ features:
 hero:
   eyebrow: OPEN SOURCE · BYOK · SELF-HOSTABLE
   headline: Besidka — open-source AI chat. Your keys, your costs.
-  subheadline: Self-host it or use besidka.com. Switch between GPT and Gemini models on your own API key — pay per use, no subscriptions, no markup, no lock-in.
+  subheadline: Self-host it or use besidka.com. Switch between Claude, GPT and Gemini models on your own API key — pay per use, no subscriptions, no markup, no lock-in.
   primaryCta:
     label: Start chatting
     href: /signup
@@ -181,7 +181,7 @@ steps:
     body: Create a free account with email and password, or sign in with Google or GitHub. No credit card required.
   - icon: lucide:key
     title: 2. Add your API key
-    body: Paste your OpenAI or Google AI Studio API key into your profile. Keys are encrypted at rest and never shared.
+    body: Paste your Anthropic, OpenAI or Google AI Studio API key into your profile. Keys are encrypted at rest and never shared.
   - icon: lucide:message-square
     title: 3. Start chatting
     body: Open a new chat, pick your model, and go. You pay the provider's rate directly — Besidka adds nothing on top.
@@ -196,7 +196,7 @@ useCases:
     payoff: Every byte of chat history stays in infrastructure they control — no third-party reads their conversations.
   - icon: lucide:briefcase
     persona: Occasional AI user
-    scenario: Skips the flat monthly subscription and pays only for the tokens they actually use, switching between GPT and Gemini flagships depending on the task.
+    scenario: Skips the flat monthly subscription and pays only for the tokens they actually use, switching between Claude, GPT and Gemini flagships depending on the task.
     payoff: A typical light-use month costs a few dollars instead of twenty.
 video:
   src: /videos/demo.mp4
@@ -272,7 +272,7 @@ sr-label: BYOK solution summary and call to action
 ---
 Your keys, your costs, your data.
 
-Connect an OpenAI or Google AI Studio key and pay only for what you use — no monthly fee, no per-seat charge, no markup. Switch between the latest GPT and Gemini models in one place. Add or remove keys any time from your profile. Because Besidka is open-source and self-hostable, you are never locked in.
+Connect an Anthropic, OpenAI or Google AI Studio key and pay only for what you use — no monthly fee, no per-seat charge, no markup. Switch between the latest Claude, GPT and Gemini models in one place. Add or remove keys any time from your profile. Because Besidka is open-source and self-hostable, you are never locked in.
 
   :::home-cta
   ---

--- a/content/legal/privacy-policy.md
+++ b/content/legal/privacy-policy.md
@@ -27,7 +27,7 @@ Besidka does not process personal data on the scale that requires a data protect
 
 ## How Besidka works, in one paragraph
 
-Besidka is a free AI chat app. You bring your own API key from an AI provider (OpenAI or Google AI Studio), and you pay that provider directly for the usage. **There is no payment relationship between you and me at all** — no subscription, no ads, no donations, no payment processor, and therefore no billing or card data anywhere in this policy. What I store is what is needed to run the chat app for you.
+Besidka is a free AI chat app. You bring your own API key from an AI provider (Anthropic, OpenAI or Google AI Studio), and you pay that provider directly for the usage. **There is no payment relationship between you and me at all** — no subscription, no ads, no donations, no payment processor, and therefore no billing or card data anywhere in this policy. What I store is what is needed to run the chat app for you.
 
 ## What I store
 
@@ -89,7 +89,7 @@ This is the most important section of this policy, so please read it.
 
 When you send a message, I send your prompt, the message history of that chat and any attachments to the AI provider whose API key you supplied. I send it **with your own API key**, on your instruction.
 
-Those providers are **independent controllers**, not my processors. I have no contract with them about your data. Your relationship is directly with them, under the terms of your own OpenAI or Google account. What they do with your content, how long they keep it and how you delete it is governed by their terms, not mine.
+Those providers are **independent controllers**, not my processors. I have no contract with them about your data. Your relationship is directly with them, under the terms of your own Anthropic, OpenAI or Google account. What they do with your content, how long they keep it and how you delete it is governed by their terms, not mine.
 
 ### If you use a free Google Gemini key
 
@@ -100,6 +100,10 @@ Most people using their own Google AI Studio key are on that free tier. If that 
 ### If you use an OpenAI key
 
 OpenAI states that it does not use data submitted through its API to train its models by default. It does retain logs for abuse monitoring, and those logs can contain your prompts, for **up to 30 days**.
+
+### If you use an Anthropic key
+
+Anthropic states that it does not train its models on content submitted through its API. It automatically deletes API inputs and outputs from its backend within **30 days** of receipt or generation, except content flagged for a Usage Policy violation, which it may retain longer for safety enforcement. There is no self-service option to delete this data sooner — deletion relies on that automatic 30-day window.
 
 ### I never train on your data
 
@@ -113,7 +117,7 @@ Whether the **provider** trains on your content is a matter between you and that
 | --- | --- | --- | --- |
 | Cloudflare | Everything the service stores and serves — Workers, D1 database, KV cache, R2 files, Images, Email Sending and Routing | EU and US | Processor for me. Certified under the EU–US Data Privacy Framework. |
 | Axiom | Operational and error logs | US | Processor for me. Standard Contractual Clauses. |
-| OpenAI or Google AI Studio | Your prompts, message history and attachments, sent with your own API key | Depends on your provider account | Independent controller. Your own terms with them apply. |
+| Anthropic, OpenAI or Google AI Studio | Your prompts, message history and attachments, sent with your own API key | Depends on your provider account | Independent controller. Your own terms with them apply. |
 | Google FCM, Apple APNs, Mozilla autopush | The push endpoint your browser issued, plus the encrypted notification | Depends on your browser vendor | Necessary to deliver a push notification you asked for. |
 | Google or GitHub | Only if you use them to sign in. I request the scopes `email profile openid` from Google and `read:user user:email` from GitHub. | US | Independent controllers for your account with them. |
 | Search engines | A shared chat, and only if you turned on the separate indexing option for that share | Worldwide | Your consent. |
@@ -263,7 +267,7 @@ Open that link in the same browser you are signed in to. The link is tied to you
 Two honest limits:
 
 1. **Backups.** As described under [Backups](#backups), Cloudflare D1 keeps point-in-time backups for up to 30 days. Deleted data can persist there for that window before rolling off. Those backups exist only for disaster recovery.
-2. **Your AI provider.** I **cannot** erase anything from OpenAI or Google. That processing happened under **your** provider account, with your key, and they are independent controllers. To delete data there, use their own controls and privacy requests — OpenAI at [privacy.openai.com](https://privacy.openai.com/) and Google through your Google account's privacy settings.
+2. **Your AI provider.** I **cannot** erase anything from Anthropic, OpenAI or Google. That processing happened under **your** provider account, with your key, and they are independent controllers. To delete data there, use their own controls and privacy requests — Anthropic automatically deletes API data within 30 days, OpenAI at [privacy.openai.com](https://privacy.openai.com/) and Google through your Google account's privacy settings.
 
 ### Complaining
 

--- a/content/legal/terms-of-use.md
+++ b/content/legal/terms-of-use.md
@@ -29,7 +29,7 @@ By creating an account or using the service you accept these terms. If you do no
 
 Besidka is a chat interface to third-party AI models. I provide the interface, the storage for your chats and files, and the plumbing that talks to the model.
 
-**I do not provide the AI model.** You supply your own API key from an AI provider (currently OpenAI or Google AI Studio), and your prompts are sent to that provider using your key.
+**I do not provide the AI model.** You supply your own API key from an AI provider (currently Anthropic, OpenAI or Google AI Studio), and your prompts are sent to that provider using your key.
 
 ## There is no payment
 


### PR DESCRIPTION
### 📚 Description

Stacked on #319. Content-only — no code changes.

- `content/index.md`: extends every provider-list mention on the landing page (benefit copy, hero, FAQ, features, CTA) to include Anthropic/Claude. The "which providers are supported" FAQ now explicitly lists Claude Opus 5, Claude Sonnet 5, and Claude Haiku 4.5. Deliberately left untouched: the image-generation FAQ (Anthropic has no image model) and the deep-research FAQ's provider list (Anthropic has no research-agent model) — added a clarifying sentence there instead of silently implying parity. Kept the existing "Claude Pro" comparison-table entry as-is; it's not a contradiction, since the pitch (pay the provider's API rate instead of a flat subscription) is strengthened, not weakened, by this app now running Claude models.
- `content/legal/privacy-policy.md`: added a new "If you use an Anthropic key" section with Anthropic's actual current data-retention policy, fetched live from Anthropic's Commercial Terms of Service and Privacy Center (not paraphrased from memory) — no training on API content by default, 30-day automatic deletion of inputs/outputs (longer only for Usage Policy violations), no self-service ad-hoc deletion. Extended the sub-processor table row and deletion-limits section to include Anthropic.
- `content/legal/terms-of-use.md`: extended the supported-providers mention. Left the 18+ age-gate untouched — it's justified via Google AI Studio's requirement, which remains valid on its own; Anthropic's Commercial Terms don't state an explicit age requirement to add.

**No CI runs on this PR** — same reasoning as #319, base isn't `main`.