### PR TITLE
ci: reduce build time via runner reallocation and e2e fix

### DIFF
--- a/.github/pr-media/ci-e2e-fix/figure-1-mechanism-before.svg
+++ b/.github/pr-media/ci-e2e-fix/figure-1-mechanism-before.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 320" font-family="ui-monospace, Menlo, Consolas, monospace">
+  <rect x="0" y="0" width="800" height="320" rx="8" fill="#ffffff" stroke="#d8dbe2" stroke-width="1" />
+  <text x="20" y="30" font-size="14" font-weight="600" fill="#14161c">Why parallel e2e workers used to corrupt each other</text>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#14161c" />
+    </marker>
+    <marker id="arrowAccent" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#c9581c" />
+    </marker>
+  </defs>
+
+  <g transform="translate(20,50)" font-size="11">
+    <rect x="10" y="86" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="85" y="106" text-anchor="middle" fill="#14161c">PR push</text>
+    <text x="85" y="120" text-anchor="middle" fill="#5b5f6b">job starts</text>
+
+    <rect x="210" y="86" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="285" y="106" text-anchor="middle" fill="#14161c">Nuxt dev server</text>
+    <text x="285" y="120" text-anchor="middle" fill="#5b5f6b">boots (Vite)</text>
+
+    <line x1="160" y1="110" x2="208" y2="110" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow)" />
+
+    <rect x="410" y="20" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="485" y="40" text-anchor="middle" fill="#14161c">Worker A page</text>
+    <text x="485" y="54" text-anchor="middle" fill="#5b5f6b">imports new pkg</text>
+
+    <rect x="410" y="188" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="485" y="208" text-anchor="middle" fill="#14161c">Worker B page</text>
+    <text x="485" y="222" text-anchor="middle" fill="#5b5f6b">mid 2FA-code test</text>
+
+    <path d="M285,86 Q340,60 408,44" fill="none" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow)" />
+    <path d="M285,134 Q340,180 408,212" fill="none" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow)" />
+
+    <rect x="600" y="20" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="675" y="40" text-anchor="middle" fill="#14161c">Vite pre-bundles</text>
+    <text x="675" y="54" text-anchor="middle" fill="#5b5f6b">the dependency</text>
+
+    <line x1="560" y1="44" x2="598" y2="44" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow)" />
+
+    <rect x="600" y="188" width="150" height="48" rx="6" fill="#fbe3d3" stroke="#c9581c" stroke-width="1.6" />
+    <text x="675" y="206" text-anchor="middle" fill="#c9581c" font-weight="600">context destroyed</text>
+    <text x="675" y="220" text-anchor="middle" fill="#c9581c" font-weight="600">→ flake</text>
+
+    <line x1="675" y1="68" x2="675" y2="186" stroke="#c9581c" stroke-width="1.6" marker-end="url(#arrowAccent)" />
+    <text x="686" y="120" font-size="10.5" fill="#c9581c" font-weight="600">HMR: reload ALL</text>
+    <text x="686" y="132" font-size="10.5" fill="#c9581c" font-weight="600">connected pages</text>
+
+    <line x1="560" y1="212" x2="598" y2="212" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow)" />
+  </g>
+</svg>

