### PR TITLE
ci: harden build step against silent OOM crashes

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -214,7 +214,9 @@ jobs:
         id: build-app
         env:
           ROLLDOWN_OPTIONS_VALIDATION: loose
+          NODE_OPTIONS: --max-old-space-size=3072
         run: |
+          set -o pipefail
           START=$(date +%s)
           pnpm run build 2>&1 | tee build-output.log
           END=$(date +%s)
@@ -231,8 +233,8 @@ jobs:
 
       - name: Verify build output exists
         run: |
-          if [ ! -d ".output" ]; then
-            echo "❌ ERROR: .output/ directory not found!"
+          if [ ! -f ".output/server/index.mjs" ]; then
+            echo "❌ ERROR: .output/server/index.mjs not found!"
             exit 1
           fi
           echo "✅ Build successful"


### PR DESCRIPTION
## Summary

PR #337's CI build job (`Build PR` on `blacksmith-2vcpu-ubuntu-2404`)
crashed with a V8 `JavaScript heap out of memory` error during
`nuxt build`, but the step still reported success and the job pushed
on to a much more confusing failure downstream.

## Root cause

- `pnpm run build 2>&1 | tee build-output.log` loses the real exit
  code through the pipe (no `pipefail`), so a step that OOM-crashed
  with exit code 134 still shows as green.
- The "Verify build output exists" step only checked
  `[ -d ".output" ]` - the directory existed (partially populated by
  the crashed build) even though `.output/server/index.mjs` was never
  written, so this check couldn't catch it either.
- The corpse of the crashed build sailed through to the E2E job,
  which failed with an unrelated-looking
  `The entry-point file at ".output/server/index.mjs" was not found`
  error instead of the real OOM cause.

This traces back to the recent runner migration to
`blacksmith-2vcpu-ubuntu-2404` - V8's default heap ceiling on that
runner sits right at the edge of what a full `nuxt build` needs.

## Fix

- `set -o pipefail` on the build step so the real exit code surfaces.
- `NODE_OPTIONS: --max-old-space-size=3072` to give V8 more heap
  headroom (cost-neutral - no runner tier change).
- "Verify build output exists" now checks for
  `.output/server/index.mjs` specifically, not just the directory.

If `--max-old-space-size=3072` still OOMs on this runner, the next
step would be bumping the Blacksmith runner tier, which is a billing
decision left for a follow-up rather than bundled here.

## Test plan

- [ ] CI on this PR builds successfully with the new settings
- [ ] Confirm the same fix unblocks PR #337 (dev-deps bump), which
      triggered this OOM