### PR TITLE
chore: migrate canonical host from www.besidka.com to besidka.com

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -71,9 +71,9 @@ NUXT_AXIOM_CONSENT_TOKEN=
 # dev. These credentials only power the deployed editor at /_studio, where
 # editors sign in with GitHub and changes are committed to the repo.
 # Setup: GitHub → Settings → Developer settings → OAuth Apps → New OAuth App
-#   Homepage URL:               https://www.besidka.com
-#   Authorization callback URL: https://www.besidka.com/_studio
-#   (use the canonical www host — prod redirects besidka.com → www.besidka.com,
+#   Homepage URL:               https://besidka.com
+#   Authorization callback URL: https://besidka.com/_studio
+#   (use the canonical apex host — prod redirects www.besidka.com → besidka.com,
 #    and the OAuth callback must match the final host exactly)
 STUDIO_GITHUB_CLIENT_ID=
 STUDIO_GITHUB_CLIENT_SECRET=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ pnpm run db:reset         # Reset local D1 database and regenerate
 npx wrangler d1 time-travel info <db-name>
 npx wrangler d1 time-travel info <db-name> --timestamp=<ISO8601>
 npx wrangler d1 time-travel restore <db-name> --bookmark=<bookmark>
-# Production DB: chat   |   Preview DB: chat-preview
+# Production DB: besidka (needs --env production)  |  Preview DB: besidka-preview
 
 # Cloudflare
 pnpm run cf-typegen       # Generate Cloudflare env types
@@ -97,13 +97,13 @@ Before running `pnpm run db:migrate` or `wrangler d1 migrations apply ... --remo
 
 - Always take a Time Travel bookmark **before** applying, save it somewhere retrievable:
   ```bash
-  npx wrangler d1 time-travel info chat
-  npx wrangler d1 time-travel info chat-preview
+  npx wrangler d1 time-travel info besidka --env production
+  npx wrangler d1 time-travel info besidka-preview
   ```
-- Apply to `chat-preview` first, verify data integrity, then `chat`.
+- Apply to `besidka-preview` first, verify data integrity, then `besidka`.
 - Verify row counts before/after on cascade-children:
   ```bash
-  npx wrangler d1 execute chat --remote --command="SELECT
+  npx wrangler d1 execute besidka --env production --remote --command="SELECT
     (SELECT COUNT(*) FROM chats) AS chats,
     (SELECT COUNT(*) FROM messages) AS messages,
     (SELECT COUNT(*) FROM projects) AS projects,
@@ -116,10 +116,10 @@ D1 Time Travel keeps point-in-time bookmarks for **30 days** (Workers Paid) / **
 
 ```bash
 # Find a pre-disaster bookmark by walking back timestamps
-npx wrangler d1 time-travel info chat --timestamp=2026-05-15T16:00:00Z
+npx wrangler d1 time-travel info besidka --env production --timestamp=2026-05-15T16:00:00Z
 
 # Restore (overwrites current state — irreversible without the undo bookmark it prints)
-npx wrangler d1 time-travel restore chat --bookmark=<bookmark>
+npx wrangler d1 time-travel restore besidka --env production --bookmark=<bookmark>
 ```
 
 The first bookmark whose timestamp predates the migration is **not necessarily safe** — the migration may have been applied minutes before it became the "active" bookmark for that timestamp window. **Always verify row counts after each restore and walk further back if cascade-children are still empty.**
@@ -192,6 +192,11 @@ The first bookmark whose timestamp predates the migration is **not necessarily s
   `allowedHosts` mismatch that blocks versioned preview URLs), and why
   password-only 2FA gating (no challenge via passkey/OAuth sign-in) is a
   confirmed, accepted design decision rather than a gap
+- `docs/domain-migration-www-to-apex.md` - The `www.besidka.com` →
+  `besidka.com` canonical-host migration: D1 Time Travel bookmarks and
+  read-only scan, blast radius for existing sessions/push/passkeys, and the
+  ordered manual runbook for the Cloudflare redirect rule flip and OAuth
+  app callback updates that can't be automated from this repo
 
 ### Tech Stack
 
@@ -207,10 +212,10 @@ The first bookmark whose timestamp predates the migration is **not necessarily s
 
 ### SEO and canonical host
 
-- **Canonical host is `www.besidka.com`.** A Cloudflare redirect rule sends the
-  apex (`besidka.com`) to `www.besidka.com`, so all crawler-facing URLs must use
-  the `www` subdomain to match the post-redirect host. Pointing them at the apex
-  would advertise URLs that immediately 301, splitting SEO signals.
+- **Canonical host is the bare apex `besidka.com`.** A Cloudflare redirect rule
+  sends `www.besidka.com` to the apex (`besidka.com`), so all crawler-facing
+  URLs must use the apex to match the post-redirect host. Pointing them at
+  `www` would advertise URLs that immediately 301, splitting SEO signals.
 - `robots.txt` and `sitemap.xml` are **auto-generated** by `@nuxtjs/robots` and
   `@nuxtjs/sitemap` — there is NO static `public/robots.txt` (it was removed; a
   static file would conflict with the module-owned route). Edit the `robots`
@@ -219,13 +224,14 @@ The first bookmark whose timestamp predates the migration is **not necessarily s
     create one; it silently overrides the config (this resurrected a stale `www`
     sitemap line and a dead `/projects/` rule during setup).
 - The canonical URL comes from `site.url` in `nuxt.config.ts`, which defaults to