--- a/.github/pr-media/ci-e2e-fix/figure-2-mechanism-after.svg
+++ b/.github/pr-media/ci-e2e-fix/figure-2-mechanism-after.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 320" font-family="ui-monospace, Menlo, Consolas, monospace">
+  <rect x="0" y="0" width="800" height="320" rx="8" fill="#ffffff" stroke="#d8dbe2" stroke-width="1" />
+  <text x="20" y="30" font-size="14" font-weight="600" fill="#14161c">Why a built app can't have this problem</text>
+
+  <defs>
+    <marker id="arrow2" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#14161c" />
+    </marker>
+  </defs>
+
+  <g transform="translate(20,50)" font-size="11">
+    <rect x="10" y="86" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="85" y="106" text-anchor="middle" fill="#14161c">PR push</text>
+    <text x="85" y="120" text-anchor="middle" fill="#5b5f6b">job starts</text>
+
+    <rect x="210" y="86" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="285" y="102" text-anchor="middle" fill="#14161c">build → .output/,</text>
+    <text x="285" y="116" text-anchor="middle" fill="#14161c">serve via</text>
+    <text x="285" y="130" text-anchor="middle" fill="#14161c">wrangler dev</text>
+
+    <line x1="160" y1="110" x2="208" y2="110" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow2)" />
+
+    <rect x="410" y="20" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="485" y="40" text-anchor="middle" fill="#14161c">Worker A page</text>
+    <text x="485" y="54" text-anchor="middle" fill="#5b5f6b">connects, runs test</text>
+
+    <rect x="410" y="188" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="485" y="208" text-anchor="middle" fill="#14161c">Worker B page</text>
+    <text x="485" y="222" text-anchor="middle" fill="#5b5f6b">connects, runs test</text>
+
+    <path d="M285,86 Q340,60 408,44" fill="none" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow2)" />
+    <path d="M285,134 Q340,180 408,212" fill="none" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow2)" />
+
+    <rect x="600" y="20" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="675" y="40" text-anchor="middle" fill="#14161c">test completes</text>
+    <text x="675" y="54" text-anchor="middle" fill="#5b5f6b">independently</text>
+
+    <line x1="560" y1="44" x2="598" y2="44" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow2)" />
+
+    <rect x="600" y="188" width="150" height="48" rx="6" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+    <text x="675" y="206" text-anchor="middle" fill="#14161c">test completes</text>
+    <text x="675" y="220" text-anchor="middle" fill="#5b5f6b">independently</text>
+
+    <line x1="560" y1="212" x2="598" y2="212" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow2)" />
+
+    <rect x="600" y="94" width="150" height="66" rx="6" fill="none" stroke="#5b5f6b" stroke-width="1" stroke-dasharray="4 4" opacity="0.85" />
+    <text x="675" y="120" text-anchor="middle" fill="#5b5f6b">✗ no pre-bundle step</text>
+    <text x="675" y="136" text-anchor="middle" fill="#5b5f6b">✗ no HMR channel</text>
+    <text x="675" y="152" text-anchor="middle" fill="#5b5f6b">— nothing to broadcast</text>
+  </g>
+
+</svg>

