### PR TITLE
ci: add timeout-minutes so a hung job can't run unbounded

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -114,6 +114,7 @@ jobs:
       - check-latest-commit
     if: needs.check-latest-commit.outputs.should-skip != 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 25
     permissions:
       contents: read
       statuses: write
@@ -260,6 +261,7 @@ jobs:
       - name: Run affected E2E tests
         id: test-e2e
         if: steps.check-e2e.outputs.has-tests == 'true'
+        timeout-minutes: 12
         run: |
           START=$(date +%s)
           node scripts/test-affected.mjs --base=origin/${{ github.base_ref }} --type=e2e

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -74,6 +74,7 @@ jobs:
     name: Build and Deploy to Production
     needs: resolve-preview-context
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 30
     outputs:
       deployment-url: ${{ steps.deploy.outputs.deployment-url }}
       bundle-size: ${{ steps.bundle-size.outputs.bundle-size }}
@@ -227,6 +228,7 @@ jobs:
 
       - name: Run all E2E tests
         id: test-e2e
+        timeout-minutes: 15
         run: |
           START=$(date +%s)
           pnpm run test:e2e


### PR DESCRIPTION
## Summary

The production deploy triggered by merging #349 hung for ~40 minutes
before I had to be told to notice and cancel it manually:
https://github.com/besidka/besidka/actions/runs/31267136185

## Root cause

A transient `workerd` error during E2E:

```
[WebServer] ✘ [ERROR] kj::getCaughtExceptionAsKj() =
kj/async-io-unix.c++:186: disconnected:
::write(fd, buffer.begin(), buffer.size()): Broken pipe
```

left `wrangler dev`'s local server in a degraded state. This exact
line also appears harmlessly in an earlier *passing* run, so it's
not inherently fatal - but this time, 18 completely unrelated tests
(theme switching, history dropdowns, context menus) all started
failing the same way (`net::ERR_ABORTED`, timeouts) for the rest of
the run. With `workers: 1` and Playwright's default retries, each
failing test burned its full retry budget sequentially against an
unresponsive server.

**No job or step anywhere in this repo's workflows sets
`timeout-minutes`**, so GitHub Actions' default 360-minute job
timeout was the only ceiling in effect. Nothing stopped this from
running until a human noticed.

## Fix

Adds `timeout-minutes`:

- A step-level timeout on the E2E step specifically, so a future
  hang points straight at the likely culprit.
- A job-level ceiling as defense-in-depth, in case a different step
  hangs.

Sized to comfortably exceed a normal healthy run (production's build
+ full test suite finishes in ~15-20 min normally; preview's
affected-subset finishes faster):

| | Step (E2E) | Job |
|---|---|---|
| `production.yml` (full suite) | 15 min | 30 min |
| `preview-build.yml` (affected subset) | 12 min | 25 min |

## What this does NOT fix

The underlying `workerd`/`wrangler dev` degradation itself. It's
unclear yet whether that's something fixable from this repo, or an
inherent flakiness in running Cloudflare's local dev runtime under
sustained sequential load - worth investigating separately if it
recurs. This PR just bounds the blast radius so it fails fast and
visibly instead of silently consuming CI minutes for the better part
of an hour.