### PR TITLE
feat: add Cmd/Ctrl+K search modal, replace sidebar History link

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -33,6 +33,7 @@
     <UiConfirmation />
     <UiMessages />
     <LazyChatShareModal />
+    <LazySearchModal />
     <LazyNotificationPrompt />
     <Sidebar v-if="hasSidebar" />
     <LazyUiCursorGlow v-if="$device.isDesktop" />

--- a/app/components/ChatInput.client.vue
+++ b/app/components/ChatInput.client.vue
@@ -737,6 +737,21 @@ function openFilesModal(tab: 'select' | 'upload', source?: FileSourceFilter) {
   filesModalRef.value?.open(tab, source)
 }
 
+const { pendingOpen, clearPendingOpen } = useFilesModalHandoff()
+
+watch([pendingOpen, filesModalRef], () => {
+  if (!pendingOpen.value || !filesModalRef.value) {
+    return
+  }
+
+  if (pendingOpen.value.targetPath !== route.path) {
+    return
+  }
+
+  filesModalRef.value.open(pendingOpen.value.tab, pendingOpen.value.source)
+  clearPendingOpen()
+}, { immediate: true, flush: 'post' })
+
 const chatInputRef = useTemplateRef<HTMLDivElement>('chatInputRef')
 const { height: chatInputHeight } = useElementSize(chatInputRef)
 const isSentHeightOnMounted = shallowRef<boolean>(false)
@@ -770,11 +785,11 @@ onStartTyping(() => {
 })
 
 function onPaste(event: ClipboardEvent) {
-  const isFilesModalOpen = !!document.querySelector(
-    'dialog.js-files-modal[open]',
+  const isBlockingModalOpen = !!document.querySelector(
+    'dialog.js-files-modal[open], dialog.js-search-modal[open]',
   )
 
-  if (isFilesModalOpen) {
+  if (isBlockingModalOpen) {
     return
   }
 

--- a/app/components/Search/Modal.client.vue
+++ b/app/components/Search/Modal.client.vue
@@ -1,0 +1,534 @@
+<template>
+  <Teleport to="body">
+    <dialog
+      ref="modal"
+      data-testid="search-modal"
+      class="js-search-modal modal modal-middle"
+      aria-label="Search"
+      @close="onDialogClosed"
+    >
+      <div class="modal-box max-w-lg max-h-[80vh] flex flex-col gap-3">
+        <div class="shrink-0">
+          <UiSearchInput
+            ref="searchInputRef"
+            v-model="query"
+            :is-searching="isSearching"
+            :show-keyboard-hint="false"
+            placeholder="Search chats and actions..."
+            @keydown="onSearchKeydown"
+          />
+        </div>
+
+        <div
+          ref="list"
+          role="listbox"
+          aria-label="Search results and actions"
+          data-testid="search-modal-results"
+          class="flex-1 min-h-0 overflow-y-auto -mx-1.5 px-1.5"
+        >
+          <template
+            v-for="group in groups"
+            :key="group.id"
+          >
+            <div
+              v-if="group.heading"
+              aria-hidden="true"
+              class="px-3 pt-3 pb-1 text-xs font-semibold uppercase opacity-50"
+            >
+              {{ group.heading }}
+            </div>
+
+            <template
+              v-for="item in group.items"
+              :key="item.id"
+            >
+              <SearchResultRow
+                v-if="item.chat"
+                :id="item.id"
+                role="option"
+                :aria-selected="item.index === activeIndex"
+                :chat="item.chat"
+                :active="item.index === activeIndex"
+                @mousemove="activeIndex = item.index"
+                @select="item.run()"
+              />
+              <div
+                v-else
+                :id="item.id"
+                role="option"
+                :aria-selected="item.index === activeIndex"
+                data-testid="search-command-row"
+                class="flex items-center gap-2.5 rounded-box px-3 py-2 cursor-pointer transition-colors"
+                :class="item.index === activeIndex
+                  ? 'bg-base-content/10'
+                  : 'hover:bg-base-content/5'"
+                @click="item.run()"
+                @mousemove="activeIndex = item.index"
+              >
+                <Icon
+                  v-if="item.iconName"
+                  :name="item.iconName"
+                  size="16"
+                  class="shrink-0 opacity-70"
+                />
+                <span class="truncate text-sm">
+                  {{ item.label }}
+                </span>
+              </div>
+            </template>
+          </template>
+        </div>
+      </div>
+      <form
+        method="dialog"
+        class="modal-backdrop"
+      >
+        <button>Close</button>
+      </form>
+    </dialog>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import type { HistoryChat } from '#shared/types/history.d'
+import { MIN_SEARCH_LENGTH } from '#shared/utils/search'
+
+interface SearchInputInstance {
+  inputRef: HTMLInputElement | null
+}
+
+interface SearchModalEntry {
+  id: string
+  iconName?: string
+  label?: string
+  chat?: HistoryChat
+  run: () => void
+}
+
+interface SearchModalItem extends SearchModalEntry {
+  index: number
+}
+
+interface SearchModalGroup<Item = SearchModalItem> {
+  id: string
+  heading: string | null
+  items: Item[]
+}
+
+const RESULTS_LIMIT = 5
+const SEARCH_DEBOUNCE_MS = 180
+
+const route = useRoute()
+const { loggedIn } = useAuth()
+const { isModalOpen, openSearchModal, closeSearchModal } = useSearchModal()
+const { currentPreference, toggle } = useThemeToggle()
+const {
+  pendingOpen: pendingFilesModalOpen,
+  requestOpen: requestFilesModalOpen,
+  clearPendingOpen: clearPendingFilesModalOpen,
+} = useFilesModalHandoff()
+
+const modal = useTemplateRef<HTMLDialogElement>('modal')
+const list = useTemplateRef<HTMLElement>('list')
+const searchInputRef = shallowRef<SearchInputInstance | null>(null)
+
+const query = shallowRef<string>('')
+const results = shallowRef<HistoryChat[]>([])
+const isSearching = shallowRef<boolean>(false)
+const activeIndex = shallowRef<number>(0)
+
+let requestId = 0
+
+const trimmedQuery = computed<string>(() => query.value.trim())
+
+const hasSearchQuery = computed<boolean>(() => {
+  return trimmedQuery.value.length >= MIN_SEARCH_LENGTH
+})
+
+const themeIconName = computed<string>(() => {
+  if (currentPreference.value === 'light') {
+    return 'lucide:sun'
+  }
+
+  if (currentPreference.value === 'dark') {
+    return 'lucide:moon'
+  }
+
+  return 'lucide:sun-moon'
+})
+
+function dismiss() {
+  closeSearchModal()
+  modal.value?.close()
+}
+
+async function goTo(path: string) {
+  dismiss()
+
+  await navigateTo(path)
+}
+
+function toggleTheme() {
+  dismiss()
+  toggle()
+}
+
+async function openAttachments() {
+  dismiss()
+
+  const isOnChatPage = route.name === 'chats-slug' || route.name === 'chats-new'
+  const targetPath = isOnChatPage ? route.path : '/chats/new'
+
+  requestFilesModalOpen('select', targetPath, 'all')
+
+  if (isOnChatPage) {
+    return
+  }
+
+  await navigateTo(targetPath)
+}
+
+async function findInChats() {
+  const search = trimmedQuery.value
+
+  dismiss()
+
+  await navigateTo({ path: '/chats/history', query: { search } })
+}
+
+function buildCommandGroups(): SearchModalGroup<SearchModalEntry>[] {
+  return [
+    {
+      id: 'primary',
+      heading: null,
+      items: [
+        {
+          id: 'search-option-new-chat',
+          iconName: 'lucide:plus',
+          label: 'New Chat',
+          run: () => goTo('/chats/new'),
+        },
+      ],
+    },
+    {
+      id: 'chat',
+      heading: 'Chat',
+      items: [
+        {
+          id: 'search-option-history',
+          iconName: 'lucide:history',
+          label: 'Manage Chat History',
+          run: () => goTo('/chats/history'),
+        },
+        {
+          id: 'search-option-attachments',
+          iconName: 'lucide:paperclip',
+          label: 'View All Uploaded Attachments',
+          run: openAttachments,
+        },
+      ],
+    },
+    {
+      id: 'settings',
+      heading: 'Settings',
+      items: [
+        {
+          id: 'search-option-theme',
+          iconName: themeIconName.value,
+          label: 'Toggle Theme',
+          run: toggleTheme,
+        },
+        {
+          id: 'search-option-security',
+          iconName: 'lucide:shield-check',
+          label: 'Security',
+          run: () => goTo('/profile/security'),
+        },
+        {
+          id: 'search-option-keys',
+          iconName: 'lucide:key-round',
+          label: 'API Keys',
+          run: () => goTo('/profile/keys'),
+        },
+      ],
+    },
+  ]
+}
+
+function buildResultGroups(): SearchModalGroup<SearchModalEntry>[] {
+  const resultGroups: SearchModalGroup<SearchModalEntry>[] = []
+
+  if (results.value.length) {
+    resultGroups.push({
+      id: 'chats',
+      heading: 'Chats',
+      items: results.value.map((chat) => {
+        return {
+          id: `search-option-chat-${chat.id}`,
+          chat,
+          run: () => goTo(`/chats/${chat.slug}`),
+        }
+      }),
+    })
+  }
+
+  resultGroups.push({
+    id: 'actions',
+    heading: 'Actions',
+    items: [
+      {
+        id: 'search-option-find-in-chats',
+        iconName: 'lucide:search',
+        label: `Find "${trimmedQuery.value}" in chats`,
+        run: findInChats,
+      },
+    ],
+  })
+
+  return resultGroups
+}
+
+const groups = computed<SearchModalGroup[]>(() => {
+  const rawGroups = hasSearchQuery.value
+    ? buildResultGroups()
+    : buildCommandGroups()
+  const indexedGroups: SearchModalGroup[] = []
+
+  let index = 0
+
+  for (const group of rawGroups) {
+    const items: SearchModalItem[] = []
+
+    for (const entry of group.items) {
+      items.push({ ...entry, index })
+      index += 1
+    }
+
+    indexedGroups.push({ ...group, items })
+  }
+
+  return indexedGroups
+})
+
+const items = computed<SearchModalItem[]>(() => {
+  return groups.value.flatMap((group) => {
+    return group.items
+  })
+})
+
+const activeDescendantId = computed<string | null>(() => {
+  return items.value[activeIndex.value]?.id ?? null
+})
+
+function syncActiveDescendant() {
+  const input = searchInputRef.value?.inputRef
+
+  if (!input) {
+    return
+  }
+
+  if (!activeDescendantId.value) {
+    input.removeAttribute('aria-activedescendant')
+
+    return
+  }
+
+  input.setAttribute('aria-activedescendant', activeDescendantId.value)
+}
+
+async function scrollActiveIntoView() {
+  await nextTick()
+
+  const activeId = activeDescendantId.value
+
+  if (!activeId) {
+    return
+  }
+
+  const element = list.value?.querySelector<HTMLElement>(`[id="${activeId}"]`)
+
+  element?.scrollIntoView?.({ block: 'nearest' })
+}
+
+function moveActive(step: number) {
+  const total = items.value.length
+
+  if (!total) {
+    return
+  }
+
+  activeIndex.value = (activeIndex.value + step + total) % total
+  scrollActiveIntoView()
+}
+
+function runActive() {
+  const item = items.value[activeIndex.value]
+
+  if (!item) {
+    return
+  }
+
+  item.run()
+}
+
+function onSearchKeydown(event: KeyboardEvent) {
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveActive(1)
+
+    return
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveActive(-1)
+
+    return
+  }
+
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    runActive()
+  }
+}
+
+const runSearch = useDebounceFn(async () => {
+  const search = trimmedQuery.value
+
+  if (search.length < MIN_SEARCH_LENGTH) {
+    return
+  }
+
+  requestId += 1
+
+  const currentRequestId = requestId
+
+  try {
+    const response = await $fetch('/api/v1/chats/history', {
+      query: {
+        search,
+        limit: RESULTS_LIMIT,
+      },
+    })
+
+    if (currentRequestId !== requestId) {
+      return
+    }
+
+    results.value = [
+      ...response.pinned,
+      ...response.chats,
+    ].slice(0, RESULTS_LIMIT)
+  } catch {
+    if (currentRequestId !== requestId) {
+      return
+    }
+
+    results.value = []
+  }
+
+  isSearching.value = false
+}, SEARCH_DEBOUNCE_MS)
+
+function resetState() {
+  requestId += 1
+  query.value = ''
+  results.value = []
+  isSearching.value = false
+  activeIndex.value = 0
+}
+
+function onDialogClosed() {
+  closeSearchModal()
+  resetState()
+}
+
+async function focusSearchInput() {
+  await nextTick()
+
+  searchInputRef.value?.inputRef?.focus()
+  syncActiveDescendant()
+}
+
+watch(trimmedQuery, (search) => {
+  if (search.length < MIN_SEARCH_LENGTH) {
+    requestId += 1
+    results.value = []
+    isSearching.value = false
+
+    return
+  }
+
+  isSearching.value = true
+  runSearch()
+})
+
+watch([hasSearchQuery, results], () => {
+  activeIndex.value = 0
+})
+
+watch(activeDescendantId, () => {
+  syncActiveDescendant()
+}, { flush: 'post' })
+
+watch([isModalOpen, modal], ([open, dialog]) => {
+  if (!dialog) {
+    return
+  }
+
+  if (!open) {
+    dialog.close()
+
+    return
+  }
+
+  if (dialog.open) {
+    return
+  }
+
+  dialog.showModal()
+  focusSearchInput()
+}, { immediate: true, flush: 'post' })
+
+watch(() => route.path, (routePath) => {
+  if (!pendingFilesModalOpen.value) {
+    return
+  }
+
+  if (routePath === pendingFilesModalOpen.value.targetPath) {
+    return
+  }
+
+  clearPendingFilesModalOpen()
+})
+
+function onGlobalKeydown(event: KeyboardEvent) {
+  if (!loggedIn.value) {
+    return
+  }
+
+  if (document.querySelector('dialog[open]')) {
+    return
+  }
+
+  if (!(event.metaKey || event.ctrlKey)) {
+    return
+  }
+
+  if (event.key?.toLowerCase() !== 'k') {
+    return
+  }
+
+  event.preventDefault()
+  openSearchModal()
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', onGlobalKeydown)
+  syncActiveDescendant()
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onGlobalKeydown)
+})
+</script>