--- a/.github/pr-media/ci-e2e-fix/figure-3-pipeline-reorder.svg
+++ b/.github/pr-media/ci-e2e-fix/figure-3-pipeline-reorder.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 340" font-family="ui-monospace, Menlo, Consolas, monospace">
+  <rect x="0" y="0" width="1080" height="340" rx="8" fill="#ffffff" stroke="#d8dbe2" stroke-width="1" />
+  <text x="20" y="30" font-size="14" font-weight="600" fill="#14161c">What changed in the CI YAML</text>
+
+  <defs>
+    <marker id="arrow3" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#14161c" />
+    </marker>
+    <marker id="arrow3accent" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#c9581c" />
+    </marker>
+  </defs>
+
+  <g transform="translate(20,50)" font-size="11">
+    <text x="0" y="10" font-size="11" letter-spacing="1" fill="#5b5f6b">BEFORE</text>
+    <g>
+      <rect x="0" y="24" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="65" y="43" text-anchor="middle" fill="#14161c">setup + lint</text>
+      <text x="65" y="57" text-anchor="middle" fill="#5b5f6b">+ typecheck</text>
+
+      <line x1="130" y1="47" x2="146" y2="47" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="148" y="24" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="213" y="43" text-anchor="middle" fill="#14161c">unit +</text>
+      <text x="213" y="57" text-anchor="middle" fill="#5b5f6b">integration tests</text>
+
+      <line x1="278" y1="47" x2="294" y2="47" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="296" y="24" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="361" y="43" text-anchor="middle" fill="#14161c">apply D1</text>
+      <text x="361" y="57" text-anchor="middle" fill="#5b5f6b">migrations</text>
+
+      <line x1="426" y1="47" x2="442" y2="47" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="444" y="24" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="509" y="43" text-anchor="middle" fill="#14161c">e2e tests</text>
+      <text x="509" y="57" text-anchor="middle" fill="#5b5f6b">vs. dev server</text>
+
+      <line x1="574" y1="47" x2="590" y2="47" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="592" y="24" width="130" height="46" rx="5" fill="#fbe3d3" stroke="#c9581c" stroke-width="1.6" />
+      <text x="657" y="43" text-anchor="middle" fill="#c9581c" font-weight="600">build</text>
+      <text x="657" y="57" text-anchor="middle" fill="#c9581c" font-weight="600">→ .output/</text>
+
+      <line x1="722" y1="47" x2="738" y2="47" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="740" y="24" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="805" y="43" text-anchor="middle" fill="#14161c">upload +</text>
+      <text x="805" y="57" text-anchor="middle" fill="#5b5f6b">deploy</text>
+    </g>
+
+    <text x="0" y="160" font-size="11" letter-spacing="1" fill="#5b5f6b">AFTER</text>
+    <g>
+      <rect x="0" y="174" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="65" y="193" text-anchor="middle" fill="#14161c">setup + lint</text>
+      <text x="65" y="207" text-anchor="middle" fill="#5b5f6b">+ typecheck</text>
+
+      <line x1="130" y1="197" x2="146" y2="197" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="148" y="174" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="213" y="193" text-anchor="middle" fill="#14161c">unit +</text>
+      <text x="213" y="207" text-anchor="middle" fill="#5b5f6b">integration tests</text>
+
+      <line x1="278" y1="197" x2="294" y2="197" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="296" y="174" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="361" y="193" text-anchor="middle" fill="#14161c">apply D1</text>
+      <text x="361" y="207" text-anchor="middle" fill="#5b5f6b">migrations</text>
+
+      <line x1="426" y1="197" x2="442" y2="197" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="444" y="174" width="130" height="46" rx="5" fill="#fbe3d3" stroke="#c9581c" stroke-width="1.6" />
+      <text x="509" y="193" text-anchor="middle" fill="#c9581c" font-weight="600">build</text>
+      <text x="509" y="207" text-anchor="middle" fill="#c9581c" font-weight="600">→ .output/</text>
+
+      <line x1="574" y1="197" x2="590" y2="197" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="592" y="174" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="657" y="193" text-anchor="middle" fill="#14161c">write</text>
+      <text x="657" y="207" text-anchor="middle" fill="#5b5f6b">.dev.vars</text>
+
+      <line x1="722" y1="197" x2="738" y2="197" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="740" y="174" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="805" y="193" text-anchor="middle" fill="#14161c">e2e tests</text>
+      <text x="805" y="207" text-anchor="middle" fill="#5b5f6b">vs. wrangler dev</text>
+
+      <line x1="870" y1="197" x2="886" y2="197" stroke="#14161c" stroke-width="1.2" marker-end="url(#arrow3)" />
+      <rect x="888" y="174" width="130" height="46" rx="5" fill="#ffffff" stroke="#14161c" stroke-width="1.1" />
+      <text x="953" y="193" text-anchor="middle" fill="#14161c">upload +</text>
+      <text x="953" y="207" text-anchor="middle" fill="#5b5f6b">deploy</text>
+    </g>
+
+    <path d="M657,70 Q590,120 509,172" fill="none" stroke="#c9581c" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#arrow3accent)" />
+    <text x="690" y="105" font-size="10.5" fill="#c9581c" font-weight="600">build moves</text>
+    <text x="690" y="118" font-size="10.5" fill="#c9581c" font-weight="600">earlier</text>
+  </g>
+</svg>

