### PR TITLE
ci: fall back to a fresh preview deploy when no PR alias is found

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -101,9 +101,9 @@ Triggers when a maintainer comments `/deploy-preview` on a fork PR.
 
 Triggers on push to `main`. Two parallel jobs:
 
-**build-production**: Full test suite, build, deploy to production. When
-`.drizzle/` changed, applies remote migrations to both production databases
-(`DB`, then `CONSENT_DB`) before deploy.
+**build-production**: Full test suite, build, deploy to production. Applies
+remote migrations to both production databases (`DB`, then `CONSENT_DB`)
+before deploy, unconditionally on every run (see below).
 
 **update-preview**: Finds the PR version by alias (`pr-{number}`) and, when
 found, promotes it to the preview environment — reusing the exact build that
@@ -124,13 +124,21 @@ restack push supersedes it before the upload finishes. Either way, this job
 builds+deploys the `preview-build` artifact from `build-production` fresh —
 the same artifact already validated by the full test suite for this exact
 `main` HEAD — rather than silently leaving `besidka-preview` on stale code.
-It applies remote migrations to both preview databases (`DB`, then
-`CONSENT_DB`) when `.drizzle/` changed.
+It regenerates and applies remote migrations to both preview databases
+(`DB`, then `CONSENT_DB`) unconditionally, same as `build-production`. This
+job installs dependencies with a plain `pnpm install --frozen-lockfile` (not
+`--ignore-scripts`) specifically so `postinstall`'s `nuxt prepare` runs and
+`.nuxt/tsconfig.json` exists — `drizzle-kit generate` loads the root
+`tsconfig.json`, which `extends` that file, and hard-fails without it.
 
-Both databases are gated on the same `drizzle-changed` detection (any change
-under `.drizzle/`). `wrangler d1 migrations apply` is idempotent — it only
-runs migrations not yet recorded in each database's `d1_migrations` table, so
-applying both when only one changed is a harmless no-op.
+Both `build-production` and `deploy-preview-fallback` apply migrations to
+`DB` and `CONSENT_DB` unconditionally on every run — an earlier git-diff-based
+`drizzle-changed` gate was removed because a diff of only the current push's
+before/after SHAs could permanently miss a migration if an unrelated prior
+run failed before reaching the migration step. `wrangler d1 migrations apply`
+is idempotent — it only runs migrations not yet recorded in each database's
+`d1_migrations` table, so applying both every time (even when neither
+changed) is a harmless no-op.
 
 ### `cleanup-runs.yml` - Workflow Run Cleanup
 
@@ -323,11 +331,15 @@ the uploaded `.drizzle` artifact (no regeneration). The production jobs
 regenerate before applying via `preCommands`: `pnpm run db:generate` for `DB`
 and `pnpm run db:consents:generate` for `CONSENT_DB`.
 
