### PR TITLE
test(providers): cover curated Anthropic model invariants

### DIFF
--- a/docs/deep-research.md
+++ b/docs/deep-research.md
@@ -33,7 +33,16 @@ Runs are billed to the user's own key. `assistModel` in the same config block
 names the cheap chat model used for the two pre-calls (clarifying questions
 via `generateObject`, brief rewrite via `generateText`). Anthropic has no
 deep-research API, so none of its models declare a `research` block — the
-trigger never renders for them.
+trigger never renders for them. This isn't a temporary gap: Anthropic has no
+first-party hosted async "deep research" agent model equivalent to OpenAI's
+`o3-deep-research`/`o4-mini-deep-research` or Google's Gemini Deep Research
+models. Anthropic's Managed Agents platform (session/agent hosting with its
+own SDK surface) is architecturally a different shape — a stateful hosted
+agent session with an event stream you steer turn by turn, not a single
+async job against a purpose-built research model — and it doesn't fit this
+feature's `start → {providerJobId, status} → poll → result` job pattern.
+That's why `shared/types/research.d.ts`'s `ResearchProviderId` stays
+`'openai' | 'google'` rather than widening to include Anthropic.
 
 Selecting a research model hides web search, reasoning controls, and file
 attachments in `ChatInput` — the agents do their own browsing, and attachments

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -101,6 +101,7 @@ export function getAffectedTests(changedFiles) {
   ]
   const modelCatalogTests = [
     'tests/unit/providers/merge.spec.ts',
+    'tests/unit/providers/anthropic.spec.ts',
     'tests/unit/scripts/audit-curated-models.spec.ts',
     'tests/unit/utils/model.spec.ts',
     'tests/unit/utils/cost-map.spec.ts',
@@ -271,7 +272,7 @@ export function getAffectedTests(changedFiles) {
   const testMappings = [
     {
       pattern:
-        /^(server\/utils\/ai\/image-generation(-lock|-cost)?\.ts|server\/db\/schemas\/image-generation-locks\.ts|server\/utils\/providers\/(openai|google)\.ts|providers\/(openai|google)\.ts|shared\/types\/(image-generation|providers)\.d\.ts|shared\/utils\/model\.ts|app\/composables\/chat-input\.ts|app\/components\/ChatInput(\.client\.vue|\/ToolbarMore\.client\.vue)|server\/types\/tools\.d\.ts)$/,
+        /^(server\/utils\/ai\/image-generation(-lock|-cost)?\.ts|server\/db\/schemas\/image-generation-locks\.ts|server\/utils\/providers\/(openai|google|anthropic)\.ts|providers\/(openai|google|anthropic)\.ts|shared\/types\/(image-generation|providers)\.d\.ts|shared\/utils\/model\.ts|app\/composables\/chat-input\.ts|app\/components\/ChatInput(\.client\.vue|\/ToolbarMore\.client\.vue)|server\/types\/tools\.d\.ts)$/,
       tests: imageGenerationTests,
     },
     {
@@ -280,7 +281,7 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern:
-        /^(providers\/(index|merge|google|openai)\.ts|providers\/data\/models-dev-snapshot\.json|scripts\/(fetch-models-metadata|audit-curated-models)\.mjs|shared\/types\/providers\.d\.ts)$/,
+        /^(providers\/(index|merge|google|openai|anthropic)\.ts|providers\/data\/models-dev-snapshot\.json|scripts\/(fetch-models-metadata|audit-curated-models)\.mjs|shared\/types\/providers\.d\.ts)$/,
       tests: modelCatalogTests,
     },
     {
@@ -548,7 +549,7 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern:
-        /^(providers\/(openai|google)\.ts|shared\/types\/(research|providers)\.d\.ts|shared\/utils\/research\.ts|app\/utils\/research\.ts)$/,
+        /^(providers\/(openai|google|anthropic)\.ts|shared\/types\/(research|providers)\.d\.ts|shared\/utils\/research\.ts|app\/utils\/research\.ts)$/,
       tests: deepResearchTests,
     },
     {

--- a/tests/unit/providers/anthropic.spec.ts
+++ b/tests/unit/providers/anthropic.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import anthropic from '../../../providers/anthropic'
+import snapshot from '../../../providers/data/models-dev-snapshot.json'
+
+const expectedModelIds = [
+  'claude-opus-5',
+  'claude-sonnet-5',
+  'claude-haiku-4-5',
+]
+
+describe('curated anthropic provider', () => {
+  it('curates exactly the three expected models', () => {
+    const ids = anthropic.models.map(model => model.id)
+
+    expect(anthropic.models).toHaveLength(expectedModelIds.length)
+    expect(new Set(ids)).toEqual(new Set(expectedModelIds))
+  })
+
+  it('has no model marked as the app-wide default', () => {
+    for (const model of anthropic.models) {
+      expect(model.default).toBeFalsy()
+    }
+  })
+
+  it('has no model marked for project memory', () => {
+    for (const model of anthropic.models) {
+      expect(model.forProjectMemory).toBeFalsy()
+    }
+  })
+
+  it('has no model exposing image generation', () => {
+    for (const model of anthropic.models) {
+      expect(model.tools).not.toContain('image_generation')
+      expect(model.imageGeneration).toBeUndefined()
+    }
+  })
+
+  it('has no model configured as a deep-research agent', () => {
+    for (const model of anthropic.models) {
+      expect(model.research).toBeUndefined()
+    }
+  })
+
+  it('gives every model levels-based reasoning with low/medium/high', () => {
+    for (const model of anthropic.models) {
+      expect(model.reasoning).toBeDefined()
+      expect(model.reasoning?.mode).toBe('levels')
+
+      const levels = model.reasoning?.mode === 'levels'
+        ? [...model.reasoning.levels].sort()
+        : []
+
+      expect(levels).toEqual(['high', 'low', 'medium'])
+    }
+  })
+
+  it('has a models.dev snapshot entry for every curated id', () => {
+    const snapshotIds = Object.keys(snapshot)
+
+    for (const id of expectedModelIds) {
+      expect(snapshotIds).toContain(id)
+    }
+  })
+})


### PR DESCRIPTION
### 📚 Description

Stacked on #320 — the top of the stack. Adds test coverage and CI registration for everything below it.

- `tests/unit/providers/anthropic.spec.ts`: guards the curated-model invariants that matter for this integration — exactly the 3 expected models, none marked `default` or `forProjectMemory` (both are array-order-sensitive across all providers, so an accidental flag here would silently steal behavior from Gemini), none exposing `image_generation` or a `research` config, and every model has levels-based reasoning with `low`/`medium`/`high`. Imports the raw curated export directly (not the merged catalog) so these assertions aren't vacuously true from merge-time field stripping.
- `scripts/test-affected-check.mjs`: registers `anthropic` in the existing `openai|google` regex alternations so CI actually runs the model-catalog/image-generation/deep-research test groups when Anthropic's provider files change, plus registers the new spec above.
- `docs/deep-research.md`: expands the existing note on why Anthropic isn't a research provider (no first-party hosted deep-research agent model; Managed Agents is a different architectural shape that doesn't fit this feature's job-polling pattern).

Full unit suite at the top of the stack: **123 files, 1315 tests passing**. `pnpm run format && pnpm run typecheck` clean.

**This PR should be retargeted to `main` before merging the stack**, so a full build+deploy runs against the complete combined change — the only CI that's run on any layer so far is #318's (base `main`), which predates the UI/content/test layers.