--- a/.github/pr-media/ci-e2e-fix/figure-4-time-comparison.svg
+++ b/.github/pr-media/ci-e2e-fix/figure-4-time-comparison.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 340" font-family="ui-monospace, Menlo, Consolas, monospace">
+  <rect x="0" y="0" width="820" height="340" rx="8" fill="#ffffff" stroke="#d8dbe2" stroke-width="1" />
+  <text x="20" y="30" font-size="14" font-weight="600" fill="#14161c">production.yml — measured vs. projected (per step)</text>
+
+  <g transform="translate(20,55)" font-size="11">
+    <text x="0" y="7" text-anchor="start" fill="#14161c">e2e tests</text>
+    <rect x="140" y="0" width="500" height="14" rx="4" fill="#2a78d6" />
+    <text x="648" y="10" fill="#14161c">489s measured</text>
+    <rect x="140" y="18" width="205" height="14" rx="4" fill="#c9581c" />
+    <text x="353" y="28" fill="#14161c">~150–250s projected*</text>
+
+    <text x="0" y="55" fill="#14161c">unit tests</text>
+    <rect x="140" y="48" width="97" height="14" rx="4" fill="#2a78d6" />
+    <text x="245" y="58" fill="#14161c">95s</text>
+
+    <text x="0" y="83" fill="#14161c">build</text>
+    <rect x="140" y="76" width="94" height="14" rx="4" fill="#2a78d6" />
+    <text x="242" y="86" fill="#14161c">92s</text>
+
+    <text x="0" y="111" fill="#14161c">other overhead</text>
+    <rect x="140" y="104" width="132" height="14" rx="4" fill="#2a78d6" />
+    <text x="280" y="114" fill="#14161c">129s — checkout, install, cache, migrations</text>
+
+    <text x="0" y="139" fill="#14161c">integration tests</text>
+    <rect x="140" y="132" width="39" height="14" rx="4" fill="#2a78d6" />
+    <text x="187" y="142" fill="#14161c">38s</text>
+
+    <text x="0" y="167" fill="#14161c">deploy</text>
+    <rect x="140" y="160" width="30" height="14" rx="4" fill="#2a78d6" />
+    <text x="178" y="170" fill="#14161c">29s</text>
+
+    <rect x="0" y="196" width="9" height="9" rx="2" fill="#2a78d6" />
+    <text x="15" y="204" fill="#5b5f6b">measured today</text>
+    <rect x="150" y="196" width="9" height="9" rx="2" fill="#c9581c" />
+    <text x="165" y="204" fill="#5b5f6b">projected — not yet validated</text>
+  </g>
+
+  <text x="20" y="290" font-size="11" fill="#14161c" font-weight="600">14m32s measured → ~9m43s projected (saves ~4m49s, ≈33%)</text>
+  <text x="20" y="308" font-size="10.5" fill="#5b5f6b">* e2e range requires raising `workers` above 1 and a clean live-CI validation run — not done yet.</text>
+  <text x="20" y="322" font-size="10.5" fill="#5b5f6b">Every other row is expected to stay exactly as measured; this fix only touches e2e.</text>
+</svg>

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   cleanup:
     name: Delete skipped and matched runs
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -244,6 +244,7 @@ jobs:
           cat > .dev.vars <<'EOF'
           CI=true
           NUXT_PUBLIC_BASE_URL=http://localhost:3000
+          NUXT_PUBLIC_E2E_TEST_HOOKS_ENABLED=true
           NUXT_ENCRYPTION_HASHIDS=secret
           NUXT_ENCRYPTION_KEY=secret
           NUXT_BETTER_AUTH_SECRET=secret

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   check-pr-state:
     name: Check PR state
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -50,7 +50,7 @@ jobs:
   check-latest-commit:
     name: Check latest commit paths
     needs: check-pr-state
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       should-skip: ${{ steps.paths.outputs.should-skip }}
     steps:
@@ -210,6 +210,50 @@ jobs:
         if: steps.check-e2e.outputs.has-tests == 'true'
         run: yes | pnpm exec wrangler d1 migrations apply CONSENT_DB --local
 