-**Gating.** Both DB and CONSENT_DB apply steps in `production.yml` share the
-`drizzle-changed` output (true when any file under `.drizzle/` changed in the
-push). Because `wrangler d1 migrations apply` only runs migrations missing
-from each database's `d1_migrations` tracking table, running both steps when
-only one database changed is an idempotent no-op.
+**Gating.** Both DB and CONSENT_DB apply steps in `production.yml` run
+unconditionally on every push, in both `build-production` and
+`deploy-preview-fallback` — there is no `.drizzle/`-change gate. An earlier
+git-diff-based gate (comparing only the current push's before/after SHAs)
+was removed because it could permanently miss a migration if an unrelated
+prior run failed before reaching the migration step. Because
+`wrangler d1 migrations apply` only runs migrations missing from each
+database's `d1_migrations` tracking table, running both steps on every push
+regardless of what changed is an idempotent no-op.
 
 **Local commands** (mirror the CI steps; run these yourself for remote DBs —
 never let CI touch a remote DB you have not migrated locally first):

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,9 +40,13 @@ CI/CD workflows for building, testing, and deploying Besidka to Cloudflare Worke
 │      │   ├─ Build application                                    │
 │      │   └─ Deploy to production                                 │
 │      │                                                           │
-│      └─ update-preview job (parallel)                            │
-│          ├─ Get merged PR number                                 │
-│          └─ Promote PR version to preview                        │
+│      ├─ update-preview job (parallel)                            │
+│      │   ├─ Get merged PR number                                 │
+│      │   └─ Promote PR version to preview (if alias found)       │
+│      │                                                           │
+│      └─ deploy-preview-fallback job (after update-preview)        │
+│          Direct push OR no PR-alias version found: build+deploy  │
+│          the fallback build fresh instead of silently skipping   │
 │                                                                  │
 │  Preview URLs:                                                   │
 │    https://{hash}-besidka-preview.chernenko.workers.dev          │
@@ -101,12 +105,27 @@ Triggers on push to `main`. Two parallel jobs:
 `.drizzle/` changed, applies remote migrations to both production databases
 (`DB`, then `CONSENT_DB`) before deploy.
 
-**update-preview**: Finds the PR version by alias and promotes it to the
-preview environment. For direct pushes to `main` (no PR), the
-`deploy-preview-direct-push` job runs a plain preview deploy and, when
-`.drizzle/` changed, applies remote migrations to both preview databases
-(`DB`, then `CONSENT_DB`). If a PR exists but no version alias is found, it
-skips promotion gracefully.
+**update-preview**: Finds the PR version by alias (`pr-{number}`) and, when
+found, promotes it to the preview environment — reusing the exact build that
+was already deployed and reviewed on the PR, instead of rebuilding.
+
+**deploy-preview-fallback**: Runs after `update-preview` when either (a) the
+push was direct to `main` with no associated PR, or (b) a PR was found but no
+`pr-{number}` alias exists for it. Case (b) is not just a theoretical edge
+case: `resolve-preview-context` resolves `github.sha` — the HEAD commit of
+the push — to find "the" merged PR. When several squash-merge commits land
+on `main` in one push (e.g. a stack of PRs merged back-to-back), only the
+*last* commit's PR is ever consulted, even though earlier commits' PRs may
+have their own valid, unrelated aliases. That last PR can easily have no
+alias of its own: restack churn on a stacked branch can get its preview
+build cancelled outright, or get a successful build's deploy cancelled
+mid-upload by `preview-deploy.yml`'s own concurrency group when a later
+restack push supersedes it before the upload finishes. Either way, this job
+builds+deploys the `preview-build` artifact from `build-production` fresh —
+the same artifact already validated by the full test suite for this exact
+`main` HEAD — rather than silently leaving `besidka-preview` on stale code.
+It applies remote migrations to both preview databases (`DB`, then
+`CONSENT_DB`) when `.drizzle/` changed.
 
 Both databases are gated on the same `drizzle-changed` detection (any change
 under `.drizzle/`). `wrangler d1 migrations apply` is idempotent — it only
@@ -297,7 +316,7 @@ migrated with a separate step so a failure is attributable to one database:
 |----------------|---------|---------|-----------------|--------|
 | `preview-deploy.yml` → `deploy` | Same-repo PR build success | `wrangler d1 migrations apply DB --remote` | `wrangler d1 migrations apply CONSENT_DB --remote` | Downloaded `preview-drizzle` artifact (committed migrations) |
 | `production.yml` → `build-production` | Merge / push to `main` | `… apply DB --remote --env production` | `… apply CONSENT_DB --remote --env production` | Regenerated in-step via `preCommands` |
-| `production.yml` → `deploy-preview-direct-push` | Direct push to `main` (no PR) | `… apply DB --remote` | `… apply CONSENT_DB --remote` | Regenerated in-step via `preCommands` |
+| `production.yml` → `deploy-preview-fallback` | Direct push, or PR merge with no preview alias found | `… apply DB --remote` | `… apply CONSENT_DB --remote` | Regenerated in-step via `preCommands` |
 
 **Regeneration source.** Preview-deploy applies the exact migration files from
 the uploaded `.drizzle` artifact (no regeneration). The production jobs

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -341,6 +341,8 @@ jobs:
       - resolve-preview-context
       - build-production
     runs-on: ubuntu-24.04
+    outputs:
+      version-found: ${{ steps.find-version.outputs.found }}
     permissions:
       contents: read
     env:
@@ -400,12 +402,13 @@ jobs:
           echo "⚠️ No merged PR found for commit ${{ github.sha }}"
           echo "Skipping version promotion to preview"
 
-  deploy-preview-direct-push:
-    name: Deploy preview for direct push
+  deploy-preview-fallback:
+    name: Deploy preview (fallback build)
     needs:
       - resolve-preview-context
       - build-production
-    if: needs.resolve-preview-context.outputs.is-direct == 'true'
+      - update-preview
+    if: needs.resolve-preview-context.outputs.is-direct == 'true' || needs.update-preview.outputs.version-found == 'false'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -454,19 +457,20 @@ jobs:
           command: -v
           postCommands: yes | pnpm exec wrangler d1 migrations apply CONSENT_DB --remote
 
-      - name: Deploy preview for direct push
+      - name: Deploy fallback build to preview
         uses: cloudflare/wrangler-action@v4
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           packageManager: pnpm
+          command: deploy
 
   cleanup-preview-build-artifact:
     name: Cleanup preview build artifact
     needs:
       - build-production
       - update-preview
-      - deploy-preview-direct-push
+      - deploy-preview-fallback
     if: always()
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -435,7 +435,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        run: pnpm install --frozen-lockfile
 
       - name: Apply migrations to preview database
         uses: cloudflare/wrangler-action@v4

--- a/docs/cookie-consent.md
+++ b/docs/cookie-consent.md
@@ -681,8 +681,9 @@ main `DB`, mirroring the existing migration pipeline:
 - **Merge / push to `main`** → `production.yml` (`build-production`) applies
   `CONSENT_DB --remote --env production`, gated on any change under
   `.drizzle/`, regenerating first via `pnpm run db:consents:generate`.
-- **Direct push to `main` without a PR** → `production.yml`
-  (`deploy-preview-direct-push`) applies `CONSENT_DB --remote` to preview.
+- **Direct push to `main`, or a PR merge with no preview alias found** →
+  `production.yml` (`deploy-preview-fallback`) applies `CONSENT_DB --remote`
+  to preview.
 
 `wrangler d1 migrations apply` is idempotent, so these steps only run
 migrations not yet recorded in `CONSENT_DB`'s `d1_migrations` table. See


### PR DESCRIPTION
## Summary

- `production.yml` only handled two post-merge cases: a PR with an existing
  `pr-{number}` preview alias to promote, or a direct push with no PR at
  all. A third case — a PR is found but no alias exists for it — fell
  through both and `update-preview` silently skipped promotion.
- Root cause traced empirically to the #318-#321 stacked-PR merge: all four
  squash commits landed on `main` in one push, so `resolve-preview-context`
  (which resolves only `github.sha`, the HEAD commit) only ever considered
  PR #321. #321's own preview build never completed (cancelled by restack
  churn), so no `pr-321` alias existed, and `besidka-preview` never got
  updated even though `build-production` deployed to production fine.
  (#319's build/deploy did succeed and did get a `pr-319` alias — it was
  simply never consulted, since the batch only looks at the last commit.)
  #320's successful deploy also got cancelled mid-upload by
  `preview-deploy.yml`'s own concurrency group when a later restack push
  superseded it.
