### PR TITLE
ci: skip preview build and deploy on stacked sub-PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,7 +57,11 @@ CI/CD workflows for building, testing, and deploying Besidka to Cloudflare Worke
 
 ### `preview-build.yml` - PR Build & Test
 
-Triggers on `pull_request` events. Runs in the PR author's context without access to secrets.
+Triggers on `pull_request` events targeting `main` only (`branches: [main]`). A
+stacked PR whose base is another feature branch never triggers this workflow,
+and since `preview-deploy.yml` only runs off this workflow's `workflow_run`
+completion, stacked sub-PRs get no build or deploy — only the PR targeting
+`main` does. Runs in the PR author's context without access to secrets.
 
 1. Check PR is still open
 2. Install dependencies

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -2,6 +2,7 @@ name: Preview Build
 
 on:
   pull_request:
+    branches: [main]
     types: [opened, synchronize, reopened]
     paths-ignore:
       # NOTE: do not ignore '**/*.md' — content/*.md is the landing page


### PR DESCRIPTION
### 📚 Description

Filters `preview-build.yml`'s `pull_request` trigger to `branches: [main]`. A stacked PR targeting another feature branch (not `main`) never triggers a build, and `preview-deploy.yml` (which only runs off `workflow_run` completion of Preview Build) never fires either — so only the PR actually targeting `main` gets a preview build and deploy.

This unblocks using [GitHub's stacked PRs](https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests) (and the `gh stack` extension) for reviewing a large change in layers without burning CI minutes on every intermediate sub-PR.

**Recommend merging this before the stacked feature PRs land**, so the skip behavior is in effect for their review cycle. Diff is CI-config only (`.github/**` is already in `preview-build.yml`'s own `paths-ignore`, so this PR itself triggers no build).

### ✅ Checklist

- [x] No functional/application code changed — workflow trigger + docs only