+      - name: Build application
+        id: build-app
+        env:
+          ROLLDOWN_OPTIONS_VALIDATION: loose
+        run: |
+          START=$(date +%s)
+          pnpm run build 2>&1 | tee build-output.log
+          END=$(date +%s)
+          DURATION=$((END - START))
+          echo "duration=${DURATION}s" >> $GITHUB_OUTPUT
+          echo "✅ Build completed in ${DURATION}s"
+
+      - name: Extract bundle size
+        id: bundle-size
+        run: |
+          SIZE_INFO=$(grep -E "Total size:.*MB.*gzip" build-output.log | sed 's/\x1b\[[0-9;]*m//g' | sed 's/Σ Total size: //' || echo "Size information not found")
+          echo "Bundle Size: $SIZE_INFO"
+          echo "bundle-size=$SIZE_INFO" >> $GITHUB_OUTPUT
+
+      - name: Verify build output exists
+        run: |
+          if [ ! -d ".output" ]; then
+            echo "❌ ERROR: .output/ directory not found!"
+            exit 1
+          fi
+          echo "✅ Build successful"
+          ls -lah .output/
+
+      - name: Write .dev.vars for CI e2e
+        if: steps.check-e2e.outputs.has-tests == 'true'
+        run: |
+          cat > .dev.vars <<'EOF'
+          CI=true
+          NUXT_PUBLIC_BASE_URL=http://localhost:3000
+          NUXT_ENCRYPTION_HASHIDS=secret
+          NUXT_ENCRYPTION_KEY=secret
+          NUXT_BETTER_AUTH_SECRET=secret
+          NUXT_EMAIL_NOOP_ENABLED=true
+          NUXT_FILES_RETENTION_CLEANUP_ENABLED=true
+          NUXT_FILES_RETENTION_CLEANUP_BATCH_SIZE=100
+          NUXT_FILES_RETENTION_CLEANUP_MAX_RUNTIME_MS=20000
+          NUXT_FILES_MAINTENANCE_TOKEN=token
+          EOF
+
       - name: Run affected E2E tests
         id: test-e2e
         if: steps.check-e2e.outputs.has-tests == 'true'
@@ -239,34 +283,6 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
-
-      - name: Build application
-        id: build-app
-        env:
-          ROLLDOWN_OPTIONS_VALIDATION: loose
-        run: |
-          START=$(date +%s)
-          pnpm run build 2>&1 | tee build-output.log
-          END=$(date +%s)
-          DURATION=$((END - START))
-          echo "duration=${DURATION}s" >> $GITHUB_OUTPUT
-          echo "✅ Build completed in ${DURATION}s"
-
-      - name: Extract bundle size
-        id: bundle-size
-        run: |
-          SIZE_INFO=$(grep -E "Total size:.*MB.*gzip" build-output.log | sed 's/\x1b\[[0-9;]*m//g' | sed 's/Σ Total size: //' || echo "Size information not found")
-          echo "Bundle Size: $SIZE_INFO"
-          echo "bundle-size=$SIZE_INFO" >> $GITHUB_OUTPUT
-
-      - name: Verify build output exists
-        run: |
-          if [ ! -d ".output" ]; then
-            echo "❌ ERROR: .output/ directory not found!"
-            exit 1
-          fi
-          echo "✅ Build successful"
-          ls -lah .output/
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -211,6 +211,7 @@ jobs:
           cat > .dev.vars <<'EOF'
           CI=true
           NUXT_PUBLIC_BASE_URL=http://localhost:3000
+          NUXT_PUBLIC_E2E_TEST_HOOKS_ENABLED=true
           NUXT_ENCRYPTION_HASHIDS=secret
           NUXT_ENCRYPTION_KEY=secret
           NUXT_BETTER_AUTH_SECRET=secret

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Get merged PR number
         id: pr
@@ -96,8 +94,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v6
@@ -167,36 +163,6 @@ jobs:
       - name: Apply consent DB migrations for E2E
         run: yes | pnpm exec wrangler d1 migrations apply CONSENT_DB --local
 
-      - name: Run all E2E tests
-        id: test-e2e
-        run: |
-          START=$(date +%s)
-          pnpm run test:e2e
-          END=$(date +%s)
-          DURATION=$((END - START))
-          echo "duration=${DURATION}s" >> $GITHUB_OUTPUT
-          echo "✅ All E2E tests completed in ${DURATION}s"
-        env:
-          CI: true
-          NUXT_PUBLIC_BASE_URL: http://localhost:3000
-          NUXT_ENCRYPTION_HASHIDS: secret
-          NUXT_ENCRYPTION_KEY: secret
-          NUXT_BETTER_AUTH_SECRET: secret
-          NUXT_EMAIL_NOOP_ENABLED: true
-          NUXT_FILES_RETENTION_CLEANUP_ENABLED: true
-          NUXT_FILES_RETENTION_CLEANUP_BATCH_SIZE: 100
-          NUXT_FILES_RETENTION_CLEANUP_MAX_RUNTIME_MS: 20000
-          NUXT_FILES_MAINTENANCE_TOKEN: token
-          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
-
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
-        if: '!cancelled()'
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
-
       - name: Build application
         id: build-app
         env:
