### PR TITLE
fix(email): remove leftover dark-mode accent border-top on card

### DIFF
--- a/app/emails/components/EmailLayout.vue
+++ b/app/emails/components/EmailLayout.vue
@@ -33,7 +33,6 @@ const darkModeCss = `
     .email-card {
       background-color: ${surfaceDark} !important;
       border-color: ${borderDark} !important;
-      border-top-color: ${accentDark} !important;
     }
     .email-wordmark {
       color: ${accentDark} !important;


### PR DESCRIPTION
## Summary

Follow-up to #340. The light-mode accent border-top on the email card
was removed in that PR, but the dark-mode `@media (prefers-color-scheme:
dark)` override still set `border-top-color` on the card, layered on
top of the card's base `border: 1px solid` (which already gives every
side, including the top, a 1px width). That made the pink border-top
reappear in dark mode only — confirmed in a real Gmail dark-mode
screenshot.

Removes the dark-mode `border-top-color` override so the card has a
plain neutral border in both themes.

## Verification

- `pnpm run format && pnpm run typecheck && pnpm run lint` — clean.
- Full suite: 197 files / 1882 tests passing.
- `pnpm run build` succeeds.
- Verified via the module's real SSR render (not the dev server) that
  the dark-mode `.email-card` rule now only sets `background-color`
  and `border-color`, with no `border-top-color`.