-  `https://www.besidka.com` and is overridden at runtime by
-  `NUXT_PUBLIC_BASE_URL`. **Set `NUXT_PUBLIC_BASE_URL=https://www.besidka.com`
-  in the production Worker env** so sitemap/robots/canonical all resolve to www.
+  `https://besidka.com` and is overridden at runtime by
+  `NUXT_PUBLIC_BASE_URL`. **Set `NUXT_PUBLIC_BASE_URL=https://besidka.com`
+  in the production Worker env** so sitemap/robots/canonical all resolve to the
+  apex.
 - Robots indexing is blocked in dev (the module's default); verify production
   rules locally with `curl 'http://localhost:3000/robots.txt?mockProductionEnv'`.
-- Studio OAuth callback URL must also use the `www` host
-  (`https://www.besidka.com/_studio`).
+- Studio OAuth callback URL must also use the apex host
+  (`https://besidka.com/_studio`).
 - **Canonical and `og:url` are derived per route in `app/app.vue`** from
   `useRoute()` — a single source of truth that every page inherits. Do NOT add a
   per-page `canonical` or `ogUrl`; the global one is already correct and a second

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Project board is available [here](https://github.com/orgs/besidka/projects/2).
 
 ## How to try?
 
-1. You are welcome to visit the production site [www.besidka.com](https://www.besidka.com).
+1. You are welcome to visit the production site [besidka.com](https://besidka.com).
 2. Please choose any option of authentication such as Google sign in, GitHub sign in or more common way of the Email + Password flow.
-3. When you are authorized, please put your API keys there: [www.besidka.com/profile/keys](https://www.besidka.com/profile/keys).
-4. You are welcome to start a new chat: [https://www.besidka.com/chats/new](https://www.besidka.com/chats/new)
+3. When you are authorized, please put your API keys there: [besidka.com/profile/keys](https://besidka.com/profile/keys).
+4. You are welcome to start a new chat: [https://besidka.com/chats/new](https://besidka.com/chats/new)
 
 ## Tech stack
 
@@ -161,8 +161,8 @@ Nuxt Content manages its own schema inside `CONTENT_DB` at runtime — no Drizzl
 Studio is optional. The landing page renders and all content is editable via Git without it. Studio adds a `/_studio` route to the deployed site so editors can make changes through a browser UI.
 
 1. Go to GitHub → Settings → Developer settings → OAuth Apps → New OAuth App.
-2. Set **Homepage URL** to `https://www.besidka.com` (the canonical `www` host — a Cloudflare redirect sends the apex `besidka.com` to `www.besidka.com`).
-3. Set **Authorization callback URL** to `https://www.besidka.com/_studio` (production) or `http://localhost:3000/_studio` (development).
+2. Set **Homepage URL** to `https://besidka.com` (the canonical apex host — a Cloudflare redirect sends `www.besidka.com` to `besidka.com`).
+3. Set **Authorization callback URL** to `https://besidka.com/_studio` (production) or `http://localhost:3000/_studio` (development).
 4. Copy the Client ID and generate a Client Secret.
 5. Add them to `.dev.vars` for local development:
    ```

--- a/content/legal/cookie-policy.md
+++ b/content/legal/cookie-policy.md
@@ -7,7 +7,7 @@ summary: "Besidka uses a handful of cookies and browser storage keys, and nothin
 
 ## What this policy covers
 
-This policy explains what Besidka stores in your browser on the hosted service at **www.besidka.com**, and why. It sits alongside the [Privacy Policy](/privacy-policy), which covers everything I store on the server.
+This policy explains what Besidka stores in your browser on the hosted service at **besidka.com**, and why. It sits alongside the [Privacy Policy](/privacy-policy), which covers everything I store on the server.
 
 If you run your own copy of Besidka, this policy does not describe your deployment. You are the operator of it and you set your own policy.
 

--- a/content/legal/privacy-policy.md
+++ b/content/legal/privacy-policy.md
@@ -7,7 +7,7 @@ summary: "Besidka stores your account, chats, files, settings and your encrypted
 
 ## What this policy covers
 
-This policy applies to the hosted service at **www.besidka.com** only.
+This policy applies to the hosted service at **besidka.com** only.
 
 Besidka is open-source software. If you run your own copy of it, **you** are the data controller for that deployment. I have no access to it, and this policy does not apply to it. Under the EU AI Act you would also be the provider or deployer of that system, not me.
 

--- a/content/legal/terms-of-use.md
+++ b/content/legal/terms-of-use.md
@@ -7,7 +7,7 @@ summary: "Besidka is a free AI chat app run by one person in Poland. You bring y
 
 ## Who I am
 
-The hosted Besidka service at **www.besidka.com** is provided by **Serhii Chernenko**, an individual resident in Poland (European Union). Besidka is a personal, non-commercial project and **not a registered business** — there is no company, no sole proprietorship and no VAT registration behind it.
+The hosted Besidka service at **besidka.com** is provided by **Serhii Chernenko**, an individual resident in Poland (European Union). Besidka is a personal, non-commercial project and **not a registered business** — there is no company, no sole proprietorship and no VAT registration behind it.
 
 - Name: **Serhii Chernenko**
 - Email: **:privacy-email-link{}**
@@ -19,7 +19,7 @@ In these terms, "I" and "me" mean the person above, and "you" means the person u
 
 ## What these terms cover
 
-These terms are an agreement between you and me about the **hosted service at www.besidka.com**.
+These terms are an agreement between you and me about the **hosted service at besidka.com**.
 
 They do not cover copies of Besidka that other people run. If you run your own copy, you set your own terms, you are the data controller for it, and under the EU AI Act you are the provider or deployer of that system. I have no access to and no responsibility for it.
 
@@ -194,7 +194,7 @@ Besidka's source code is published under the **MIT licence**. You are free to us
 
 Two things follow that people often get wrong:
 
-1. **The MIT licence covers the source code, not this hosted service.** The MIT "AS IS" disclaimer applies to the code you obtain under that licence. It does not disclaim anything about the service at www.besidka.com. My disclaimers for the service are the ones set out below, and they are subject to the mandatory law described there.
+1. **The MIT licence covers the source code, not this hosted service.** The MIT "AS IS" disclaimer applies to the code you obtain under that licence. It does not disclaim anything about the service at besidka.com. My disclaimers for the service are the ones set out below, and they are subject to the mandatory law described there.
 2. **The MIT licence does not license the "Besidka" name, logo or brand.** You may run your own copy; please do not present it as being Besidka, or use the name or logo in a way that suggests I run it or endorse it.
 
 If you self-host, you are the operator: your users' data is yours to protect, these terms do not apply to your deployment, and you must write your own.

--- a/docs/auth-security.md
+++ b/docs/auth-security.md
@@ -230,10 +230,10 @@ key is set):
       `NUXT_PUBLIC_TURNSTILE_SITE_KEY` (safe to commit — it's
       client-visible by design).
 - [ ] Confirm the widget's configured hostnames include
-      `www.besidka.com` — a mismatch here is exactly the failure mode
+      `besidka.com` — a mismatch here is exactly the failure mode
       `allowedHostnames` exists to prevent, so it will 403 real users if
       the widget's dashboard hostname list drifts from this. Registering
-      the bare apex (`besidka.com`) too is harmless but, per the
+      `www.besidka.com` too is harmless but, per the
       verification note below, not required.
 - [ ] Any preview/staging environment that ever gets its own
       `turnstileSecretKey`/`turnstileSiteKey` for testing must NOT also
@@ -297,15 +297,15 @@ only asserts those where `turnstileEnforced` is `true`. Treat a
 working preview test as proof of wiring, not as proof that production
 enforcement works — only a production test does that.
 
-**The bare apex doesn't need its own hostname entry.** The
+**The `www` host doesn't need its own hostname entry.** The
 `wrangler.jsonc` production `routes` block binds the Worker to both
 `besidka.com` and `www.besidka.com/*`, but a zone-level Cloudflare
-redirect rule (see `docs/seo.md`) 301s the apex to `www.besidka.com`
+redirect rule (see `docs/seo.md`) 301s `www.besidka.com` to the apex
 ahead of that binding, before any HTML or JS loads. The Turnstile
-widget itself is therefore never served from the apex — every real
+widget itself is therefore never served from `www` — every real
 `siteverify` response's `hostname` field will read
-`www.besidka.com`, never `besidka.com`. Registering the apex as an
-allowed hostname in the Cloudflare dashboard anyway is harmless
+`besidka.com`, never `www.besidka.com`. Registering `www.besidka.com`
+as an allowed hostname in the Cloudflare dashboard anyway is harmless
 (hostname allowlisting only widens acceptance, never narrows it) but
 not required for challenges to validate.
 

--- a/docs/domain-migration-www-to-apex.md
+++ b/docs/domain-migration-www-to-apex.md
@@ -1,0 +1,235 @@
+# Domain migration: `www.besidka.com` → `besidka.com`
+
+Canonical production host moves from the `www` subdomain to the bare apex.
+This doc records the pre-migration D1 Time Travel bookmarks, the read-only
+scan that justified skipping a data migration, and the ordered manual
+runbook for the parts of this migration that live outside this repo
+(Cloudflare dashboard, OAuth app consoles, Google Search Console).
+
+## Pre-migration D1 Time Travel bookmarks (2026-08-07)
+
+`production.yml` auto-applies D1 migrations on every merge with **no human
+gate** — so per this repo's D1 migration-safety doctrine (`AGENTS.md`), a
+bookmark is taken before merge regardless of whether this PR touches
+schema (it doesn't). Real database names are `besidka` / `besidka-consent`
+/ `besidka-content` in production, `besidka-preview` /
+`besidka-consent-preview` / `besidka-content-preview` in preview
+(`wrangler.jsonc`) — this supersedes the stale `chat`/`chat-preview` naming
+that was previously in `AGENTS.md`, now fixed.
+
+These bookmarks were taken while writing this doc. **They are snapshots at
+that moment, not a substitute for taking fresh ones immediately before the
+actual merge** — re-run `wrangler d1 time-travel info <db> [--env production]`
+right before clicking merge if meaningful time has passed, and update the
+values below.
+
+```
+# production
+wrangler d1 time-travel restore besidka --env production \
+  --bookmark=00003681-00000000-000050c0-4d0dc14482f789da90c848f8bb63c020
+wrangler d1 time-travel restore besidka-consent --env production \
+  --bookmark=0000002b-00000000-000050c0-3e437a51a50793b32e901c7ef8832456
+wrangler d1 time-travel restore besidka-content --env production \
+  --bookmark=00000425-00000000-000050c0-c10bb06612a4756c9ce67d70c6e4e0d5
+
+# preview
+wrangler d1 time-travel restore besidka-preview \
+  --bookmark=0000243c-00000000-000050c0-423a4117a22902bce6d0cbea9378283a
+wrangler d1 time-travel restore besidka-consent-preview \
+  --bookmark=000000f8-00000000-000050c0-5b7990b0d01feff3c91f81103ce39572
+wrangler d1 time-travel restore besidka-content-preview \
+  --bookmark=0000009f-00000000-000050c0-b514bfce4b946f7d84667d6a6befd072
+```
+
+## Read-only scan for stored `www.besidka.com` references
+
+Searched every text-bearing column that could plausibly store an absolute
+URL to our own domain (`push_subscriptions.endpoint`/`.origin`,
+`chat_shares`, `files.storageKey`, `users.image`). Only one column had
+hits:
+
+```sql
+SELECT origin, COUNT(*) FROM push_subscriptions GROUP BY origin;
+-- null                      -> 2
+-- https://www.besidka.com   -> 8
+```
+
+`push_subscriptions.endpoint` never contains our own domain — it's the
+browser push service's URL (FCM/Mozilla autopush), not besidka.com.
+`chat_shares` stores a ULID slug (relative), not an absolute URL.
+`users.image` stores third-party OAuth avatar URLs, unrelated to this
+domain. `origin` is written from `getRequestURL(event).origin` at
+subscribe time (`server/api/v1/push/subscribe.post.ts`) purely to
+disambiguate preview deployments that share one D1 database
+(`server/utils/push.ts`); production only ever had one origin, so every
+existing row reads `www.besidka.com`.
+
+**No `UPDATE` needed.** `sendPushNotificationToUser()` already falls back
+to the full subscription set whenever none match the caller's
+`targetOrigin` (`server/utils/push.ts:275-280`), so a stale `origin` value
+never silently drops a notification — it's cosmetic bookkeeping, not a
+delivery gate. These 8 rows naturally roll over to `https://besidka.com` as
+each user re-subscribes on the new origin. User-authored chat message
+content is out of scope regardless — never rewrite user data.
+
+## Blast radius (existing users, at cutover)
+
+- **Sessions**: `www.besidka.com`-scoped cookies are host-only. Every
+  signed-in user is logged out and must sign in again on `besidka.com`.
+  One-time, expected, not a bug.
+- **Push notifications / installed PWAs**: existing subscriptions are
+  registered against the `www` origin's service worker scope. Expected to
+  keep working with no user action — a service worker persists and keeps
+  receiving pushes without a revisit, and a notification's click-through
+  URL just 301s from `www` to the apex. Once a user does revisit and
+  re-subscribes on the apex, `sendPushNotificationToUser()`'s per-user
+  origin filter targets only the matching-origin subscription, so no
+  duplicate notifications. Worst case (service-worker eviction or similar)
+  is re-enabling notifications on the apex — the fallback, not the
+  expected outcome.
+- **Passkeys**: unaffected. `getRelyingPartyId()` already normalizes both
+  `besidka.com` and `www.besidka.com` to the same RP ID `besidka.com`
+  (`server/utils/auth-hosts.ts`, covered by
+  `tests/unit/utils/auth-hosts.spec.ts`). No user re-registration.
+- **SEO**: 301s preserve link equity; expect a short reindexing wobble
+  while Google migrates the canonical.
+
+## Why this is safe to ship as one PR
+
+Everything in this repo derives canonical identity from one runtime value,
+`NUXT_PUBLIC_BASE_URL`. Two host-normalizing utilities make the cutover
+tolerant in both directions, so flipping that one value is the only code
+change that alters behavior:
+
+- `getAllowedHosts()` (`server/utils/auth-hosts.ts`) returns
+  `[apex, www.apex]` for either input — both hosts stay valid Better Auth
+  origins and Turnstile allowed hostnames throughout the migration.
+- `getRelyingPartyId()` already strips a leading `www.` — the WebAuthn
+  RP-ID is `besidka.com` today and stays `besidka.com` after.
+
+The serving host itself is controlled by a **zone-level Cloudflare
+redirect rule** (dashboard-only, not in this repo) that currently 301s
+apex → www ahead of the Worker's routes. The Worker already binds both
+hosts (`wrangler.jsonc` production `routes`) and this PR keeps both
+bindings — the www route becomes a dormant fallback once the rule flips,
+which costs nothing and avoids a www 522 if the rule is ever unset. The
+only infrastructure change is flipping that one rule's direction.
+
+## Manual runbook (owner, outside this repo — cannot be automated here)
+
+The Cloudflare API token available in this environment has `zone:read`
+only (confirmed via `wrangler whoami`) — no `Zone > Single Redirect > Edit`
+or DNS-write scope — so every Cloudflare-dashboard step below is a manual
+action. GitHub's OAuth Apps REST API also has no endpoint for changing
+callback/homepage URLs — those are dashboard-only too.
+
+### Phase 0 — any time before merge (de-risking, zero-cost)
+
+1. **Google Cloud Console** (OAuth client for Better Auth's Google
+   provider): add `https://besidka.com/api/auth/callback/google` as an
+   additional authorized redirect URI, and `https://besidka.com` as an
+   additional authorized JavaScript origin. Google supports multiple URIs
+   simultaneously — both coexist, this is purely additive.
+2. **Turnstile** dashboard: confirm the existing widget's allowed
+   hostnames already include the bare apex `besidka.com` (repo docs
+   suggest it may already be registered for both — verify live, add if
+   missing). Keep `www.besidka.com` listed too.
+3. **Locate the existing apex→www redirect** in the Cloudflare dashboard
+   for the `besidka.com` zone — check **Rules → Overview** first (current
+   product name: "Single Redirects", dashboard label "Redirect Rules");
+   if it's not there, check legacy **Page Rules** and **Bulk Redirects**
+   too, since this repo's docs assert the rule exists and fires ahead of
+   the Worker but not which product implements it. Confirm you can edit
+   it. **Do not change it yet.**
+
+   GitHub OAuth Apps (both Better Auth's provider app and Nuxt Studio's,
+   which is also a classic OAuth App) support only **one** callback URL
+   each — unlike Google, there is no way to dual-register here, so their
+   swap has to happen during the cutover itself (Phase 1), not now.
+
+### Phase 1 — cutover: merge, flip, and swap, back-to-back
+
+**This is not three loosely-ordered steps — it's one operation split
+across three actions with no deliberate pause between them.** Do not
+merge and then leave the apex→www rule live "for a bit" before flipping
+it, and do not treat "canonical tags briefly disagree with the redirect
+direction" as the only cost of a gap here. Better Auth's OAuth-proxy
+plugin (`oAuthProxy({ productionURL: config.public.baseUrl })` in
+`server/utils/auth.ts`) activates precisely when the *configured*
+`NUXT_PUBLIC_BASE_URL` disagrees with the *actual* serving origin of the
+current request (`checkSkipProxy`/`resolveCurrentURL` in Better Auth's
+`plugins/oauth-proxy/utils.mjs`) — which is exactly the state that exists
+the moment this PR's deploy completes but the redirect rule hasn't
+flipped yet. In that window, the proxy forces the OAuth `redirect_uri`
+sent to the provider onto the apex, but the still-active *old* apex→www
+rule then bounces the provider's callback hit back to `www` before it
+reaches the Worker — so the `redirect_uri` seen at token-exchange no
+longer matches the one used at authorization, and the provider rejects
+it. **This breaks both Google and GitHub sign-in for the duration of the
+gap, not only GitHub** — Google's dual-registered redirect URI (Phase 0)
+doesn't help, because the mismatch happens on a single attempt's two ends
+disagreeing, not because either URI individually is unregistered. Take
+fresh D1 bookmarks immediately before starting (see above), then:
+
+1. **Merge this PR.** `production.yml` deploys with
+   `NUXT_PUBLIC_BASE_URL=https://besidka.com`.
+2. **The instant the deploy finishes, flip the redirect rule — edit it in
+   place, do not delete-then-create** (a moment with both directions live
+   is an infinite redirect loop). Reconfigure the existing rule directly:
+   match `Hostname equals www.besidka.com`, action = dynamic 301 redirect
+   to `concat("https://besidka.com", http.request.uri.path)` with
+   **preserve query string** enabled (load-bearing: OAuth `code`/`state`
+   params must survive the redirect), status **301**. Confirm the `www`
+   DNS record stays **Proxied** (orange-cloud) — Single Redirects only
+   fire on proxied traffic.
+3. **Immediately after the flip**, swap both single-callback-URL OAuth
+   apps — changing only the **host**, keeping the **path** exactly as
+   currently registered (don't guess a new path; whatever's in the field
+   today already works):
+   - Better Auth's GitHub OAuth App (`github.com/settings/developers` →
+     OAuth Apps): Authorization callback URL host → `besidka.com`,
+     Homepage URL → `https://besidka.com`.
+   - Nuxt Studio's GitHub OAuth App: Authorization callback URL host →
+     `besidka.com` (keep its existing path, whether `/_studio` or
+     `/__nuxt_studio/auth/github`), Homepage URL → `https://besidka.com`.
+
+Expect any social sign-in attempted between steps 1 and 2 to fail — that
+is this migration's one unavoidable outage, and it is expected and
+self-resolving the moment the flip lands, not a sign of a bug. Keeping
+steps 1-3 tight (minutes, ideally less) is what bounds it. Email/password,
+2FA, and passkeys are unaffected throughout — only the social-provider
+round trip depends on serving-origin/baseURL agreement.
+
+### Phase 2 — verification (immediately after the flip)
+
+```bash
+curl -sI https://www.besidka.com/                  # expect 301 -> https://besidka.com/
+curl -sI "https://www.besidka.com/chats/new?x=1"    # expect 301 preserving path+query
+curl -sI https://besidka.com/                       # expect 200 from the Worker
+curl -s https://besidka.com/robots.txt              # sitemap line uses apex
+curl -s https://besidka.com/sitemap.xml | head       # <loc> uses apex
+```
+
+Then manually: sign in on `https://besidka.com` with email/password,
+Google, GitHub, and a passkey; confirm Turnstile renders on sign-in/sign-up;
+view page source for the apex canonical tag and JSON-LD `@id`s; load
+`/_studio` (Nuxt Studio OAuth).
+
+### Phase 3 — post-cutover (same day / following days)
+
+- **Google Search Console**: if the property is a *Domain* property
+  (`besidka.com`), it already covers both hosts — just submit
+  `https://besidka.com/sitemap.xml`. If it's a URL-prefix property on
+  `https://www.besidka.com`, add a new apex URL-prefix property, submit
+  the apex sitemap there, and keep (don't delete) the www property to
+  watch the 301s drain. Optionally use Search Console's Change of Address
+  tool (www property → apex property).
+- **Cleanup**: after ~1–2 weeks of confirmed-stable apex sign-ins,
+  optionally remove the now-unused www callback URLs from Google/GitHub/
+  Studio. Keeping them costs nothing and preserves a rollback path.
+- **Rollback**, if anything goes wrong: re-flip the redirect rule (edit in
+  place, back to the www-canonical direction), revert this PR (restores
+  `NUXT_PUBLIC_BASE_URL=https://www.besidka.com`), redeploy — the www
+  OAuth callbacks are still registered throughout, so auth recovers
+  immediately. D1 bookmarks above exist in case anything unexpected
+  touched data.

--- a/docs/landing-production-todo.md
+++ b/docs/landing-production-todo.md
@@ -120,11 +120,11 @@ The production environment is **`env.production`** in `wrangler.jsonc`.
     resulting server-side data storage.
 - [ ] **Carousel mockups**: replace the placeholder SVG mockups
   (`public/preview-*.svg`) with real product screenshots.
-- [ ] **Canonical host**: a Cloudflare redirect rule sends the apex
-  (`besidka.com`) to `www.besidka.com`, so the canonical host is the **www
-  subdomain**. The SEO modules plus robots/sitemap standardize on
-  `https://www.besidka.com`, sourced from `NUXT_PUBLIC_BASE_URL`. Set
-  `NUXT_PUBLIC_BASE_URL` to `https://www.besidka.com` in the production Worker
-  env so sitemap, robots, and canonical URLs match the post-redirect host.
-  (`nuxt.config.ts` `site.url` already defaults to `https://www.besidka.com`;
-  the env var is the runtime override.)
+- [ ] **Canonical host**: a Cloudflare redirect rule sends `www.besidka.com`
+  to the apex (`besidka.com`), so the canonical host is the **bare apex**. The
+  SEO modules plus robots/sitemap standardize on `https://besidka.com`,
+  sourced from `NUXT_PUBLIC_BASE_URL`. Set `NUXT_PUBLIC_BASE_URL` to
+  `https://besidka.com` in the production Worker env so sitemap, robots, and
+  canonical URLs match the post-redirect host. (`nuxt.config.ts` `site.url`
+  already defaults to `https://besidka.com`; the env var is the runtime
+  override.)

--- a/docs/landing-studio.md
+++ b/docs/landing-studio.md
@@ -72,9 +72,9 @@ The `/_studio` GitHub sign-in requires a **GitHub OAuth App**. Dev has no
 Worker:
 
 1. GitHub → Settings → Developer settings → OAuth Apps → **New OAuth App**.
-2. **Authorization callback URL**: `https://www.besidka.com/_studio`
-   (production — use the `www` host, since a Cloudflare redirect sends the apex
-   to `www.besidka.com`) or the preview Worker URL + `/_studio`.
+2. **Authorization callback URL**: `https://besidka.com/_studio`
+   (production — use the apex host, since a Cloudflare redirect sends
+   `www.besidka.com` to the apex) or the preview Worker URL + `/_studio`.
    `http://localhost:3000/_studio` is **not** needed — dev has no `/_studio`
    route.
 3. Provide the client id/secret to the deployed Worker as wrangler secrets:

--- a/docs/p95-endpoint-optimization.md
+++ b/docs/p95-endpoint-optimization.md
@@ -170,9 +170,9 @@ cannot be pushed below Google's own round-trip time. **Not fixed.**
 The gap between the two observed samples (3220ms vs 1530ms) is plausibly
 explained by Better Auth's `oAuthProxy({ productionURL })` plugin: its
 `checkSkipProxy` logic forces the entire OAuth exchange onto
-`productionURL`'s origin (`https://www.besidka.com`) with an extra redirect
+`productionURL`'s origin (`https://besidka.com`) with an extra redirect
 round-trip whenever the request's current origin differs — e.g. a sign-in
-starting on the bare apex domain or a preview URL. This is **unverified** —
+starting on the `www` subdomain or a preview URL. This is **unverified** —
 it requires checking which origins the slow samples in Axiom actually came
 from, which needs Axiom access this work didn't have. **Investigate before
 touching** — don't change `baseURL`/proxy config on this hypothesis alone.

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -9,14 +9,14 @@ Companion reading: `docs/landing-studio.md` for how the landing copy is edited,
 
 ## Canonical host
 
-Canonical host is `www.besidka.com`. A Cloudflare redirect rule 301s the apex
-(`besidka.com`) to `https://www.besidka.com/`, so every crawler-facing URL must
-use `www` to match the post-redirect host — advertising apex URLs would publish
-links that immediately redirect and split the signal.
+Canonical host is the bare apex `besidka.com`. A Cloudflare redirect rule 301s
+`www.besidka.com` to the apex (`https://besidka.com/`), so every crawler-facing
+URL must use the apex to match the post-redirect host — advertising `www` URLs
+would publish links that immediately redirect and split the signal.
 
-`site.url` in `nuxt.config.ts` defaults to `https://www.besidka.com` and is
+`site.url` in `nuxt.config.ts` defaults to `https://besidka.com` and is
 overridden at runtime by `NUXT_PUBLIC_BASE_URL`. **That variable must be set to
-`https://www.besidka.com` in the production Worker env**, or sitemap, robots and
+`https://besidka.com` in the production Worker env**, or sitemap, robots and
 canonical all resolve to the wrong host.
 
 Verified DNS state (no action needed): Cloudflare nameservers, SPF via
@@ -45,7 +45,7 @@ Two properties this deliberately buys:
   `ogUrl: baseUrl`, so all 15 routes advertised the home page as their `og:url`,
   and `/privacy` + `/terms` shipped no canonical at all.
 - **Trailing-slash agreement.** `new URL('/', base).href` normalises to
-  `https://www.besidka.com/` — byte-identical to the `<loc>` that
+  `https://besidka.com/` — byte-identical to the `<loc>` that
   `@nuxtjs/sitemap` emits. The two used to disagree (canonical had no slash),
   which is exactly the signal split canonicalisation exists to prevent.
 
@@ -297,7 +297,7 @@ preview host rather than to production, which is harmless precisely because the
 header keeps them out of the index.
 
 Note the asymmetry when reading preview output: `robots.txt` and `sitemap.xml`
-on a preview host correctly advertise the **production** `https://www.besidka.com`
+on a preview host correctly advertise the **production** `https://besidka.com`
 URLs (they come from `site.url`), while the in-page canonical comes from the
 runtime `baseUrl` and therefore shows the preview host. Both are expected.
 
@@ -322,9 +322,9 @@ confirming manually:
 - Property type: a **Domain** property (`besidka.com`) covers apex + `www` +
   all subdomains; a URL-prefix property covers only the exact host. If only a
   URL-prefix property for one host exists, data is partial.
-- `https://www.besidka.com/sitemap.xml` is submitted and last read without
+- `https://besidka.com/sitemap.xml` is submitted and last read without
   errors.
-- The apex reporting "Page with redirect" is **expected and correct** — it is
-  the 301 to `www` working as designed, not an indexing failure.
+- `www` reporting "Page with redirect" is **expected and correct** — it is
+  the 301 to the apex working as designed, not an indexing failure.
 - Watch the `besidka` and `besidka ai` queries specifically for impressions and
   average position, which is how the entity work above gets measured.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -178,11 +178,12 @@ export default defineNuxtConfig({
     },
   },
   site: {
-    // Canonical host is the www subdomain: a Cloudflare redirect rule sends
-    // the apex (besidka.com) to www.besidka.com, so robots/sitemap/canonical
-    // URLs must use www to match the post-redirect host. Override at runtime
-    // with NUXT_PUBLIC_BASE_URL (set it to https://www.besidka.com in prod).
-    url: process.env.NUXT_PUBLIC_BASE_URL || 'https://www.besidka.com',
+    // Canonical host is the apex: a Cloudflare redirect rule sends
+    // www.besidka.com to the apex (besidka.com), so robots/sitemap/canonical
+    // URLs must use the apex to match the post-redirect host. Override at
+    // runtime with NUXT_PUBLIC_BASE_URL (set it to https://besidka.com in
+    // prod).
+    url: process.env.NUXT_PUBLIC_BASE_URL || 'https://besidka.com',
     name: 'Besidka',
   },
   // /signin, /signup and /reset-password are crawler-reachable and rely on a

--- a/tests/unit/config/seo.spec.ts
+++ b/tests/unit/config/seo.spec.ts
@@ -64,10 +64,10 @@ describe('robots and sitemap configuration contract', () => {
   )
 
   it(
-    'falls back the canonical site URL to the www host when '
+    'falls back the canonical site URL to the apex host when '
     + 'NUXT_PUBLIC_BASE_URL is unset',
     () => {
-      expect(configuration.site?.url).toBe('https://www.besidka.com')
+      expect(configuration.site?.url).toBe('https://besidka.com')
     },
   )
 })

--- a/tests/unit/utils/auth-captcha.spec.ts
+++ b/tests/unit/utils/auth-captcha.spec.ts
@@ -29,7 +29,7 @@ function createConfig(overrides: Partial<{
     turnstileSecretKey = 'test-secret',
     turnstileEnforced = false,
     turnstileSiteKey = 'test-sitekey',
-    baseUrl = 'https://www.besidka.com',
+    baseUrl = 'https://besidka.com',
   } = overrides
 
   return {
@@ -109,15 +109,32 @@ describe('getCaptchaOptions', () => {
   it('sets expectedAction and allowedHostnames when enforced', () => {
     const options = getCaptchaOptions(createConfig({
       turnstileEnforced: true,
-      baseUrl: 'https://www.besidka.com',
+      baseUrl: 'https://besidka.com',
     }))
 
     expect(options?.expectedAction).toBe('auth')
     expect(options?.allowedHostnames).toEqual([
-      'www.besidka.com',
       'besidka.com',
+      'www.besidka.com',
     ])
   })
+
+  it(
+    'sets the same allowedHostnames pair when the configured base URL '
+    + 'is still the legacy www host',
+    () => {
+      const options = getCaptchaOptions(createConfig({
+        turnstileEnforced: true,
+        baseUrl: 'https://www.besidka.com',
+      }))
+
+      expect(options?.expectedAction).toBe('auth')
+      expect(options?.allowedHostnames).toEqual([
+        'www.besidka.com',
+        'besidka.com',
+      ])
+    },
+  )
 
   it('strips ports and wildcards getAllowedHosts would otherwise produce', () => {
     const options = getCaptchaOptions(createConfig({

--- a/tests/unit/utils/canonical.spec.ts
+++ b/tests/unit/utils/canonical.spec.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import { buildCanonicalUrl } from '../../../app/utils/canonical'
 
-const ORIGIN = 'https://www.besidka.com'
+const ORIGIN = 'https://besidka.com'
 
 describe('buildCanonicalUrl', () => {
   it('preserves the trailing slash on the root path', () => {
     const canonicalUrl = buildCanonicalUrl(ORIGIN, '/')
 
-    expect(canonicalUrl).toBe('https://www.besidka.com/')
+    expect(canonicalUrl).toBe('https://besidka.com/')
   })
 
   it('builds a canonical URL for a plain path', () => {
     const canonicalUrl = buildCanonicalUrl(ORIGIN, '/privacy')
 
-    expect(canonicalUrl).toBe('https://www.besidka.com/privacy')
+    expect(canonicalUrl).toBe('https://besidka.com/privacy')
   })
 
   it(
@@ -22,14 +22,14 @@ describe('buildCanonicalUrl', () => {
     () => {
       const canonicalUrl = buildCanonicalUrl(ORIGIN, '/privacy/')
 
-      expect(canonicalUrl).toBe('https://www.besidka.com/privacy')
+      expect(canonicalUrl).toBe('https://besidka.com/privacy')
     },
   )
 
   it('strips multiple trailing slashes down to one path', () => {
     const canonicalUrl = buildCanonicalUrl(ORIGIN, '/privacy///')
 
-    expect(canonicalUrl).toBe('https://www.besidka.com/privacy')
+    expect(canonicalUrl).toBe('https://besidka.com/privacy')
   })
 
   it(
@@ -38,7 +38,7 @@ describe('buildCanonicalUrl', () => {
     () => {
       const canonicalUrlWithoutSlash = buildCanonicalUrl(ORIGIN, '/privacy')
       const canonicalUrlWithSlash = buildCanonicalUrl(
-        'https://www.besidka.com/',
+        'https://besidka.com/',
         '/privacy',
       )
 
@@ -56,11 +56,11 @@ describe('buildCanonicalUrl', () => {
     + 'into the canonical URL',
     () => {
       const canonicalUrl = buildCanonicalUrl(
-        'https://www.besidka.com/?ref=x#frag',
+        'https://besidka.com/?ref=x#frag',
         '/privacy',
       )
 
-      expect(canonicalUrl).toBe('https://www.besidka.com/privacy')
+      expect(canonicalUrl).toBe('https://besidka.com/privacy')
     },
   )
 
@@ -76,7 +76,7 @@ describe('buildCanonicalUrl', () => {
       )
       const canonicalUrlHost = new URL(canonicalUrl).host
 
-      expect(canonicalUrlHost).toBe('www.besidka.com')
+      expect(canonicalUrlHost).toBe('besidka.com')
     },
   )
 
@@ -88,7 +88,7 @@ describe('buildCanonicalUrl', () => {
       const canonicalUrl = buildCanonicalUrl(ORIGIN, '//evil.com/foo')
       const canonicalUrlHost = new URL(canonicalUrl).host
 
-      expect(canonicalUrlHost).toBe('www.besidka.com')
+      expect(canonicalUrlHost).toBe('besidka.com')
     },
   )
 
@@ -96,6 +96,6 @@ describe('buildCanonicalUrl', () => {
     const path = '/shared/01KYFB1TAKRQNHJKAFR5MJR2WD'
     const canonicalUrl = buildCanonicalUrl(ORIGIN, path)
 
-    expect(canonicalUrl).toBe(`https://www.besidka.com${path}`)
+    expect(canonicalUrl).toBe(`https://besidka.com${path}`)
   })
 })

--- a/tests/unit/utils/landing-jsonld.spec.ts
+++ b/tests/unit/utils/landing-jsonld.spec.ts
@@ -8,7 +8,7 @@ import {
   buildWebSiteLd,
 } from '../../../app/utils/landing-jsonld'
 
-const BASE_URL = 'https://www.besidka.com'
+const BASE_URL = 'https://besidka.com'
 
 const INPUT = {
   baseUrl: BASE_URL,
@@ -37,23 +37,23 @@ function collectGraphIdReferences(node: Record<string, unknown>) {
 
 describe('buildLandingLdIds', () => {
   it('normalises a base URL without a trailing slash to siteUrl with one', () => {
-    const ids = buildLandingLdIds('https://www.besidka.com')
+    const ids = buildLandingLdIds('https://besidka.com')
 
-    expect(ids.siteUrl).toBe('https://www.besidka.com/')
+    expect(ids.siteUrl).toBe('https://besidka.com/')
   })
 
   it('is idempotent when the base URL already has a trailing slash', () => {
-    const ids = buildLandingLdIds('https://www.besidka.com/')
+    const ids = buildLandingLdIds('https://besidka.com/')
 
-    expect(ids.siteUrl).toBe('https://www.besidka.com/')
+    expect(ids.siteUrl).toBe('https://besidka.com/')
   })
 
   it('derives @id values from the normalised siteUrl', () => {
     const ids = buildLandingLdIds(BASE_URL)
 
-    expect(ids.organizationId).toBe('https://www.besidka.com/#organization')
-    expect(ids.websiteId).toBe('https://www.besidka.com/#website')
-    expect(ids.applicationId).toBe('https://www.besidka.com/#software')
+    expect(ids.organizationId).toBe('https://besidka.com/#organization')
+    expect(ids.websiteId).toBe('https://besidka.com/#website')
+    expect(ids.applicationId).toBe('https://besidka.com/#software')
   })
 })
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -141,7 +141,7 @@
 				}
 			},
 			"vars": {
-				"NUXT_PUBLIC_BASE_URL": "https://www.besidka.com",
+				"NUXT_PUBLIC_BASE_URL": "https://besidka.com",
 				"NUXT_PUBLIC_PRIVACY_EMAIL": "privacy@besidka.com",
 				"NUXT_PUBLIC_AUTHOR_GITHUB_PROFILE": "https://github.com/serhii-chernenko",
 				"NUXT_EMAIL_SENDER_NOREPLY": "noreply@besidka.com",


### PR DESCRIPTION
## Summary

Drops the `www` subdomain in favor of the bare apex as the canonical production host, per owner request ("no more www, it only bothers me in nuances").

- `NUXT_PUBLIC_BASE_URL` (the single source of truth for canonical URL, sitemap, robots, JSON-LD, Better Auth `baseURL`, Turnstile allowed hostnames, and the OAuth proxy's `productionURL`) flips from `https://www.besidka.com` to `https://besidka.com` in `wrangler.jsonc`'s production `vars`, plus the matching `nuxt.config.ts` fallback.
- Docs, README, `.dev.vars.example`, and legal content (`content/legal/*.md`) updated to describe/link the apex host instead of `www`.
- 4 test spec files flip their expected canonical values to the apex while **keeping** the legacy `www.besidka.com`-as-input regression cases in `auth-hosts.spec.ts`/`auth-captcha.spec.ts` (those functions are already host-direction-symmetric).
- New `docs/domain-migration-www-to-apex.md`: D1 Time Travel bookmarks, a read-only scan that ruled out any stored-URL data migration, blast-radius notes, and the ordered manual runbook for everything below that lives outside this repo.

### Explicit non-changes

- `server/utils/auth-hosts.ts` (`getAllowedHosts`, `getRelyingPartyId`) and `server/utils/auth-captcha.ts` — unchanged. Both already normalize `besidka.com` and `www.besidka.com` symmetrically regardless of which is configured as the base URL, so WebAuthn's relying-party ID, Better Auth's allowed origins, and Turnstile's allowed hostnames all need zero code changes.
- `wrangler.jsonc`'s `www.besidka.com/*` Worker route — kept. It becomes a dormant fallback once the Cloudflare redirect rule flips (see below), so it costs nothing and avoids a `www` 522 if that rule is ever unset.

## Blast radius (for existing users, at cutover)

- **Sessions**: `www`-scoped cookies are host-only — every signed-in user is logged out and signs in again on the apex. Expected, one-time.
- **Push notifications / installed PWAs**: existing subscriptions are scoped to the `www` origin's service worker. Expected to keep working with no user action (a SW persists without a revisit, and notification click-through URLs 301 from `www` to the apex); worst case is re-enabling notifications on the apex.
- **Passkeys**: unaffected — the relying-party ID was already the apex (`www` stripped) before this change.

## Manual steps — need your action, cannot be automated from this repo

Full detail and exact field values in `docs/domain-migration-www-to-apex.md`. Summary:

**Before merge (de-risking, zero cost):**
1. Google Cloud Console — add `https://besidka.com/api/auth/callback/google` + apex JS origin as additional entries (Google allows multiple, this is additive).
2. Cloudflare Turnstile dashboard — confirm the widget's allowed hostnames already include the bare apex.
3. Locate the existing apex→www Cloudflare redirect rule (Rules → Overview, or check legacy Page Rules/Bulk Redirects) and confirm you can edit it — don't change it yet.

**At merge — this is one tight operation, not three loosely-ordered steps:**
1. Merge → deploy.
2. The instant the deploy finishes, flip the redirect rule in place (edit, don't delete-then-recreate) to `www.besidka.com` → `besidka.com`, 301, preserving path + query string.
3. Immediately after, swap the callback host (keep the existing path) on both GitHub OAuth apps — Better Auth's provider app and Nuxt Studio's — since GitHub only supports one callback URL each, unlike Google.

Why the tight timing matters: Better Auth's `oAuthProxy` plugin activates whenever the configured base URL disagrees with a request's actual serving origin — exactly the state between steps 1 and 2. In that gap, **both Google and GitHub social sign-in will fail** (not just GitHub), because the redirect_uri built for the apex gets bounced back to `www` by the still-active old rule before the callback lands, causing a redirect_uri mismatch at token exchange. This is expected and self-resolves the moment the rule flips — keep the window as short as possible. Email/password, 2FA, and passkeys are unaffected throughout.

**After cutover:** verify with the curl checks in the runbook doc, sign in with each method manually, then handle Google Search Console (apex property + sitemap resubmit).

**No GitHub Actions secrets or Cloudflare env secrets carry the host** — `NUXT_PUBLIC_BASE_URL` is a committed `wrangler.jsonc` var, so the deploy itself completes the code-side config; only the dashboard/console steps above are outstanding.

## D1

Time Travel bookmarks for all 6 databases (`besidka`, `besidka-consent`, `besidka-content` + previews) taken and recorded in `docs/domain-migration-www-to-apex.md`, per this repo's D1 migration-safety doctrine — even though this PR touches no schema, `production.yml` auto-applies migrations on every merge with no gate. A read-only scan found only 8 cosmetic `push_subscriptions.origin` rows referencing `www.besidka.com`; no `UPDATE` needed (`sendPushNotificationToUser()` already falls back to the full subscription set when none match).

## Test plan

- [x] `pnpm run format && pnpm run typecheck` — clean
- [x] Targeted specs (`seo`, `auth-hosts`, `auth-captcha`, `canonical`, `landing-jsonld`) — all passing
- [x] Full unit + integration suite — 1874 tests passing
- [ ] After merge: execute the manual runbook in `docs/domain-migration-www-to-apex.md` and verify sign-in (email/password, Google, GitHub, passkey) on `https://besidka.com`