@@ -239,6 +205,51 @@ jobs:
           echo ""
           echo "Disk usage:"
           du -sh .output/
+
+      - name: Write .dev.vars for CI e2e
+        run: |
+          cat > .dev.vars <<'EOF'
+          CI=true
+          NUXT_PUBLIC_BASE_URL=http://localhost:3000
+          NUXT_ENCRYPTION_HASHIDS=secret
+          NUXT_ENCRYPTION_KEY=secret
+          NUXT_BETTER_AUTH_SECRET=secret
+          NUXT_EMAIL_NOOP_ENABLED=true
+          NUXT_FILES_RETENTION_CLEANUP_ENABLED=true
+          NUXT_FILES_RETENTION_CLEANUP_BATCH_SIZE=100
+          NUXT_FILES_RETENTION_CLEANUP_MAX_RUNTIME_MS=20000
+          NUXT_FILES_MAINTENANCE_TOKEN=token
+          EOF
+
+      - name: Run all E2E tests
+        id: test-e2e
+        run: |
+          START=$(date +%s)
+          pnpm run test:e2e
+          END=$(date +%s)
+          DURATION=$((END - START))
+          echo "duration=${DURATION}s" >> $GITHUB_OUTPUT
+          echo "✅ All E2E tests completed in ${DURATION}s"
+        env:
+          CI: true
+          NUXT_PUBLIC_BASE_URL: http://localhost:3000
+          NUXT_ENCRYPTION_HASHIDS: secret
+          NUXT_ENCRYPTION_KEY: secret
+          NUXT_BETTER_AUTH_SECRET: secret
+          NUXT_EMAIL_NOOP_ENABLED: true
+          NUXT_FILES_RETENTION_CLEANUP_ENABLED: true
+          NUXT_FILES_RETENTION_CLEANUP_BATCH_SIZE: 100
+          NUXT_FILES_RETENTION_CLEANUP_MAX_RUNTIME_MS: 20000
+          NUXT_FILES_MAINTENANCE_TOKEN: token
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: '!cancelled()'
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update:
     name: "Update PRs"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       pull-requests: write