--- a/app/components/Search/Modal.client.vue
+++ b/app/components/Search/Modal.client.vue
@@ -3,7 +3,7 @@
     <dialog
       ref="modal"
       data-testid="search-modal"
-      class="js-search-modal modal modal-middle"
+      class="js-search-modal modal modal-bottom sm:modal-middle"
       aria-label="Search"
       @close="onDialogClosed"
     >

--- a/app/components/Search/Modal.client.vue
+++ b/app/components/Search/Modal.client.vue
@@ -12,6 +12,7 @@
           <UiSearchInput
             ref="searchInputRef"
             v-model="query"
+            class="input-sm"
             :is-searching="isSearching"
             :show-keyboard-hint="false"
             placeholder="Search chats and actions..."
@@ -169,7 +170,6 @@ async function goTo(path: string) {
 }
 
 function toggleTheme() {
-  dismiss()
   toggle()
 }
 

--- a/app/components/Search/ResultRow.vue
+++ b/app/components/Search/ResultRow.vue
@@ -1,0 +1,50 @@
+<template>
+  <div
+    data-testid="search-result-row"
+    class="rounded-box px-3 py-2 cursor-pointer transition-colors"
+    :class="active ? 'bg-base-content/10' : 'hover:bg-base-content/5'"
+    @click="emit('select')"
+  >
+    <span class="block truncate text-sm font-medium">
+      {{ chat.title || 'Untitled Chat' }}
+    </span>
+    <div class="flex flex-wrap items-center gap-2 mt-0.5">
+      <span class="text-xs opacity-50 truncate">
+        {{ activityAge }}
+      </span>
+      <span
+        v-if="chat.projectName"
+        class="badge badge-ghost badge-sm gap-1"
+      >
+        <Icon name="lucide:folder" size="10" />
+        {{ chat.projectName }}
+      </span>
+      <span
+        v-if="chat.shared"
+        data-testid="chat-shared-badge"
+        class="badge badge-ghost badge-sm gap-1"
+      >
+        <Icon name="lucide:link" size="10" />
+        Shared
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { HistoryChat } from '#shared/types/history.d'
+import { formatActivityAge } from '#shared/utils/date-groups'
+
+const props = defineProps<{
+  chat: HistoryChat
+  active: boolean
+}>()
+
+const emit = defineEmits<{
+  select: []
+}>()
+
+const activityAge = computed<string>(() => {
+  return formatActivityAge(new Date(props.chat.activityAt))
+})
+</script>

--- a/app/components/Sidebar.client.vue
+++ b/app/components/Sidebar.client.vue
@@ -39,14 +39,14 @@
         <template v-if="loggedIn">
           <LazySidebarNewChat />
           <UiButton
-            to="/chats/history"
+            data-testid="sidebar-search-trigger"
             ghost
-            :disabled="$route.path === '/chats/history'"
-            icon-name="lucide:history"
+            icon-name="lucide:search"
             :icon-only="true"
-            title="History"
+            title="Search"
             circle
             tooltip-position="left"
+            @click="openSearchModal"
           />
           <LazySidebarDevelopment />
         </template>
@@ -61,6 +61,7 @@ const { isDesktop } = useDevice()
 const { visible } = useAnimateAppear()
 const { hasSafeAreaBottom } = useDeviceSafeArea()
 const { sidebarPinned } = useUserSetting()
+const { openSearchModal } = useSearchModal()
 
 const isHomePage = computed<boolean>(() => route.fullPath === '/')
 

--- a/app/components/Sidebar.client.vue
+++ b/app/components/Sidebar.client.vue
@@ -12,7 +12,7 @@
       'max-sm:translate-y-0': visible && !hasSafeAreaBottom,
       'max-sm:translate-y-[var(--sab)]':
         visible && !isKeyboardVisible && hasSafeAreaBottom,
-      'sidebar-hoverable': isDesktop && !sidebarPinned,
+      'sidebar-hoverable': isDesktop && !sidebarPinned && !isModalOpen,
     }"
   >
     <div class="sidebar-clip">
@@ -46,6 +46,7 @@
             title="Search"
             circle
             tooltip-position="left"
+            :class="{ 'btn-active': isModalOpen }"
             @click="openSearchModal"
           />
           <LazySidebarDevelopment />
@@ -61,7 +62,7 @@ const { isDesktop } = useDevice()
 const { visible } = useAnimateAppear()
 const { hasSafeAreaBottom } = useDeviceSafeArea()
 const { sidebarPinned } = useUserSetting()
-const { openSearchModal } = useSearchModal()
+const { isModalOpen, openSearchModal } = useSearchModal()
 
 const isHomePage = computed<boolean>(() => route.fullPath === '/')
 

