### PR TITLE
chore(deps): upgrade pnpm to 12.0.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "besidka",
 	"type": "module",
-	"packageManager": "pnpm@11.15.1",
+	"packageManager": "pnpm@12.0.0-rc.1",
 	"engines": {
 		"node": ">=24"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0-rc.1
+        version: 12.0.0-rc.1
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.1':
+    resolution: {integrity: sha512-lfv8qgQ2ZqZLnFG4D0SJ9X87viV20INzqlMzYj2lPSRrsqTeoByEU2tTxMKbiZ8giVQxuxHQkmEmY9t+ilN/IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0-rc.1':
+    resolution: {integrity: sha512-tk478ZXGRUffn0DCq9cDADmJiKXRsaPmROnyzhtx6QZcqBtMI806zDsMir01aXaGaHViTYYBPNolf3kMk4gErg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.1':
+    resolution: {integrity: sha512-SHP5CE3lbvHdghc0IcMO5xf5Ep22s4JCdtvSYYGREP2/CtKYHGxeFEWRXfirLCDPGbrbTSzOnpMFCGVBBlnA/w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0-rc.1':
+    resolution: {integrity: sha512-EMDNYu2OrDE7Ay56c35+HzivgwcvBVIXzTtBcgtS+BupZqO+INa7e0237zREygemqrvjiavtfGnpBrrlag9crQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.1':
+    resolution: {integrity: sha512-H2UCDccvz3DRyCHgkT95bGkesda2bsWraZOZ8cmNTwxEWE3cJOAiRIouUi+h6eSb9JcuStPgo8QhifDR+PvUBA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0-rc.1':
+    resolution: {integrity: sha512-tbJNiRAh5fWosK+0i1UdwaMRt4zxX/jt0Y1KgzP9FyRwMJ2Rg41R+le2nKka4a9inOwtK4eU9vbvT+VVxczp7A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0-rc.1':
+    resolution: {integrity: sha512-V+tsBZ+soJSljF4LcY9a1FcWXfXTDumPf2aoxCzE78BDcIEcdl/EzZwTbArRXoZ+7fZuv+ZNvPvLqjPB3qLMqA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0-rc.1':
+    resolution: {integrity: sha512-N4EOY2XKcWAoDRvVLCgHabt3Pb2Rev7jNq/VPcxGwyYquXt6H9PES1azia7sj0UGBYCFsczukNagokuFh0jdfQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0-rc.1:
+    resolution: {integrity: sha512-tAZDwW0n1oSZ9Bu+ZHec8dnICYfoGOhT7SGCiypL/tbR7Eq4IGU8kRp1ci5YSxPc1Uk5YIY5O14gKtN2ql/+pw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.1':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0-rc.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0-rc.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0-rc.1':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0-rc.1':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0-rc.1':
+    optional: true
+
+  pnpm@12.0.0-rc.1:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0-rc.1
+      '@pnpm/exe.darwin-x64': 12.0.0-rc.1
+      '@pnpm/exe.linux-arm64': 12.0.0-rc.1
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.1
+      '@pnpm/exe.linux-x64': 12.0.0-rc.1
+      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.1
+      '@pnpm/exe.win32-arm64': 12.0.0-rc.1
+      '@pnpm/exe.win32-x64': 12.0.0-rc.1
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
## Summary

Upgrades the project's pinned package manager from pnpm 11.15.1 to
the 12.0.0-rc.1 release candidate, per the maintainers' announced
plan (pnpm/pnpm#11292): the Rust fetch/link engine becomes the
default for at least `pnpm install --frozen-lockfile`, plus a few
syntax deprecations.

## Compatibility check against v12's planned breaking changes

- **`$`-prefix overrides deprecated in favor of catalogs**: not used
  here - `pnpm-workspace.yaml`'s `overrides:` block uses plain
  version strings.
- **Git-hosted tarball migration code removed**: no `git+`/`github:`
  dependencies anywhere in this repo.
- **Unscoped auth settings rejected**: `.npmrc` has no registry/auth
  settings at all (`save-exact`/`confirm-module-purge` only).
- **Rust engine default for frozen-lockfile installs**: this is the
  one real risk area, since it's a from-scratch reimplementation and
  this repo leans on non-trivial install-time behavior (`allowBuilds`
  native builds for `better-sqlite3`/`sharp`/`workerd`/etc., multiple
  postinstall scripts). Verified below.

## Verification (clean install from scratch)

- `rm -rf node_modules .nuxt .output` + `pnpm install` (plain and
  `--frozen-lockfile`, matching what CI runs)
- `pnpm run dev:prepare` - clean
- `pnpm run typecheck` - clean
- `pnpm run lint` - same pre-existing `no-console` warnings only, 0
  errors
- `pnpm run test:unit` - 1519/1519 passed
- `pnpm run test:integration` - 363/363 passed
- `pnpm run test:e2e` - 72 passed, 1 skipped (same as pre-upgrade)
- `pnpm run build` - succeeds in ~53s, `.output/server/index.mjs`
  written correctly

## Lockfile change

`pnpm-lock.yaml` gains a new multi-document structure: a leading
self-referential document tracking pnpm's own pinned platform
binaries (`packageManagerDependencies`), ahead of the existing
project lockfile document. The repo's custom "Lockfile passes
supply-chain policies" check tolerates this correctly.

## Test plan

- [ ] CI (`Build PR`) passes on this PR