--- a/app/composables/chat-test.ts
+++ b/app/composables/chat-test.ts
@@ -12,9 +12,11 @@ export function useChatTest(
 ) {
   const route = useRoute()
   const router = useRouter()
+  const isE2eTestHooksEnabled = useRuntimeConfig().public.e2eTestHooksEnabled
 
   const isTestChat = computed<boolean>(() => {
-    return import.meta.dev && route.path === '/chats/test'
+    return (import.meta.dev || isE2eTestHooksEnabled)
+      && route.path === '/chats/test'
   })
 
   const query = computed(() => {

--- a/app/pages/chats/[slug].vue
+++ b/app/pages/chats/[slug].vue
@@ -224,9 +224,11 @@ useSeoMeta({
 })
 
 const route = useRoute()
+const isE2eTestHooksEnabled = useRuntimeConfig().public.e2eTestHooksEnabled
 
 const isTestChat = computed<boolean>(() => {
-  return import.meta.dev && route.path === '/chats/test'
+  return (import.meta.dev || isE2eTestHooksEnabled)
+    && route.path === '/chats/test'
 })
 
 const key = computed<string>(() => {
@@ -743,7 +745,7 @@ const selectedMessageInfo = computed(() => {
 
 if (import.meta.client) {
   onMounted(() => {
-    if (!import.meta.dev) {
+    if (!import.meta.dev && !isE2eTestHooksEnabled) {
       return
     }
 
@@ -759,7 +761,7 @@ if (import.meta.client) {
   })
 
   onUnmounted(() => {
-    if (!import.meta.dev) {
+    if (!import.meta.dev && !isE2eTestHooksEnabled) {
       return
     }
 

--- a/app/pages/shared/[slug].vue
+++ b/app/pages/shared/[slug].vue
@@ -424,9 +424,11 @@ function clearMessageSelection() {
   resetMessageSelection()
 }
 
+const isE2eTestHooksEnabled = useRuntimeConfig().public.e2eTestHooksEnabled
+
 if (import.meta.client) {
   onMounted(() => {
-    if (!import.meta.dev) {
+    if (!import.meta.dev && !isE2eTestHooksEnabled) {
       return
     }
 
@@ -442,7 +444,7 @@ if (import.meta.client) {
   })
 
   onUnmounted(() => {
-    if (!import.meta.dev) {
+    if (!import.meta.dev && !isE2eTestHooksEnabled) {
       return
     }
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -175,6 +175,7 @@ export default defineNuxtConfig({
       maxMessageFilesBytes: 1000 * 1024 * 1024, // 1GB
       vapidPublicKey: '',
       turnstileSiteKey: '',
+      e2eTestHooksEnabled: false,
     },
   },
   site: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,7 +46,10 @@ export default defineConfig({
   // progressively so fragile specs run after their deps are optimized. It does
   // not stop an in-page reload landing mid-interaction (see signIn's toPass in
   // helpers/auth.ts), which the lone local retry above covers. Dev-only: a
-  // production build never pre-bundles or reloads.
+  // production build never pre-bundles or reloads. CI now serves the built
+  // app via `wrangler dev` (see webServer.command below), which removes the
+  // root cause, but workers stays at 1 pending a live-CI flake-validation
+  // round before raising it.
   workers: 1,
   // Reporter to use.
   // See https://playwright.dev/docs/test-reporters
@@ -107,7 +110,9 @@ export default defineConfig({
     // },
   ],
   webServer: {
-    command: 'pnpm run db:migrate && pnpm run dev',
+    command: process.env.CI
+      ? `pnpm exec wrangler dev --port ${E2E_PORT}`
+      : 'pnpm run db:migrate && pnpm run dev',
     env: WEB_SERVER_ENV,
     url: E2E_BASE_URL,
     timeout: 120_000,

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -43,6 +43,7 @@ function createAuth() {
   const kv = useKV()
   const dataKey = 'auth'
   const deleteAccountTokenTtl = 60 * 60
+  const isCiEnvironment: boolean = process.env.CI === 'true'
 
   const allowedHosts = getAllowedHosts(config.public.baseUrl)
   const captchaOptions = getCaptchaOptions(config)
@@ -129,8 +130,8 @@ function createAuth() {
     },
     emailAndPassword: {
       enabled: true,
-      autoSignIn: import.meta.dev,
-      requireEmailVerification: !import.meta.dev,
+      autoSignIn: import.meta.dev || isCiEnvironment,
+      requireEmailVerification: !import.meta.dev && !isCiEnvironment,
       async sendResetPassword({ user, url }) {
         const { send: sendEmail } = useEmail()
 
@@ -150,7 +151,7 @@ function createAuth() {
       },
     },
     emailVerification: {
-      sendOnSignUp: !import.meta.dev,
+      sendOnSignUp: !import.meta.dev && !isCiEnvironment,
       autoSignInAfterVerification: true,
       async sendVerificationEmail({ user, url }) {
         if (import.meta.dev) {


### PR DESCRIPTION
## Summary

Preview builds grew to 10–12 min and production builds to ~14.5 min. This PR
lands the changes that don't require a live-CI validation round first:

- Move GH-API-only jobs (PR/path gate checks, weekly cleanup, PR labeling)
  off the metered Blacksmith runner onto free `ubuntu-24.04` — they do no
  CPU work and never benefited from Blacksmith's tier. This is real but
  small: ~30–40 Blacksmith-minutes/month, not the main lever.
- Drop unneeded `fetch-depth: 0` from `production.yml`'s checkout steps —
  neither job diffs git history, and `buildId` reads `$GITHUB_SHA`, not
  checkout depth.
- **Serve the built app instead of the dev server for CI e2e** — the actual
  fix, and the biggest line item: e2e alone was 489s of the last measured
  14m32s production run (56%).

`workers: 1` in `playwright.config.ts` is **unchanged** — raising it needs a
live CI validation round this PR does not attempt. See "What's next" below.

## Why: the mechanism

Vite's dev server bundles dependencies on demand. The first time any
connected page needs a package it hasn't bundled yet, it stops, bundles it,
and broadcasts a full-page reload to **every** connected page — not just the
one that asked. Two Playwright workers sharing one dev server means Worker A
discovering a new import can reload Worker B's page mid-test. That's the
actual cause of the "Execution context was destroyed" flake `workers: 1` was
introduced to work around (in the Nuxt 4.5 upgrade, #305).

<img width="720" alt="Diagram: PR push boots the Nuxt dev server. Worker A and Worker B pages both connect. Worker A discovers a new dependency, triggering Vite to pre-bundle it and broadcast an HMR reload to all pages. That reload hits Worker B mid-test, producing a context-destroyed flake." src="https://raw.githubusercontent.com/besidka/besidka/fix/ci-cd-slow/.github/pr-media/ci-e2e-fix/figure-1-mechanism-before.svg">

A production build has no dev server component at all — every dependency is
already bundled into `.output/` before the app serves a single request.
There's no on-demand bundling step to trigger and no HMR channel to
broadcast over. The mechanism above doesn't happen *less often* against a
build; it has nothing to run on:

<img width="720" alt="Diagram: PR push triggers a build to .output, served via wrangler dev. Worker A and Worker B pages connect and complete independently. Where the pre-bundle-and-broadcast step used to sit, a dashed marker shows no pre-bundle step and no HMR channel exist in this runtime." src="https://raw.githubusercontent.com/besidka/besidka/fix/ci-cd-slow/.github/pr-media/ci-e2e-fix/figure-2-mechanism-after.svg">

## What changed in the CI YAML

For the webServer to serve a build, a build has to exist first, so "Build
application" moves from after e2e to before it in both `production.yml` and
`preview-build.yml`. `wrangler dev` runs on workerd, which — unlike a plain
Node dev server — doesn't inherit the job's environment variables, so a new
step writes a `.dev.vars` file right before e2e runs:

<img width="1000" alt="Diagram: before, the pipeline runs setup, tests, D1 migrations, e2e against the dev server, then build, then upload/deploy. After, build moves earlier — right after migrations — a new step writes .dev.vars, and e2e now runs against wrangler dev." src="https://raw.githubusercontent.com/besidka/besidka/fix/ci-cd-slow/.github/pr-media/ci-e2e-fix/figure-3-pipeline-reorder.svg">

Also required, and included in this PR: `server/utils/auth.ts` gates
`autoSignIn` / `requireEmailVerification` / `sendOnSignUp` the same way the
existing test-only route handlers already do
(`import.meta.dev || isCiEnvironment`). `import.meta.dev` is a build-time
constant that's `false` in any production build — without this fallback,
e2e's test users could never satisfy email verification against the built
app, and the entire suite would fail at `auth.setup.ts`. Caught in review
before this PR was opened; see commit message for the full trace.

## Expected impact

<img width="720" alt="Bar chart comparing measured and projected step durations for production.yml. Unit tests, integration tests, build, deploy, and other overhead are unchanged. E2E tests are measured at 489 seconds today and projected to drop to roughly 150 to 250 seconds once parallel workers are validated. Total goes from 14 minutes 32 seconds to roughly 9 minutes 43 seconds, saving about 33 percent." src="https://raw.githubusercontent.com/besidka/besidka/fix/ci-cd-slow/.github/pr-media/ci-e2e-fix/figure-4-time-comparison.svg">

Every row except e2e is a real measurement pulled from `gh run view` against
this repo's actual `production.yml` history (2026-07-17 → 2026-08-07). The
e2e "projected" figure is **not measured** — it's the plan's estimate for
after `workers` is raised on a 4 vCPU runner, and is called out as such.

## What's next (not in this PR)

- Raise `workers` above 1 in `playwright.config.ts`, gated on a live CI
  round with zero flakes across several runs.
- Audit whether specs that share one signed-in test user / one local D1
  race under real parallelism before trusting the raise.
- Shard e2e across parallel jobs on `production.yml` (free on
  GitHub-hosted, since this repo is public) — combined with the workers
  raise, the plan projects production down to roughly 7–8 minutes total.

## Test plan

- [x] `pnpm run format && pnpm run typecheck` — clean
- [x] Pre-push hook: full affected unit (1515 tests) + integration (359
      tests) suite — all green
- [ ] Live CI run on this PR — first real test of `wrangler dev` serving
      e2e traffic; watch for anything the local runs above can't catch
      (workerd-specific behavior, `.dev.vars` propagation)
- [ ] Confirm Blacksmith minute usage drops as expected after merge