--- a/app/components/Sidebar/ThemeSwitcher.vue
+++ b/app/components/Sidebar/ThemeSwitcher.vue
@@ -15,7 +15,7 @@
       :tooltip-position="tipsPosition"
       :title="label"
       :text="preferenceLabel"
-      @click="changeColorMode"
+      @click="toggle"
     >
       <template #icon>
         <Icon
@@ -58,7 +58,7 @@
 </template>
 
 <script setup lang="ts">
-import type { FaviconTheme, ThemePreference } from '~/types/favicon.d'
+import type { FaviconTheme } from '~/types/favicon.d'
 import type { ButtonProps } from '~/types/button.d'
 
 interface Props {
@@ -78,13 +78,12 @@ withDefaults(defineProps<Props>(), {
 
 const { setFavicon } = useThemeFavicon()
 const colorMode = useColorMode()
-const { isIos } = useDevice()
-
-const pending = shallowRef<boolean>(false)
-
-const currentPreference = computed<ThemePreference>(() => {
-  return colorMode.preference as ThemePreference
-})
+const {
+  currentPreference,
+  pending,
+  setThemeColorMeta,
+  toggle,
+} = useThemeToggle()
 
 const resolvedTheme = computed<FaviconTheme>(() => {
   return colorMode.value as FaviconTheme
@@ -112,68 +111,6 @@ onBeforeUnmount(() => {
 
   darkModeQuery.removeEventListener('change', prefersColorSchemeHandler)
 })
-
-const appConfig = useAppConfig()
-
-function setThemeColorMeta(theme: FaviconTheme) {
-  const existing = document.querySelectorAll('meta[name="theme-color"]')
-
-  existing.forEach((element, index) => {
-    if (index === 0) {
-      element.removeAttribute('media')
-    } else {
-      element.remove()
-    }
-  })
-
-  let themeColorMeta = document.querySelector('meta[name="theme-color"]')
-
-  if (!themeColorMeta) {
-    themeColorMeta = document.createElement('meta')
-    themeColorMeta.setAttribute('name', 'theme-color')
-    document.head.appendChild(themeColorMeta)
-  }
-
-  if (
-    theme === 'light'
-    && window.matchMedia('(prefers-color-scheme: dark)').matches
-  ) {
-    themeColorMeta.setAttribute(
-      'content',
-      appConfig.themeColor['lightForDark'],
-    )
-  } else {
-    themeColorMeta.setAttribute('content', appConfig.themeColor[theme])
-  }
-}
-
-async function reloadStandaloneApp() {
-  if (!isIos) {
-    return
-  }
-
-  pending.value = true
-  await nextTick()
-
-  setTimeout(() => {
-    reloadNuxtApp({
-      force: true,
-    })
-  }, 500)
-}
-
-function changeColorMode() {
-  const nextPreference: ThemePreference
-    = currentPreference.value === 'light'
-      ? 'dark'
-      : currentPreference.value === 'dark'
-        ? 'system'
-        : 'light'
-
-  colorMode.preference = nextPreference
-  setThemeColorMeta(resolvedTheme.value)
-  reloadStandaloneApp()
-}
 
 watch(resolvedTheme, (newTheme) => {
   setFavicon(newTheme)

--- a/app/composables/files-modal-handoff.ts
+++ b/app/composables/files-modal-handoff.ts
@@ -1,0 +1,32 @@
+import type { FileSourceFilter } from '~/types/file-manager'
+
+interface PendingFilesModalOpen {
+  tab: 'select' | 'upload'
+  source?: FileSourceFilter
+  targetPath: string
+}
+
+export function useFilesModalHandoff() {
+  const pendingOpen = useState<PendingFilesModalOpen | null>(
+    'files-modal-handoff:pending-open',
+    () => null,
+  )
+
+  function requestOpen(
+    tab: 'select' | 'upload',
+    targetPath: string,
+    source?: FileSourceFilter,
+  ) {
+    pendingOpen.value = { tab, source, targetPath }
+  }
+
+  function clearPendingOpen() {
+    pendingOpen.value = null
+  }
+
+  return {
+    pendingOpen,
+    requestOpen,
+    clearPendingOpen,
+  }
+}

--- a/app/composables/search-modal.ts
+++ b/app/composables/search-modal.ts
@@ -1,0 +1,23 @@
+export function useSearchModal() {
+  const { loggedIn } = useAuth()
+
+  const isModalOpen = useState<boolean>('search:is-modal-open', () => false)
+
+  function openSearchModal() {
+    if (!loggedIn.value) {
+      return
+    }
+
+    isModalOpen.value = true
+  }
+
+  function closeSearchModal() {
+    isModalOpen.value = false
+  }
+
+  return {
+    isModalOpen,
+    openSearchModal,
+    closeSearchModal,
+  }
+}

--- a/app/composables/theme-toggle.ts
+++ b/app/composables/theme-toggle.ts
@@ -1,0 +1,84 @@
+import type { FaviconTheme, ThemePreference } from '~/types/favicon.d'
+
+export const useThemeToggle = () => {
+  const colorMode = useColorMode()
+  const { isIos } = useDevice()
+  const appConfig = useAppConfig()
+
+  const pending = useState<boolean>('theme-toggle:pending', () => false)
+
+  const currentPreference = computed<ThemePreference>(() => {
+    return colorMode.preference as ThemePreference
+  })
+
+  const resolvedTheme = computed<FaviconTheme>(() => {
+    return colorMode.value as FaviconTheme
+  })
+
+  function setThemeColorMeta(theme: FaviconTheme) {
+    const existing = document.querySelectorAll('meta[name="theme-color"]')
+
+    existing.forEach((element, index) => {
+      if (index === 0) {
+        element.removeAttribute('media')
+      } else {
+        element.remove()
+      }
+    })
+
+    let themeColorMeta = document.querySelector('meta[name="theme-color"]')
+
+    if (!themeColorMeta) {
+      themeColorMeta = document.createElement('meta')
+      themeColorMeta.setAttribute('name', 'theme-color')
+      document.head.appendChild(themeColorMeta)
+    }
+
+    if (
+      theme === 'light'
+      && window.matchMedia('(prefers-color-scheme: dark)').matches
+    ) {
+      themeColorMeta.setAttribute(
+        'content',
+        appConfig.themeColor['lightForDark'],
+      )
+    } else {
+      themeColorMeta.setAttribute('content', appConfig.themeColor[theme])
+    }
+  }
+
+  async function reloadStandaloneApp() {
+    if (!isIos) {
+      return
+    }
+
+    pending.value = true
+    await nextTick()
+
+    setTimeout(() => {
+      reloadNuxtApp({
+        force: true,
+      })
+    }, 500)
+  }
+
+  function toggle() {
+    const nextPreference: ThemePreference
+      = currentPreference.value === 'light'
+        ? 'dark'
+        : currentPreference.value === 'dark'
+          ? 'system'
+          : 'light'
+
+    colorMode.preference = nextPreference
+    setThemeColorMeta(resolvedTheme.value)
+    reloadStandaloneApp()
+  }
+
+  return {
+    currentPreference,
+    pending,
+    setThemeColorMeta,
+    toggle,
+  }
+}

--- a/app/pages/chats/history/index.vue
+++ b/app/pages/chats/history/index.vue
@@ -35,7 +35,9 @@
       :is-loading-initial="isLoadingInitial && !hasCachedData"
       :is-selection-mode="isSelectionMode"
       :selected-ids="selectedIds"
-      :empty-state-mode="search.length >= 2 ? 'search' : 'history'"
+      :empty-state-mode="search.length >= MIN_SEARCH_LENGTH
+        ? 'search'
+        : 'history'"
       empty-action-to="/chats/new"
       empty-action-label="New chat"
       @pin="togglePin"
@@ -73,6 +75,7 @@
 
 <script setup lang="ts">
 import type { HistoryChat } from '#shared/types/history.d'
+import { MIN_SEARCH_LENGTH } from '#shared/utils/search'
 
 definePageMeta({
   auth: {
@@ -121,9 +124,25 @@ if (import.meta.client && !nuxtApp.isHydrating) {
   groupedAt.value = new Date().toISOString()
 }
 
+const route = useRoute()
+
+watch(() => route.query.search, (searchParam) => {
+  if (typeof searchParam !== 'string' || !searchParam.trim()) {
+    return
+  }
+
+  search.value = searchParam.trim()
+}, { immediate: true })
+
 if (import.meta.server && !hasCachedData.value) {
   const requestFetch = useRequestFetch()
-  const response = await requestFetch('/api/v1/chats/history')
+  const response = await requestFetch('/api/v1/chats/history', {
+    query: {
+      ...(search.value.length >= MIN_SEARCH_LENGTH
+        ? { search: search.value }
+        : {}),
+    },
+  })
 
   prime(response)
 }

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -81,6 +81,7 @@ export function getAffectedTests(changedFiles) {
     'tests/unit/utils/model.spec.ts',
     'tests/unit/utils/image-generation-cost.spec.ts',
     'tests/unit/composables/chat-input.spec.ts',
+    'tests/unit/components/ChatInput.spec.ts',
     'tests/unit/components/ChatInput/ModelsTrigger.spec.ts',
     'tests/integration/server/image-generation.spec.ts',
     'tests/integration/server/image-generation-lock.spec.ts',
@@ -128,6 +129,7 @@ export function getAffectedTests(changedFiles) {
     'tests/unit/composables/project-chats.spec.ts',
     'tests/unit/components/History/ChatSections.spec.ts',
     'tests/unit/pages/chats-new.spec.ts',
+    'tests/unit/pages/chats/history/index.spec.ts',
     'tests/unit/pages/projects-index.spec.ts',
     'tests/unit/utils/date-groups.spec.ts',
     'tests/unit/utils/project-activity.spec.ts',
@@ -280,6 +282,15 @@ export function getAffectedTests(changedFiles) {
 
   const seoTests = [
     'tests/unit/config/seo.spec.ts',
+  ]
+
+  const searchModalTests = [
+    'tests/unit/composables/search-modal.spec.ts',
+    'tests/unit/composables/files-modal-handoff.spec.ts',
+    'tests/unit/components/Search/Modal.spec.ts',
+    'tests/unit/components/Search/ResultRow.spec.ts',
+    'tests/unit/components/Sidebar.spec.ts',
+    'tests/unit/components/ChatInput.spec.ts',
   ]
 
   const deepResearchTests = [
@@ -544,11 +555,28 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern:
-        /^app\/components\/Sidebar\/ThemeSwitcher\.vue$/,
+        /^(app\/components\/Sidebar\/ThemeSwitcher\.vue|app\/composables\/theme-toggle\.ts)$/,
       tests: [
         'tests/unit/components/ThemeSwitcher.spec.ts',
+        'tests/unit/composables/theme-toggle.spec.ts',
         'tests/e2e/settings/theme.spec.ts',
         'tests/e2e/settings/theme-tokens.spec.ts',
+      ],
+    },
+    {
+      pattern: /^app\/components\/Sidebar\.client\.vue$/,
+      tests: ['tests/unit/components/Sidebar.spec.ts'],
+    },
+    {
+      pattern:
+        /^(app\/composables\/(search-modal|files-modal-handoff)\.ts|app\/components\/Search\/.*\.vue)$/,
+      tests: searchModalTests,
+    },
+    {
+      pattern: /^shared\/utils\/search\.ts$/,
+      tests: [
+        ...searchModalTests,
+        'tests/unit/pages/chats/history/index.spec.ts',
       ],
     },
     {
@@ -668,7 +696,7 @@ export function getAffectedTests(changedFiles) {
       tests: historyProjectsTests,
     },
     {
-      pattern: /^app\/pages\/chats\/(history|new)\.vue$/,
+      pattern: /^app\/pages\/chats\/(history\/index|new)\.vue$/,
       tests: historyProjectsTests,
     },
     {

--- a/shared/utils/search.ts
+++ b/shared/utils/search.ts
@@ -1,0 +1,1 @@
+export const MIN_SEARCH_LENGTH = 2

--- a/tests/setup/helpers/history-fixtures.ts
+++ b/tests/setup/helpers/history-fixtures.ts
@@ -16,6 +16,7 @@ export function createHistoryChat(
     pinnedAt: overrides.pinnedAt ?? null,
     projectId: overrides.projectId ?? null,
     projectName: overrides.projectName ?? null,
+    shared: overrides.shared ?? false,
   }
 }
 

--- a/tests/unit/components/ChatInput.spec.ts
+++ b/tests/unit/components/ChatInput.spec.ts
@@ -1,0 +1,222 @@
+import { computed, defineComponent, nextTick, reactive, shallowRef } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { enableAutoUnmount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ChatInput from '../../../app/components/ChatInput.client.vue'
+import { useFilesModalHandoff } from '../../../app/composables/files-modal-handoff'
+
+const mocks = vi.hoisted(() => ({
+  useChatInput: vi.fn(),
+  useChatFiles: vi.fn(),
+  useDevice: vi.fn(),
+  uploadFiles: vi.fn(),
+}))
+
+mockNuxtImport('useChatInput', () => mocks.useChatInput)
+mockNuxtImport('useChatFiles', () => mocks.useChatFiles)
+mockNuxtImport('useDevice', () => mocks.useDevice)
+
+const mockRoute = reactive<{ path: string }>({ path: '/chats/abc123' })
+
+mockNuxtImport('useRoute', () => {
+  return () => mockRoute
+})
+
+const filesModalOpenMock = vi.fn()
+
+const filesModalStub = defineComponent({
+  name: 'ChatInputFilesModalStub',
+  methods: {
+    open: filesModalOpenMock,
+  },
+  template: '<div />',
+})
+
+enableAutoUnmount(afterEach)
+
+function mountChatInput() {
+  return mountSuspended(ChatInput, {
+    props: {
+      messagesLength: 0,
+      stop: vi.fn(),
+      regenerate: vi.fn(),
+    },
+    attachTo: document.body,
+    global: {
+      stubs: {
+        ChatInputFilesModal: filesModalStub,
+        LazyChatInputFilesModal: filesModalStub,
+        LazyChatInputFilesDropZone: true,
+        LazyChatScroll: true,
+        LazyChatInputFilesAttachedPreview: true,
+        LazyChatInputModelsTrigger: true,
+        LazyChatInputFilesTrigger: true,
+        LazyChatInputReasoningTrigger: true,
+        LazyChatInputDeepResearchTrigger: true,
+        LazyChatInputToolbarMore: true,
+        UiBubble: true,
+        UiButton: true,
+      },
+    },
+  })
+}
+
+function createPasteEvent(files: File[]) {
+  const event = new Event('paste', { cancelable: true }) as ClipboardEvent
+  const items = files.map((file) => {
+    return {
+      type: file.type,
+      getAsFile: () => file,
+    }
+  })
+
+  Object.defineProperty(event, 'clipboardData', {
+    value: { items },
+    configurable: true,
+  })
+
+  return event
+}
+
+function appendBlockingDialog(className: string) {
+  const dialog = document.createElement('dialog')
+
+  dialog.className = className
+  dialog.setAttribute('open', '')
+  document.body.appendChild(dialog)
+
+  return dialog
+}
+
+describe('ChatInput.client', () => {
+  beforeEach(() => {
+    mockRoute.path = '/chats/abc123'
+
+    mocks.useChatInput.mockReturnValue({
+      isWebSearchSupported: shallowRef(false),
+      isImageGenerationSupported: shallowRef(false),
+      isImageGenerationRequired: shallowRef(false),
+      isReasoningSupported: shallowRef(false),
+      reasoningCapability: shallowRef(null),
+      reasoningMode: shallowRef('none'),
+      isDeepResearchModel: shallowRef(false),
+      researchConfig: shallowRef(null),
+    })
+
+    mocks.useChatFiles.mockReturnValue({
+      uploadFiles: mocks.uploadFiles,
+      uploadingFiles: shallowRef(new Map()),
+      uploadingCount: computed(() => 0),
+      cancelUpload: vi.fn(),
+      retryUpload: vi.fn(),
+      cancelAllUploads: vi.fn(),
+      removeAttachedFile: vi.fn(),
+      removeAllFiles: vi.fn(),
+    })
+
+    mocks.useDevice.mockReturnValue({
+      isIos: false,
+      isAndroid: false,
+      isDesktop: true,
+    })
+
+    filesModalOpenMock.mockReset()
+    mocks.uploadFiles.mockReset()
+
+    useFilesModalHandoff().clearPendingOpen()
+  })
+
+  afterEach(() => {
+    document
+      .querySelectorAll('dialog.js-files-modal, dialog.js-search-modal')
+      .forEach((dialog) => {
+        dialog.remove()
+      })
+  })
+
+  describe('files-modal handoff consumption', () => {
+    it('opens the files modal and clears the flag for a pending request already matching the route at mount', async () => {
+      useFilesModalHandoff().requestOpen('select', '/chats/abc123', 'all')
+
+      await mountChatInput()
+      await nextTick()
+
+      expect(filesModalOpenMock).toHaveBeenCalledWith('select', 'all')
+      expect(useFilesModalHandoff().pendingOpen.value).toBeNull()
+    })
+
+    it('opens the files modal when a matching request arrives after mount', async () => {
+      await mountChatInput()
+      await nextTick()
+
+      useFilesModalHandoff().requestOpen('upload', '/chats/abc123')
+      await nextTick()
+
+      expect(filesModalOpenMock).toHaveBeenCalledWith('upload', undefined)
+      expect(useFilesModalHandoff().pendingOpen.value).toBeNull()
+    })
+
+    it('does not open the files modal while the target path does not match the current route, but still opens a fresh matching request (proving the modal ref is live, not just unreachable)', async () => {
+      useFilesModalHandoff().requestOpen(
+        'select',
+        '/chats/other-chat',
+        'all',
+      )
+
+      await mountChatInput()
+      await nextTick()
+
+      expect(filesModalOpenMock).not.toHaveBeenCalled()
+      expect(useFilesModalHandoff().pendingOpen.value).toEqual({
+        tab: 'select',
+        source: 'all',
+        targetPath: '/chats/other-chat',
+      })
+
+      useFilesModalHandoff().requestOpen('upload', '/chats/abc123')
+      await nextTick()
+
+      expect(filesModalOpenMock).toHaveBeenCalledWith('upload', undefined)
+      expect(useFilesModalHandoff().pendingOpen.value).toBeNull()
+    })
+  })
+
+  describe('paste-to-attach guard', () => {
+    it('uploads a pasted image when no blocking dialog is open', async () => {
+      await mountChatInput()
+
+      const file = new File(['data'], 'clip.png', { type: 'image/png' })
+      const event = createPasteEvent([file])
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+      document.dispatchEvent(event)
+
+      expect(preventDefaultSpy).toHaveBeenCalled()
+      expect(mocks.uploadFiles).toHaveBeenCalledWith([file])
+    })
+
+    it('ignores a pasted image while the files modal dialog is open', async () => {
+      await mountChatInput()
+
+      appendBlockingDialog('js-files-modal')
+
+      const file = new File(['data'], 'clip.png', { type: 'image/png' })
+
+      document.dispatchEvent(createPasteEvent([file]))
+
+      expect(mocks.uploadFiles).not.toHaveBeenCalled()
+    })
+
+    it('ignores a pasted image while the search modal dialog is open', async () => {
+      await mountChatInput()
+
+      appendBlockingDialog('js-search-modal')
+
+      const file = new File(['data'], 'clip.png', { type: 'image/png' })
+
+      document.dispatchEvent(createPasteEvent([file]))
+
+      expect(mocks.uploadFiles).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/components/Search/Modal.spec.ts
+++ b/tests/unit/components/Search/Modal.spec.ts
@@ -191,7 +191,7 @@ describe('Search/Modal.client', () => {
     expect(closeSpy).toHaveBeenCalled()
   })
 
-  it('closes the modal and calls toggle() for the theme row', async () => {
+  it('calls toggle() for the theme row without closing the modal', async () => {
     useSearchModal().isModalOpen.value = true
 
     const wrapper = await mountModal()
@@ -199,7 +199,7 @@ describe('Search/Modal.client', () => {
     await wrapper.find('#search-option-theme').trigger('click')
 
     expect(mocks.toggleThemeMock).toHaveBeenCalledTimes(1)
-    expect(useSearchModal().isModalOpen.value).toBe(false)
+    expect(useSearchModal().isModalOpen.value).toBe(true)
   })
 
   it('shows the theme icon matching the current preference', async () => {

--- a/tests/unit/components/Search/Modal.spec.ts
+++ b/tests/unit/components/Search/Modal.spec.ts
@@ -1,0 +1,505 @@
+import { nextTick, reactive, ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { enableAutoUnmount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ThemePreference } from '~/types/favicon.d'
+import SearchModal from '../../../../app/components/Search/Modal.client.vue'
+import { useSearchModal } from '../../../../app/composables/search-modal'
+import { useFilesModalHandoff } from '../../../../app/composables/files-modal-handoff'
+import {
+  createHistoryChat,
+  createHistoryResponse,
+} from '../../../setup/helpers/history-fixtures'
+
+const mocks = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  navigateToMock: vi.fn(),
+  toggleThemeMock: vi.fn(),
+}))
+
+const loggedIn = ref<boolean>(true)
+const currentPreference = ref<ThemePreference>('light')
+const mockRoute = reactive<{ name: string | undefined, path: string }>({
+  name: 'chats-new',
+  path: '/chats/new',
+})
+
+mockNuxtImport('$fetch', () => mocks.fetchMock)
+mockNuxtImport('navigateTo', () => mocks.navigateToMock)
+
+mockNuxtImport('useAuth', () => {
+  return () => ({ loggedIn })
+})
+
+mockNuxtImport('useRoute', () => {
+  return () => mockRoute
+})
+
+mockNuxtImport('useThemeToggle', () => {
+  return () => ({
+    currentPreference,
+    toggle: mocks.toggleThemeMock,
+  })
+})
+
+enableAutoUnmount(afterEach)
+
+function stubMatchMedia() {
+  vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => {
+    return {
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList
+  })
+}
+
+function mountModal() {
+  return mountSuspended(SearchModal, { attachTo: document.body })
+}
+
+async function waitForDebouncedSearch() {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 250)
+  })
+  await nextTick()
+}
+
+let showModalSpy: ReturnType<typeof vi.spyOn>
+let closeSpy: ReturnType<typeof vi.spyOn>
+
+describe('Search/Modal.client', () => {
+  beforeEach(() => {
+    loggedIn.value = true
+    currentPreference.value = 'light'
+    mockRoute.name = 'chats-new'
+    mockRoute.path = '/chats/new'
+
+    mocks.fetchMock.mockReset()
+    mocks.navigateToMock.mockReset().mockResolvedValue(undefined)
+    mocks.toggleThemeMock.mockReset()
+
+    useSearchModal().isModalOpen.value = false
+    useFilesModalHandoff().clearPendingOpen()
+
+    stubMatchMedia()
+
+    showModalSpy = vi.spyOn(HTMLDialogElement.prototype, 'showModal')
+      .mockImplementation(() => {})
+    closeSpy = vi.spyOn(HTMLDialogElement.prototype, 'close')
+      .mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not call showModal while the modal is closed', async () => {
+    await mountModal()
+
+    expect(showModalSpy).not.toHaveBeenCalled()
+  })
+
+  it('opens the dialog and focuses the search input when isModalOpen becomes true', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+    await nextTick()
+    await nextTick()
+
+    expect(showModalSpy).toHaveBeenCalledTimes(1)
+    expect(document.activeElement).toBe(wrapper.find('input').element)
+  })
+
+  it('sets role=listbox, an aria-label, and the js-search-modal class', async () => {
+    const wrapper = await mountModal()
+
+    expect(wrapper.find('[data-testid="search-modal-results"]')
+      .attributes('role')).toBe('listbox')
+    expect(wrapper.find('dialog').attributes('aria-label')).toBe('Search')
+    expect(wrapper.find('dialog').classes()).toContain('js-search-modal')
+  })
+
+  it('syncs isModalOpen to false and resets local state on native dialog close (B1)', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('input').setValue('report')
+    await nextTick()
+
+    await wrapper.find('dialog').trigger('close')
+
+    expect(useSearchModal().isModalOpen.value).toBe(false)
+    expect((wrapper.find('input').element as HTMLInputElement).value)
+      .toBe('')
+  })
+
+  it('renders the six documented command rows in order for an empty query', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+    await nextTick()
+
+    const ids = wrapper.findAll('[role="option"]')
+      .map(option => option.attributes('id'))
+
+    expect(ids).toEqual([
+      'search-option-new-chat',
+      'search-option-history',
+      'search-option-attachments',
+      'search-option-theme',
+      'search-option-security',
+      'search-option-keys',
+    ])
+  })
+
+  it('marks section headings as aria-hidden', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+    await nextTick()
+
+    const headingTexts = wrapper.findAll('[aria-hidden="true"]')
+      .map(heading => heading.text())
+
+    expect(headingTexts).toEqual(expect.arrayContaining(['Chat', 'Settings']))
+  })
+
+  it('closes the modal before navigating to New Chat (B6)', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    let isModalOpenDuringNavigate: boolean | null = null
+
+    mocks.navigateToMock.mockImplementation(() => {
+      isModalOpenDuringNavigate = useSearchModal().isModalOpen.value
+
+      return Promise.resolve()
+    })
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('#search-option-new-chat').trigger('click')
+
+    expect(isModalOpenDuringNavigate).toBe(false)
+    expect(mocks.navigateToMock).toHaveBeenCalledWith('/chats/new')
+    expect(closeSpy).toHaveBeenCalled()
+  })
+
+  it('closes the modal and calls toggle() for the theme row', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('#search-option-theme').trigger('click')
+
+    expect(mocks.toggleThemeMock).toHaveBeenCalledTimes(1)
+    expect(useSearchModal().isModalOpen.value).toBe(false)
+  })
+
+  it('shows the theme icon matching the current preference', async () => {
+    currentPreference.value = 'dark'
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+    await nextTick()
+
+    const themeIcon = wrapper.find('#search-option-theme .iconify')
+
+    expect(themeIcon.classes()).toContain('i-lucide:moon')
+  })
+
+  it('requests the files-modal handoff without navigating while already on a chat route', async () => {
+    mockRoute.name = 'chats-slug'
+    mockRoute.path = '/chats/abc123'
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('#search-option-attachments').trigger('click')
+
+    expect(useFilesModalHandoff().pendingOpen.value).toEqual({
+      tab: 'select',
+      source: 'all',
+      targetPath: '/chats/abc123',
+    })
+    expect(mocks.navigateToMock).not.toHaveBeenCalled()
+    expect(useSearchModal().isModalOpen.value).toBe(false)
+  })
+
+  it('navigates to /chats/new when requesting attachments off a chat route', async () => {
+    mockRoute.name = 'profile-security'
+    mockRoute.path = '/profile/security'
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('#search-option-attachments').trigger('click')
+
+    expect(mocks.navigateToMock).toHaveBeenCalledWith('/chats/new')
+    expect(useFilesModalHandoff().pendingOpen.value).toEqual({
+      tab: 'select',
+      source: 'all',
+      targetPath: '/chats/new',
+    })
+  })
+
+  it('clears a pending files-modal request when navigating away from chat routes', async () => {
+    mockRoute.name = 'chats-slug'
+    mockRoute.path = '/chats/abc123'
+    useFilesModalHandoff().requestOpen('select', '/chats/abc123', 'all')
+
+    await mountModal()
+
+    mockRoute.name = 'profile-security'
+    mockRoute.path = '/profile/security'
+    await nextTick()
+
+    expect(useFilesModalHandoff().pendingOpen.value).toBeNull()
+  })
+
+  it('keeps a pending files-modal request when the route path matches the target exactly', async () => {
+    mockRoute.name = 'chats-new'
+    mockRoute.path = '/chats/new'
+    useFilesModalHandoff().requestOpen('select', '/chats/abc123', 'all')
+
+    await mountModal()
+
+    mockRoute.name = 'chats-slug'
+    mockRoute.path = '/chats/abc123'
+    await nextTick()
+
+    expect(useFilesModalHandoff().pendingOpen.value).toEqual({
+      tab: 'select',
+      source: 'all',
+      targetPath: '/chats/abc123',
+    })
+  })
+
+  it('clears a stale attachments request when the route changes to a different chat than the target path (regression)', async () => {
+    mockRoute.name = 'profile-security'
+    mockRoute.path = '/profile/security'
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('#search-option-attachments').trigger('click')
+
+    expect(useFilesModalHandoff().pendingOpen.value).toEqual({
+      tab: 'select',
+      source: 'all',
+      targetPath: '/chats/new',
+    })
+
+    mockRoute.name = 'chats-slug'
+    mockRoute.path = '/chats/abc123'
+    await nextTick()
+
+    expect(useFilesModalHandoff().pendingOpen.value).toBeNull()
+  })
+
+  it('does not query the API or show typed results for a 1-character query', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('input').setValue('a')
+    await waitForDebouncedSearch()
+
+    expect(mocks.fetchMock).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="search-result-row"]').exists())
+      .toBe(false)
+    expect(wrapper.find('[data-testid="search-command-row"]').exists())
+      .toBe(true)
+  })
+
+  it('runs "Find in chats" on Enter before the debounced fetch resolves', async () => {
+    useSearchModal().isModalOpen.value = true
+    mocks.fetchMock.mockResolvedValue(createHistoryResponse({
+      chats: [createHistoryChat({ id: 'chat-1', slug: 'chat-1' })],
+    }))
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('input').setValue('report')
+    await wrapper.find('input').trigger('keydown', { key: 'Enter' })
+
+    expect(mocks.navigateToMock).toHaveBeenCalledWith({
+      path: '/chats/history',
+      query: { search: 'report' },
+    })
+  })
+
+  it('shows fetched chat results after the debounce elapses', async () => {
+    useSearchModal().isModalOpen.value = true
+    mocks.fetchMock.mockResolvedValue(createHistoryResponse({
+      chats: [createHistoryChat({
+        id: 'chat-1',
+        slug: 'chat-1',
+        title: 'Growth plan',
+      })],
+    }))
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('input').setValue('growth')
+    await waitForDebouncedSearch()
+
+    expect(mocks.fetchMock).toHaveBeenCalledWith('/api/v1/chats/history', {
+      query: { search: 'growth', limit: 5 },
+    })
+
+    const resultRow = wrapper.find('[data-testid="search-result-row"]')
+
+    expect(resultRow.exists()).toBe(true)
+    expect(resultRow.text()).toContain('Growth plan')
+  })
+
+  it('navigates to the selected chat and closes the modal first', async () => {
+    useSearchModal().isModalOpen.value = true
+    mocks.fetchMock.mockResolvedValue(createHistoryResponse({
+      chats: [createHistoryChat({
+        id: 'chat-1',
+        slug: 'chat-1',
+        title: 'Growth plan',
+      })],
+    }))
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('input').setValue('growth')
+    await waitForDebouncedSearch()
+
+    await wrapper.find('[data-testid="search-result-row"]').trigger('click')
+
+    expect(mocks.navigateToMock).toHaveBeenCalledWith('/chats/chat-1')
+    expect(useSearchModal().isModalOpen.value).toBe(false)
+  })
+
+  it('omits the Chats heading when the search returns no results', async () => {
+    useSearchModal().isModalOpen.value = true
+    mocks.fetchMock.mockResolvedValue(createHistoryResponse())
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('input').setValue('nothing')
+    await waitForDebouncedSearch()
+
+    expect(wrapper.find('[data-testid="search-result-row"]').exists())
+      .toBe(false)
+
+    const headingTexts = wrapper.findAll('[aria-hidden="true"]')
+      .map(heading => heading.text().trim())
+      .filter(Boolean)
+
+    expect(headingTexts).toEqual(['Actions'])
+  })
+
+  it('lists pinned chats before regular chats, capped at 5, without re-sorting', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const pinned = [
+      createHistoryChat({ id: 'p1', slug: 'p1' }),
+      createHistoryChat({ id: 'p2', slug: 'p2' }),
+    ]
+    const chats = [
+      createHistoryChat({ id: 'c1', slug: 'c1' }),
+      createHistoryChat({ id: 'c2', slug: 'c2' }),
+      createHistoryChat({ id: 'c3', slug: 'c3' }),
+      createHistoryChat({ id: 'c4', slug: 'c4' }),
+    ]
+
+    mocks.fetchMock.mockResolvedValue(createHistoryResponse({ pinned, chats }))
+
+    const wrapper = await mountModal()
+
+    await wrapper.find('input').setValue('chat')
+    await waitForDebouncedSearch()
+
+    const ids = wrapper.findAll('[role="option"]')
+      .map(option => option.attributes('id'))
+      .filter((id): id is string => !!id?.startsWith('search-option-chat-'))
+
+    expect(ids).toEqual([
+      'search-option-chat-p1',
+      'search-option-chat-p2',
+      'search-option-chat-c1',
+      'search-option-chat-c2',
+      'search-option-chat-c3',
+    ])
+  })
+
+  it('moves the active option with ArrowDown/ArrowUp and updates aria-activedescendant', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+    await nextTick()
+
+    expect(wrapper.find('input').attributes('aria-activedescendant'))
+      .toBe('search-option-new-chat')
+
+    await wrapper.find('input').trigger('keydown', { key: 'ArrowDown' })
+    await nextTick()
+    expect(wrapper.find('input').attributes('aria-activedescendant'))
+      .toBe('search-option-history')
+
+    await wrapper.find('input').trigger('keydown', { key: 'ArrowUp' })
+    await nextTick()
+    expect(wrapper.find('input').attributes('aria-activedescendant'))
+      .toBe('search-option-new-chat')
+  })
+
+  it('wraps around to the last option when pressing ArrowUp at the top', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountModal()
+    await nextTick()
+
+    await wrapper.find('input').trigger('keydown', { key: 'ArrowUp' })
+
+    expect(wrapper.find('input').attributes('aria-activedescendant'))
+      .toBe('search-option-keys')
+  })
+
+  it('opens the modal on Cmd+K when logged in and no dialog is open', async () => {
+    await mountModal()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'k',
+      metaKey: true,
+    }))
+
+    expect(useSearchModal().isModalOpen.value).toBe(true)
+  })
+
+  it('ignores Cmd+K when logged out', async () => {
+    loggedIn.value = false
+
+    await mountModal()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'k',
+      metaKey: true,
+    }))
+
+    expect(useSearchModal().isModalOpen.value).toBe(false)
+  })
+
+  it('ignores Cmd+K when a dialog is already open', async () => {
+    const wrapper = await mountModal()
+
+    wrapper.find('dialog').element.setAttribute('open', '')
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'k',
+      metaKey: true,
+    }))
+
+    expect(useSearchModal().isModalOpen.value).toBe(false)
+  })
+})

--- a/tests/unit/components/Search/ResultRow.spec.ts
+++ b/tests/unit/components/Search/ResultRow.spec.ts
@@ -1,0 +1,143 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SearchResultRow from '../../../../app/components/Search/ResultRow.vue'
+import { createHistoryChat } from '../../../setup/helpers/history-fixtures'
+
+describe('Search/ResultRow', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.setSystemTime(new Date('2026-03-11T10:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders the chat title and formatted activity age', async () => {
+    const wrapper = await mountSuspended(SearchResultRow, {
+      props: {
+        chat: createHistoryChat({ title: 'Quarterly report', shared: false }),
+        active: false,
+      },
+    })
+
+    expect(wrapper.text()).toContain('Quarterly report')
+    expect(wrapper.text()).toContain('Last activity 2 hours ago')
+  })
+
+  it('falls back to "Untitled Chat" when the title is empty', async () => {
+    const wrapper = await mountSuspended(SearchResultRow, {
+      props: {
+        chat: createHistoryChat({ title: '', shared: false }),
+        active: false,
+      },
+    })
+
+    expect(wrapper.text()).toContain('Untitled Chat')
+  })
+
+  it('shows the project badge when the chat belongs to a project', async () => {
+    const wrapper = await mountSuspended(SearchResultRow, {
+      props: {
+        chat: createHistoryChat({
+          projectName: 'Research',
+          shared: false,
+        }),
+        active: false,
+      },
+    })
+
+    expect(wrapper.text()).toContain('Research')
+  })
+
+  it('hides both badges when there is no project and it is not shared', async () => {
+    const wrapper = await mountSuspended(SearchResultRow, {
+      props: {
+        chat: createHistoryChat({ projectName: null, shared: false }),
+        active: false,
+      },
+    })
+
+    expect(wrapper.find('.badge').exists()).toBe(false)
+  })
+
+  it('shows the shared badge with the expected testid when shared', async () => {
+    const wrapper = await mountSuspended(SearchResultRow, {
+      props: {
+        chat: createHistoryChat({ shared: true }),
+        active: false,
+      },
+    })
+
+    expect(wrapper.find('[data-testid="chat-shared-badge"]').exists())
+      .toBe(true)
+  })
+
+  it('hides the shared badge when the chat is not shared', async () => {
+    const wrapper = await mountSuspended(SearchResultRow, {
+      props: {
+        chat: createHistoryChat({ shared: false }),
+        active: false,
+      },
+    })
+
+    expect(wrapper.find('[data-testid="chat-shared-badge"]').exists())
+      .toBe(false)
+  })
+
+  it('applies the active highlight class when active', async () => {
+    const wrapper = await mountSuspended(SearchResultRow, {
+      props: {
+        chat: createHistoryChat({ shared: false }),
+        active: true,
+      },
+    })
+
+    expect(wrapper.classes()).toContain('bg-base-content/10')
+    expect(wrapper.classes()).not.toContain('hover:bg-base-content/5')
+  })
+
+  it('applies the hover class when inactive', async () => {
+    const wrapper = await mountSuspended(SearchResultRow, {
+      props: {
+        chat: createHistoryChat({ shared: false }),
+        active: false,
+      },
+    })
+
+    expect(wrapper.classes()).toContain('hover:bg-base-content/5')
+    expect(wrapper.classes()).not.toContain('bg-base-content/10')
+  })
+
+  it('emits select when clicked', async () => {
+    const wrapper = await mountSuspended(SearchResultRow, {
+      props: {
+        chat: createHistoryChat({ shared: false }),
+        active: false,
+      },
+    })
+
+    await wrapper.trigger('click')
+
+    expect(wrapper.emitted('select')).toHaveLength(1)
+  })
+
+  it('has a single root element so parent-assigned attrs fall through', async () => {
+    const wrapper = await mountSuspended(SearchResultRow, {
+      props: {
+        chat: createHistoryChat({ shared: false }),
+        active: false,
+      },
+      attrs: {
+        'id': 'search-option-chat-1',
+        'role': 'option',
+        'aria-selected': 'true',
+      },
+    })
+
+    expect(wrapper.attributes('id')).toBe('search-option-chat-1')
+    expect(wrapper.attributes('role')).toBe('option')
+    expect(wrapper.attributes('aria-selected')).toBe('true')
+    expect(wrapper.attributes('data-testid')).toBe('search-result-row')
+  })
+})

--- a/tests/unit/components/Sidebar.spec.ts
+++ b/tests/unit/components/Sidebar.spec.ts
@@ -80,6 +80,31 @@ describe('Sidebar.client', () => {
     expect(isModalOpen.value).toBe(true)
   })
 
+  it('carries btn-active on the search trigger while the modal is open', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountSidebar()
+    const trigger = wrapper.get('[data-testid="sidebar-search-trigger"]')
+
+    expect(trigger.classes()).toContain('btn-active')
+  })
+
+  it('does not carry btn-active on the search trigger while the modal is closed', async () => {
+    const wrapper = await mountSidebar()
+    const trigger = wrapper.get('[data-testid="sidebar-search-trigger"]')
+
+    expect(trigger.classes()).not.toContain('btn-active')
+  })
+
+  it('omits sidebar-hoverable from the root element while the modal is open', async () => {
+    useSearchModal().isModalOpen.value = true
+
+    const wrapper = await mountSidebar()
+
+    expect(wrapper.get('[data-testid="sidebar"]').classes())
+      .not.toContain('sidebar-hoverable')
+  })
+
   it('does not render a history icon trigger anymore', async () => {
     const wrapper = await mountSidebar()
     const iconClasses = wrapper.findAll('.iconify')

--- a/tests/unit/components/Sidebar.spec.ts
+++ b/tests/unit/components/Sidebar.spec.ts
@@ -1,0 +1,100 @@
+import { ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { enableAutoUnmount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Sidebar from '../../../app/components/Sidebar.client.vue'
+import { useSearchModal } from '../../../app/composables/search-modal'
+
+enableAutoUnmount(afterEach)
+
+const loggedIn = ref<boolean>(true)
+
+mockNuxtImport('useAuth', () => {
+  return () => ({ loggedIn })
+})
+
+function mountSidebar() {
+  return mountSuspended(Sidebar, {
+    global: {
+      stubs: {
+        SidebarAuthCta: true,
+        LazySidebarNewChat: true,
+        LazySidebarDevelopment: true,
+      },
+    },
+  })
+}
+
+function stubMatchMedia() {
+  vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => {
+    return {
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList
+  })
+}
+
+describe('Sidebar.client', () => {
+  beforeEach(() => {
+    loggedIn.value = true
+    useSearchModal().isModalOpen.value = false
+    stubMatchMedia()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the search trigger with a search icon when logged in', async () => {
+    const wrapper = await mountSidebar()
+    const trigger = wrapper.get('[data-testid="sidebar-search-trigger"]')
+
+    expect(trigger.attributes('aria-label')).toBe('Search')
+    expect(trigger.find('.iconify').classes()).toContain('i-lucide:search')
+  })
+
+  it('hides the search trigger when logged out', async () => {
+    loggedIn.value = false
+
+    const wrapper = await mountSidebar()
+
+    expect(wrapper.find('[data-testid="sidebar-search-trigger"]').exists())
+      .toBe(false)
+  })
+
+  it('opens the shared search-modal state when clicked', async () => {
+    const wrapper = await mountSidebar()
+    const { isModalOpen } = useSearchModal()
+
+    expect(isModalOpen.value).toBe(false)
+
+    await wrapper.get('[data-testid="sidebar-search-trigger"]')
+      .trigger('click')
+
+    expect(isModalOpen.value).toBe(true)
+  })
+
+  it('does not render a history icon trigger anymore', async () => {
+    const wrapper = await mountSidebar()
+    const iconClasses = wrapper.findAll('.iconify')
+      .flatMap(icon => icon.classes())
+
+    expect(iconClasses).not.toContain('i-lucide:history')
+  })
+
+  it('renders the home button independently of auth state', async () => {
+    loggedIn.value = false
+
+    const wrapper = await mountSidebar()
+    const iconClasses = wrapper.findAll('.iconify')
+      .flatMap(icon => icon.classes())
+
+    expect(iconClasses).toContain('i-lucide:home')
+  })
+})

--- a/tests/unit/composables/files-modal-handoff.spec.ts
+++ b/tests/unit/composables/files-modal-handoff.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useFilesModalHandoff } from '../../../app/composables/files-modal-handoff'
+
+describe('useFilesModalHandoff', () => {
+  beforeEach(() => {
+    useFilesModalHandoff().clearPendingOpen()
+  })
+
+  it('starts with no pending open request', () => {
+    const { pendingOpen } = useFilesModalHandoff()
+
+    expect(pendingOpen.value).toBeNull()
+  })
+
+  it('requests opening the select tab with a source filter', () => {
+    const { pendingOpen, requestOpen } = useFilesModalHandoff()
+
+    requestOpen('select', '/chats/new', 'all')
+
+    expect(pendingOpen.value).toEqual({
+      tab: 'select',
+      source: 'all',
+      targetPath: '/chats/new',
+    })
+  })
+
+  it('requests opening the upload tab without a source filter', () => {
+    const { pendingOpen, requestOpen } = useFilesModalHandoff()
+
+    requestOpen('upload', '/chats/new')
+
+    expect(pendingOpen.value).toEqual({
+      tab: 'upload',
+      source: undefined,
+      targetPath: '/chats/new',
+    })
+    expect(pendingOpen.value).not.toStrictEqual({
+      tab: 'upload',
+      targetPath: '/chats/new',
+    })
+  })
+
+  it('clears the pending request', () => {
+    const { pendingOpen, requestOpen, clearPendingOpen }
+      = useFilesModalHandoff()
+
+    requestOpen('select', '/chats/abc123', 'assistant')
+    clearPendingOpen()
+
+    expect(pendingOpen.value).toBeNull()
+  })
+
+  it('overwrites a previous pending request with the latest one', () => {
+    const { pendingOpen, requestOpen } = useFilesModalHandoff()
+
+    requestOpen('select', '/chats/abc123', 'assistant')
+    requestOpen('upload', '/chats/new')
+
+    expect(pendingOpen.value).toEqual({
+      tab: 'upload',
+      source: undefined,
+      targetPath: '/chats/new',
+    })
+  })
+
+  it('shares pendingOpen across separate call sites', () => {
+    const chatInputInstance = useFilesModalHandoff()
+    const searchModalInstance = useFilesModalHandoff()
+
+    searchModalInstance.requestOpen('select', '/chats/new', 'all')
+
+    expect(chatInputInstance.pendingOpen.value).toEqual({
+      tab: 'select',
+      source: 'all',
+      targetPath: '/chats/new',
+    })
+
+    chatInputInstance.clearPendingOpen()
+
+    expect(searchModalInstance.pendingOpen.value).toBeNull()
+  })
+})

--- a/tests/unit/composables/search-modal.spec.ts
+++ b/tests/unit/composables/search-modal.spec.ts
@@ -1,0 +1,71 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSearchModal } from '../../../app/composables/search-modal'
+
+const mocks = vi.hoisted(() => ({
+  loggedIn: { value: true },
+}))
+
+mockNuxtImport('useAuth', () => {
+  return () => ({ loggedIn: mocks.loggedIn })
+})
+
+function resetSearchModalState() {
+  useSearchModal().isModalOpen.value = false
+}
+
+describe('useSearchModal', () => {
+  beforeEach(() => {
+    mocks.loggedIn.value = true
+    resetSearchModalState()
+  })
+
+  it('starts closed', () => {
+    const { isModalOpen } = useSearchModal()
+
+    expect(isModalOpen.value).toBe(false)
+  })
+
+  it('opens the modal when the user is logged in', () => {
+    const { isModalOpen, openSearchModal } = useSearchModal()
+
+    openSearchModal()
+
+    expect(isModalOpen.value).toBe(true)
+  })
+
+  it('does not open the modal when the user is logged out', () => {
+    mocks.loggedIn.value = false
+
+    const { isModalOpen, openSearchModal } = useSearchModal()
+
+    openSearchModal()
+
+    expect(isModalOpen.value).toBe(false)
+  })
+
+  it('closes the modal unconditionally, regardless of auth state', () => {
+    const { isModalOpen, openSearchModal, closeSearchModal } = useSearchModal()
+
+    openSearchModal()
+    expect(isModalOpen.value).toBe(true)
+
+    mocks.loggedIn.value = false
+    closeSearchModal()
+
+    expect(isModalOpen.value).toBe(false)
+  })
+
+  it('shares isModalOpen across separate call sites', () => {
+    const sidebarInstance = useSearchModal()
+    const modalInstance = useSearchModal()
+
+    sidebarInstance.openSearchModal()
+
+    expect(modalInstance.isModalOpen.value).toBe(true)
+
+    modalInstance.closeSearchModal()
+
+    expect(sidebarInstance.isModalOpen.value).toBe(false)
+  })
+})

--- a/tests/unit/composables/theme-toggle.spec.ts
+++ b/tests/unit/composables/theme-toggle.spec.ts
@@ -1,0 +1,181 @@
+import { reactive } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ThemePreference } from '~/types/favicon.d'
+import { useThemeToggle } from '../../../app/composables/theme-toggle'
+
+const mocks = vi.hoisted(() => ({
+  isIos: false,
+  reloadNuxtApp: vi.fn(),
+}))
+
+const colorModeState = reactive<{
+  preference: ThemePreference
+  value: 'light' | 'dark'
+}>({
+  preference: 'light',
+  value: 'light',
+})
+
+mockNuxtImport('useColorMode', () => {
+  return () => colorModeState
+})
+
+mockNuxtImport('useDevice', () => {
+  return () => ({ isIos: mocks.isIos })
+})
+
+mockNuxtImport('reloadNuxtApp', () => mocks.reloadNuxtApp)
+
+function getThemeColorMeta() {
+  return document.querySelector('meta[name="theme-color"]')
+}
+
+function stubMatchMedia(matches: boolean) {
+  vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => {
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList
+  })
+}
+
+describe('useThemeToggle', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    mocks.isIos = false
+    colorModeState.preference = 'light'
+    colorModeState.value = 'light'
+    mocks.reloadNuxtApp.mockClear()
+
+    document.querySelectorAll('meta[name="theme-color"]').forEach((element) => {
+      element.remove()
+    })
+
+    stubMatchMedia(false)
+
+    const { pending } = useThemeToggle()
+
+    pending.value = false
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('cycles the preference light -> dark -> system -> light', () => {
+    const { currentPreference, toggle } = useThemeToggle()
+
+    expect(currentPreference.value).toBe('light')
+
+    toggle()
+    expect(currentPreference.value).toBe('dark')
+
+    toggle()
+    expect(currentPreference.value).toBe('system')
+
+    toggle()
+    expect(currentPreference.value).toBe('light')
+  })
+
+  it('writes the light theme color to a fresh meta tag', () => {
+    const { setThemeColorMeta } = useThemeToggle()
+
+    setThemeColorMeta('light')
+
+    expect(getThemeColorMeta()?.getAttribute('content')).toBe('#fde4f1')
+  })
+
+  it('writes the dark theme color', () => {
+    const { setThemeColorMeta } = useThemeToggle()
+
+    setThemeColorMeta('dark')
+
+    expect(getThemeColorMeta()?.getAttribute('content')).toBe('#4b283c')
+  })
+
+  it('substitutes lightForDark when the OS prefers dark but the theme is light', () => {
+    stubMatchMedia(true)
+
+    const { setThemeColorMeta } = useThemeToggle()
+
+    setThemeColorMeta('light')
+
+    expect(getThemeColorMeta()?.getAttribute('content')).toBe('#834f68')
+  })
+
+  it('collapses duplicate theme-color meta tags into the first one', () => {
+    const first = document.createElement('meta')
+
+    first.setAttribute('name', 'theme-color')
+    first.setAttribute('media', '(prefers-color-scheme: light)')
+    document.head.appendChild(first)
+
+    const second = document.createElement('meta')
+
+    second.setAttribute('name', 'theme-color')
+    second.setAttribute('media', '(prefers-color-scheme: dark)')
+    document.head.appendChild(second)
+
+    const { setThemeColorMeta } = useThemeToggle()
+
+    setThemeColorMeta('dark')
+
+    const metas = document.querySelectorAll('meta[name="theme-color"]')
+
+    expect(metas).toHaveLength(1)
+    expect(metas[0]).toBe(first)
+    expect(first.hasAttribute('media')).toBe(false)
+    expect(first.getAttribute('content')).toBe('#4b283c')
+  })
+
+  it('toggle() reads the resolved theme before it catches up with the new preference', () => {
+    const { toggle } = useThemeToggle()
+
+    expect(colorModeState.preference).toBe('light')
+    expect(colorModeState.value).toBe('light')
+
+    toggle()
+
+    expect(colorModeState.preference).toBe('dark')
+    expect(getThemeColorMeta()?.getAttribute('content')).toBe('#fde4f1')
+  })
+
+  it('reloads the standalone app 500ms after toggling on iOS', async () => {
+    vi.useFakeTimers()
+    mocks.isIos = true
+
+    const { toggle, pending } = useThemeToggle()
+
+    toggle()
+
+    expect(pending.value).toBe(true)
+    expect(mocks.reloadNuxtApp).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(mocks.reloadNuxtApp).toHaveBeenCalledWith({ force: true })
+  })
+
+  it('never reloads or flags pending on non-iOS devices', async () => {
+    vi.useFakeTimers()
+    mocks.isIos = false
+
+    const { toggle, pending } = useThemeToggle()
+
+    toggle()
+
+    expect(pending.value).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(mocks.reloadNuxtApp).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/pages/chats/history/index.spec.ts
+++ b/tests/unit/pages/chats/history/index.spec.ts
@@ -1,0 +1,93 @@
+import { nextTick, reactive, ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { enableAutoUnmount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import HistoryPage from '../../../../../app/pages/chats/history/index.vue'
+
+const mocks = vi.hoisted(() => ({
+  useHistory: vi.fn(),
+}))
+
+mockNuxtImport('useHistory', () => mocks.useHistory)
+
+const mockRoute = reactive<{ query: Record<string, unknown> }>({
+  query: {},
+})
+
+mockNuxtImport('useRoute', () => {
+  return () => mockRoute
+})
+
+enableAutoUnmount(afterEach)
+
+function createHistoryState() {
+  return {
+    chats: ref([]),
+    pinned: ref([]),
+    search: ref(''),
+    isLoading: ref(false),
+    isLoadingInitial: ref(false),
+    isSearching: ref(false),
+    hasCachedData: ref(true),
+    hasMore: ref(false),
+    selectedIds: ref(new Set<string>()),
+    isSelectionMode: ref(false),
+    selectedCount: ref(0),
+    prime: vi.fn(),
+    hydrateAndRefresh: vi.fn(),
+    loadMore: vi.fn(),
+    togglePin: vi.fn(),
+    handleSelect: vi.fn(),
+    enterSelectionMode: vi.fn(),
+    deselectAll: vi.fn(),
+    deleteSelected: vi.fn(),
+    renameChat: vi.fn(),
+    deleteChat: vi.fn(),
+    cancelSharing: vi.fn(),
+    moveChatToProject: vi.fn(),
+    moveSelectedToProject: vi.fn(),
+  }
+}
+
+function mountHistoryPage() {
+  return mountSuspended(HistoryPage, {
+    shallow: true,
+  })
+}
+
+describe('pages/chats/history/index', () => {
+  let historyState: ReturnType<typeof createHistoryState>
+
+  beforeEach(() => {
+    mockRoute.query = {}
+    historyState = createHistoryState()
+    mocks.useHistory.mockReturnValue(historyState)
+  })
+
+  it('prefills search from the initial route query on mount', async () => {
+    mockRoute.query = { search: 'growth plan' }
+
+    await mountHistoryPage()
+
+    expect(historyState.search.value).toBe('growth plan')
+  })
+
+  it('leaves search untouched when the route query has no search param', async () => {
+    historyState.search.value = 'existing draft'
+
+    await mountHistoryPage()
+
+    expect(historyState.search.value).toBe('existing draft')
+  })
+
+  it('reactively refills search when route.query.search changes after mount', async () => {
+    await mountHistoryPage()
+
+    expect(historyState.search.value).toBe('')
+
+    mockRoute.query = { search: 'follow up' }
+    await nextTick()
+
+    expect(historyState.search.value).toBe('follow up')
+  })
+})


### PR DESCRIPTION
## Summary
- Replaces the sidebar's "History" link with a search-trigger button (tooltip "Search") that opens a t3.chat-style command-palette modal, also reachable via Cmd/Ctrl+K anywhere in the app.
- Empty state surfaces quick actions: New Chat, Manage Chat History, View All Uploaded Attachments, Toggle Theme, Security, API Keys.
- Typing 2+ characters searches chats (reusing the existing `/api/v1/chats/history` endpoint, no backend changes) and shows up to 5 matches styled like the history page's rows (title, last-activity, project/shared badges) minus the per-row context menu, plus a `Find "<query>" in chats` action that deep-links to `/chats/history?search=<query>` with the query prefilled.
- Extracts theme-toggle logic out of `Sidebar/ThemeSwitcher.vue` into a shared `useThemeToggle()` composable so toggling from the modal works correctly everywhere (including the iOS PWA reload-loading overlay, now backed by shared state instead of a per-instance ref).
- Adds an intent-flag handoff (`useFilesModalHandoff()`) so "View All Uploaded Attachments" can open the chat file manager from any page, not just chat pages — with a route-path safety net so a stale request can't pop the files modal open on an unrelated chat if the user navigates away before it loads.

## Test plan
- [x] `pnpm run format && pnpm run typecheck` clean
- [x] Full `pnpm exec vitest run` green (1950 tests)
- [x] `tests/e2e/settings/theme.spec.ts` + `theme-tokens.spec.ts` green (real regression gate for the theme-toggle extraction)
- [x] Manually verified in a real browser: sidebar trigger + tooltip, empty-state actions, keyboard nav (arrows/Enter), Escape-to-close, real Cmd+K dispatch, live chat search with real data, result-row click navigation, "Find in chats" from both a fresh page load and while already on the history page (the harder reactive case), files-modal handoff from both a chat page and a non-chat page, theme toggle, Security/API Keys navigation
- [x] Independent code review + security audit passed; one real lifecycle bug found and fixed (stale files-modal-handoff flag could open the files modal on the wrong chat), with a regression test proving the fix