### PR TITLE
ci: allow manually triggering the production deploy workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -23,7 +23,8 @@ on:
       - '.*rc'
       - '*.md'
       - 'skills-lock.json'
-    
+  workflow_dispatch:
+
 concurrency:
   group: production
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

`production.yml` only triggers on `push` to `main`, with `.github/**`
in its own `paths-ignore`. That means a `.github/workflows`-only fix
to this exact workflow (like #350, which just fixed the OOM crash
that broke real production deploys) can never be exercised by an
actual deploy run until an unrelated code change happens to land on
`main` next. There is currently no way to validate an infra-only fix
to the production pipeline on demand.

## Change

Adds `workflow_dispatch:` as an additional trigger, so this workflow
can be run manually from the Actions tab or `gh workflow run` without
waiting on an unrelated commit.

## Test plan

- [ ] After merging, manually dispatch this workflow to confirm #350's
      OOM fix actually resolves the production build/deploy