- Generalizes the old `deploy-preview-direct-push` job into
  `deploy-preview-fallback`, which now runs after `update-preview` whenever
  it's a direct push **or** no alias was found, building+deploying the
  already-tested `preview-build` artifact instead of leaving preview stale.
- Updated `.github/workflows/README.md` and `docs/cookie-consent.md` to
  match the renamed job and corrected the "skips promotion gracefully"
  description that undersold how routine this gap actually is with stacked
  PRs.

## Second bug found while validating this fix

While this PR was open, an unrelated same-day commit (`5d066823`, "always
apply D1 migrations on deploy instead of git-diff gating") removed a
git-diff gate that had been silently hiding a pre-existing bug in this exact
job: it installs deps with `--ignore-scripts` (copied from
`preview-deploy.yml`'s pattern), which skips `postinstall`'s `nuxt prepare`,
so `.nuxt/tsconfig.json` never exists. `drizzle-kit generate` loads the root
`tsconfig.json`, which `extends` that file, and hard-fails without it.
Confirmed live: the very next direct push to `main` hit exactly this
failure (`File './.nuxt/tsconfig.json' not found.`).

Unlike `preview-deploy.yml`, this job regenerates migrations live via
`db:generate` rather than using a pre-generated `.drizzle` artifact, so it
actually needs the Nuxt-prepared environment. Fixed by dropping
`--ignore-scripts` here (matching `build-production`'s already-working
`pnpm install --frozen-lockfile`). Verified locally that `pnpm run
db:generate` succeeds once `.nuxt/tsconfig.json` exists.

Also corrected three now-stale README claims about migrations being gated
on `.drizzle/` changes — that gate was the same one `5d066823` removed;
migrations now apply unconditionally everywhere, relying on
`d1_migrations`-table idempotency instead.

## Caveats

- `.github/**` is in both `production.yml`'s and `preview-build.yml`'s
  `paths-ignore`, so **this PR itself will not trigger a production run or
  a preview build** — there's no CI dry-run path for this change. First
  real exercise is the next non-ignored merge to `main` (direct push or
  stacked-PR merge with a missing alias).
- As of this PR's original diagnosis, `besidka-preview` was behind `main` by
  the four `#318-#321` commits; this has since been manually resolved by
  promoting the existing `pr-319` version via `wrangler versions deploy`.

## Test plan

- [x] YAML validated (`ruby -ryaml`) — job graph, `if:` conditions, and
      the new `version-found` output resolve as intended.
- [x] `pnpm run format && pnpm run typecheck` (pre-commit hook) passed.
- [x] Reproduced the `.nuxt/tsconfig.json` failure's mechanism locally and
      confirmed `pnpm run db:generate` succeeds once that file exists.
- [ ] Confirm on the next real merge to `main` that `deploy-preview-fallback`
      fires only when expected and completes its migration steps
      successfully (skipped on a normal single-PR merge with a valid alias,
      run on direct pushes / missing-alias cases).