### PR TITLE
ci: raise build heap ceiling to 6144MB (still within runner RAM)

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -214,7 +214,7 @@ jobs:
         id: build-app
         env:
           ROLLDOWN_OPTIONS_VALIDATION: loose
-          NODE_OPTIONS: --max-old-space-size=3072
+          NODE_OPTIONS: --max-old-space-size=6144
         run: |
           set -o pipefail
           START=$(date +%s)


### PR DESCRIPTION
## Summary

Follow-up to #347. The `pipefail`/artifact-check hardening from #347
worked correctly (confirmed on PR #337's rerun: the build now fails
cleanly with a real error instead of a silent pass), but
`--max-old-space-size=3072` wasn't enough - the Nitro server bundle
step for the `cloudflare-module` preset now hits V8's own configured
heap limit at exactly 3072MB and aborts with a clean
`FATAL ERROR: Reached heap limit` (not an OS-level kill).

## Why this isn't a runner tier bump yet

`blacksmith-2vcpu-ubuntu-2404` has 8GB total RAM (Blacksmith allocates
4GB per vCPU). We only hit *our own* configured ceiling, not the
runner's physical limit, so there's still cost-neutral headroom to
use before considering a tier bump (a billing decision).

## Change

Raises `NODE_OPTIONS: --max-old-space-size` from 3072 to 6144,
leaving ~2GB for the OS and sibling build processes.

## Test plan

- [ ] Confirm this unblocks PR #337's build job
- [ ] If 6144 still OOMs, next step is a Blacksmith runner tier bump
      (4vcpu/16GB), which needs a call from the repo owner on cost