### PR TITLE
ci: apply OOM hardening to production build step

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -167,7 +167,9 @@ jobs:
         id: build-app
         env:
           ROLLDOWN_OPTIONS_VALIDATION: loose
+          NODE_OPTIONS: --max-old-space-size=6144
         run: |
+          set -o pipefail
           START=$(date +%s)
           pnpm run build 2>&1 | tee build-output.log
           END=$(date +%s)
@@ -184,9 +186,9 @@ jobs:
 
       - name: Verify build output exists
         run: |
-          echo "Checking if .output/ directory exists..."
-          if [ ! -d ".output" ]; then
-            echo "❌ ERROR: .output/ directory not found!"
+          echo "Checking if .output/server/index.mjs exists..."
+          if [ ! -f ".output/server/index.mjs" ]; then
+            echo "❌ ERROR: .output/server/index.mjs not found!"
             echo "Build may have failed silently."
             echo ""
             echo "Current directory contents:"
@@ -198,7 +200,7 @@ jobs:
             exit 1
           fi
 
-          echo "✅ .output/ directory exists"
+          echo "✅ .output/server/index.mjs exists"
           echo ""
           echo "Contents of .output/:"
           ls -lah .output/


### PR DESCRIPTION
## Summary

Merging #349 (pnpm 12 upgrade) triggered a real production deploy
failure: https://github.com/besidka/besidka/actions/runs/31266481668

`production.yml` has its own copy-pasted build/verify steps that
never received the fix from #347/#348, which only touched
`preview-build.yml`. Same exact signature:

- `pnpm run build` OOM-crashes (exit 134) building the Nitro server
  bundle (`cloudflare-module` preset).
- The crash's exit code is lost through an unguarded pipe to `tee`
  (no `pipefail`), so the step prints `✅ Build completed in 61s`
  anyway.
- "Verify build output exists" only checked `[ -d ".output" ]` - true
  even though `.output/server/index.mjs` was never written - so the
  corpse sailed through to the E2E step, which failed with a much
  more confusing `entry-point file ... was not found` error instead
  of the real OOM cause.

## Fix

Identical to #347/#348, applied to `production.yml`'s build step:

- `set -o pipefail` so the real exit code surfaces.
- `NODE_OPTIONS: --max-old-space-size=6144` (this job also runs on
  `blacksmith-2vcpu-ubuntu-2404`, 8GB RAM - same value that fixed
  the preview build).
- Check for `.output/server/index.mjs` specifically, not just the
  directory.

## Note

This branch/PR itself can't exercise the production build path (only
runs against pushes to `main`), so the real validation is that the
next `main` push deploys successfully.