### PR TITLE
feat: gateway catalog fetch layer (Vercel AI Gateway + OpenRouter)

### DIFF
--- a/app/composables/gateway-catalog.ts
+++ b/app/composables/gateway-catalog.ts
@@ -1,11 +1,15 @@
 import type { GatewayId, GatewayModel } from '#shared/types/gateways.d'
 
+type SupportedGatewayId = Exclude<GatewayId, 'cloudflare'>
+
 interface GatewayModelsResponse {
   gateway: GatewayId
   models: GatewayModel[]
 }
 
-export function useGatewayCatalog(gatewayId: Ref<GatewayId> | GatewayId) {
+export function useGatewayCatalog(
+  gatewayId: Ref<SupportedGatewayId> | SupportedGatewayId,
+) {
   const gatewayCatalogCache = useState<
     Partial<Record<GatewayId, GatewayModel[]>>
   >('gateway-catalog-cache', () => ({}))

--- a/app/composables/gateway-catalog.ts
+++ b/app/composables/gateway-catalog.ts
@@ -1,0 +1,41 @@
+import type { GatewayId, GatewayModel } from '#shared/types/gateways.d'
+
+interface GatewayModelsResponse {
+  gateway: GatewayId
+  models: GatewayModel[]
+}
+
+export function useGatewayCatalog(gatewayId: Ref<GatewayId> | GatewayId) {
+  const gatewayCatalogCache = useState<
+    Partial<Record<GatewayId, GatewayModel[]>>
+  >('gateway-catalog-cache', () => ({}))
+
+  const { data, pending, error, refresh } = useLazyFetch<
+    GatewayModelsResponse
+  >(
+    () => `/api/v1/gateways/${toValue(gatewayId)}/models`,
+    {
+      key: () => `gateway-catalog-${toValue(gatewayId)}`,
+      getCachedData: () => {
+        const currentGatewayId = toValue(gatewayId)
+        const cachedModels = gatewayCatalogCache.value[currentGatewayId]
+
+        return cachedModels
+          ? { gateway: currentGatewayId, models: cachedModels }
+          : undefined
+      },
+    },
+  )
+
+  watch(data, (value) => {
+    if (!value) {
+      return
+    }
+
+    gatewayCatalogCache.value[value.gateway] = value.models
+  })
+
+  const models = computed(() => data.value?.models ?? [])
+
+  return { models, pending, error, refresh }
+}

--- a/docs/auth-security.md
+++ b/docs/auth-security.md
@@ -178,6 +178,25 @@ that wildcard for this reason — reordering the object breaks the
 per-endpoint overrides silently, falling back to the wildcard's looser
 limit.
 
+## Reused outside Better Auth: the gateway catalog route
+
+`GET /api/v1/gateways/[gateway]/models` (providers/gateways initiative)
+isn't a Better Auth endpoint and isn't in the table above, but it reuses
+the same `createAuthRateLimitStorage()` KV-backed limiter with its own
+key prefix (`gateway-catalog:rate-limit`) and a dedicated per-user rule:
+
+| Path | Window | Max |
+| --- | --- | --- |
+| `GET /api/v1/gateways/[gateway]/models` | 60s | 20 |
+
+Unlike the table above, this rule is keyed by the authenticated
+`session.user.id`, not by IP. It exists because the route triggers an
+upstream fetch to Vercel AI Gateway or OpenRouter on every cache miss
+(the catalog is cached in KV for 1 hour, with no request coalescing —
+see `server/utils/gateways/catalog.ts`), so an unbounded client could
+drive repeated concurrent upstream fetches. This is a cost/availability
+concern for those upstreams rather than an auth-sensitive action.
+
 ## KV rate-limit storage: the TTL fix and the `consume` caveat
 
 The previous `customStorage` implemented only `get`/`set`, with `set`

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -275,6 +275,11 @@ export function getAffectedTests(changedFiles) {
     'tests/unit/utils/auth-hosts.spec.ts',
   ]
 
+  const gatewayCatalogTests = [
+    'tests/unit/utils/gateway-catalog-normalize.spec.ts',
+    'tests/integration/api/gateways-models.spec.ts',
+  ]
+
   const turnstileTests = [
     'tests/unit/composables/turnstile.spec.ts',
     'tests/unit/components/Auth/Turnstile.client.spec.ts',
@@ -368,6 +373,11 @@ export function getAffectedTests(changedFiles) {
       pattern:
         /^server\/utils\/(email|auth|auth-rate-limit|auth-captcha|auth-hosts)\.ts$/,
       tests: [...emailTests, ...authSecurityTests],
+    },
+    {
+      pattern:
+        /^(server\/utils\/gateways\/.*\.ts|server\/api\/v1\/gateways\/.*\.ts|shared\/types\/gateways\.d\.ts|app\/composables\/gateway-catalog\.ts)$/,
+      tests: gatewayCatalogTests,
     },
     {
       pattern: /^(server\/utils\/email-template\.ts|app\/emails\/.*)$/,

--- a/server/api/v1/gateways/[gateway]/models.get.ts
+++ b/server/api/v1/gateways/[gateway]/models.get.ts
@@ -1,0 +1,74 @@
+import { createError, useLogger } from 'evlog'
+import type { H3Event } from 'h3'
+import { createAuthRateLimitStorage } from '~~/server/utils/auth-rate-limit'
+import { getCachedGatewayCatalog } from '~~/server/utils/gateways/catalog'
+
+const GATEWAY_MODELS_RATE_LIMIT = { window: 60, max: 20 }
+const GATEWAY_MODELS_RATE_LIMIT_KEY_PREFIX = 'gateway-catalog:rate-limit'
+
+async function enforceGatewayModelsRateLimit(
+  event: H3Event,
+  userId: string,
+): Promise<void> {
+  const storage = createAuthRateLimitStorage(
+    useKV(),
+    GATEWAY_MODELS_RATE_LIMIT_KEY_PREFIX,
+  )
+  const result = await storage.consume(userId, GATEWAY_MODELS_RATE_LIMIT)
+
+  if (result.allowed) {
+    return
+  }
+
+  if (result.retryAfter !== null) {
+    setResponseHeader(event, 'Retry-After', result.retryAfter)
+  }
+
+  throw createError({
+    message: 'Too many requests',
+    status: 429,
+    why: 'Gateway catalog rate limit exceeded',
+    fix: 'Wait a moment before retrying',
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  const params = await getValidatedRouterParams(event, z.object({
+    gateway: z.enum(['vercel', 'cloudflare', 'openrouter']),
+  }).safeParse)
+
+  if (params.error) {
+    throw createError({
+      message: 'Invalid request parameters',
+      status: 400,
+      why: params.error.message,
+    })
+  }
+
+  if (params.data.gateway === 'cloudflare') {
+    throw createError({
+      message: 'Cloudflare AI Gateway is not yet supported',
+      status: 400,
+      why: 'Cloudflare AI Gateway catalog support ships in a later PR',
+      fix: 'Use "vercel" or "openrouter" for now',
+    })
+  }
+
+  const session = await useUserSession()
+
+  if (!session) {
+    return useUnauthorizedError()
+  }
+
+  await enforceGatewayModelsRateLimit(event, session.user.id)
+
+  const logger = useLogger(event)
+  const models = await getCachedGatewayCatalog(params.data.gateway, {
+    logger,
+  })
+
+  return {
+    gateway: params.data.gateway,
+    models,
+  }
+})

--- a/server/utils/gateways/catalog.ts
+++ b/server/utils/gateways/catalog.ts
@@ -165,7 +165,8 @@ interface GetCachedGatewayCatalogOptions {
  * variance) with a 1-hour freshness window. The cache entry itself never
  * expires in storage — freshness is decided entirely by comparing `cachedAt`
  * against the TTL — so a stale copy always remains available as a fallback
- * if the upstream fetch fails.
+ * if the upstream fetch fails. A cache-write failure never discards a valid
+ * freshly-fetched catalog — it is logged as non-fatal context instead.
  */
 export async function getCachedGatewayCatalog(
   gatewayId: CachedGatewayId,
@@ -180,15 +181,10 @@ export async function getCachedGatewayCatalog(
     return cached.models
   }
 
+  let models: GatewayModel[]
+
   try {
-    const models = await gatewayCatalogFetchers[gatewayId]()
-
-    await cache.setItem<GatewayCatalogCacheEntry>(cacheKey, {
-      models,
-      cachedAt: now,
-    })
-
-    return models
+    models = await gatewayCatalogFetchers[gatewayId]()
   } catch (exception) {
     if (!cached) {
       throw exception
@@ -208,4 +204,22 @@ export async function getCachedGatewayCatalog(
 
     return cached.models
   }
+
+  try {
+    await cache.setItem<GatewayCatalogCacheEntry>(cacheKey, {
+      models,
+      cachedAt: now,
+    })
+  } catch (exception) {
+    options.logger?.set({
+      attributes: {
+        gatewayCatalogCacheWrite: {
+          gateway: gatewayId,
+          error: exceptionMessage(exception),
+        },
+      },
+    })
+  }
+
+  return models
 }

--- a/server/utils/gateways/catalog.ts
+++ b/server/utils/gateways/catalog.ts
@@ -1,0 +1,211 @@
+import { createError } from 'evlog'
+import type { GatewayModel } from '#shared/types/gateways.d'
+import { exceptionMessage } from '~~/server/utils/evlog-attributes'
+
+const VERCEL_GATEWAY_MODELS_URL = 'https://ai-gateway.vercel.sh/v1/models'
+const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models'
+const GATEWAY_CATALOG_CACHE_TTL_MS = 60 * 60 * 1000
+
+interface VercelGatewayPricing {
+  input?: string
+  output?: string
+}
+
+interface VercelGatewayModalities {
+  input: string[]
+  output: string[]
+}
+
+interface VercelGatewayRawModel {
+  id: string
+  name: string
+  description?: string
+  context_window?: number
+  max_tokens?: number
+  type: string
+  modalities?: VercelGatewayModalities
+  supported_parameters?: string[]
+  pricing?: VercelGatewayPricing
+}
+
+interface VercelGatewayModelsResponse {
+  data: VercelGatewayRawModel[]
+}
+
+interface OpenRouterPricing {
+  prompt?: string
+  completion?: string
+}
+
+interface OpenRouterArchitecture {
+  input_modalities?: string[]
+  output_modalities?: string[]
+}
+
+interface OpenRouterTopProvider {
+  max_completion_tokens?: number | null
+}
+
+interface OpenRouterRawModel {
+  id: string
+  name: string
+  description?: string
+  context_length?: number
+  architecture?: OpenRouterArchitecture
+  pricing?: OpenRouterPricing
+  supported_parameters?: string[]
+  top_provider?: OpenRouterTopProvider
+}
+
+interface OpenRouterModelsResponse {
+  data: OpenRouterRawModel[]
+}
+
+/**
+ * Both Vercel AI Gateway and OpenRouter report `pricing` as per-token decimal
+ * strings (e.g. `"0.0000025"`), unlike this app's curated static catalog,
+ * which displays per-million-token strings. `GatewayModel.pricing` passes
+ * each gateway's raw per-token strings through unchanged rather than
+ * converting between the two conventions.
+ */
+export async function fetchVercelGatewayCatalog(): Promise<GatewayModel[]> {
+  const response = await fetch(VERCEL_GATEWAY_MODELS_URL)
+
+  if (!response.ok) {
+    throw createError({
+      message: 'Failed to fetch Vercel AI Gateway model catalog',
+      status: 502,
+      why: `Vercel AI Gateway returned HTTP ${response.status}`,
+      fix: 'Retry later or check https://ai-gateway.vercel.sh status',
+    })
+  }
+
+  const payload = await response.json() as VercelGatewayModelsResponse
+
+  return payload.data
+    .filter(model => model.type === 'language')
+    .map(normalizeVercelGatewayModel)
+}
+
+function normalizeVercelGatewayModel(
+  model: VercelGatewayRawModel,
+): GatewayModel {
+  return {
+    id: model.id,
+    name: model.name,
+    description: model.description,
+    contextLength: model.context_window,
+    maxOutputTokens: model.max_tokens,
+    pricing: model.pricing?.input && model.pricing?.output
+      ? { input: model.pricing.input, output: model.pricing.output }
+      : undefined,
+    modalities: model.modalities,
+    supportsTools: model.supported_parameters?.includes('tools'),
+  }
+}
+
+export async function fetchOpenRouterCatalog(): Promise<GatewayModel[]> {
+  const response = await fetch(OPENROUTER_MODELS_URL)
+
+  if (!response.ok) {
+    throw createError({
+      message: 'Failed to fetch OpenRouter model catalog',
+      status: 502,
+      why: `OpenRouter returned HTTP ${response.status}`,
+      fix: 'Retry later or check https://openrouter.ai status',
+    })
+  }
+
+  const payload = await response.json() as OpenRouterModelsResponse
+
+  return payload.data.map(normalizeOpenRouterModel)
+}
+
+function normalizeOpenRouterModel(model: OpenRouterRawModel): GatewayModel {
+  return {
+    id: model.id,
+    name: model.name,
+    description: model.description,
+    contextLength: model.context_length,
+    maxOutputTokens: model.top_provider?.max_completion_tokens ?? undefined,
+    pricing: model.pricing?.prompt && model.pricing?.completion
+      ? { input: model.pricing.prompt, output: model.pricing.completion }
+      : undefined,
+    modalities: model.architecture
+      ? {
+        input: model.architecture.input_modalities ?? [],
+        output: model.architecture.output_modalities ?? [],
+      }
+      : undefined,
+    supportsTools: model.supported_parameters?.includes('tools'),
+  }
+}
+
+type CachedGatewayId = 'vercel' | 'openrouter'
+
+const gatewayCatalogFetchers: Record<
+  CachedGatewayId,
+  () => Promise<GatewayModel[]>
+> = {
+  vercel: fetchVercelGatewayCatalog,
+  openrouter: fetchOpenRouterCatalog,
+}
+
+interface GatewayCatalogCacheEntry {
+  models: GatewayModel[]
+  cachedAt: number
+}
+
+interface GetCachedGatewayCatalogOptions {
+  logger?: { set: (fields: Record<string, unknown>) => void }
+}
+
+/**
+ * Caches each gateway's catalog globally in KV (public data, no per-user
+ * variance) with a 1-hour freshness window. The cache entry itself never
+ * expires in storage — freshness is decided entirely by comparing `cachedAt`
+ * against the TTL — so a stale copy always remains available as a fallback
+ * if the upstream fetch fails.
+ */
+export async function getCachedGatewayCatalog(
+  gatewayId: CachedGatewayId,
+  options: GetCachedGatewayCatalogOptions = {},
+): Promise<GatewayModel[]> {
+  const cache = useStorage('cache')
+  const cacheKey = `gateway-catalog:${gatewayId}`
+  const cached = await cache.getItem<GatewayCatalogCacheEntry>(cacheKey)
+  const now = Date.now()
+
+  if (cached && now - cached.cachedAt < GATEWAY_CATALOG_CACHE_TTL_MS) {
+    return cached.models
+  }
+
+  try {
+    const models = await gatewayCatalogFetchers[gatewayId]()
+
+    await cache.setItem<GatewayCatalogCacheEntry>(cacheKey, {
+      models,
+      cachedAt: now,
+    })
+
+    return models
+  } catch (exception) {
+    if (!cached) {
+      throw exception
+    }
+
+    options.logger?.set({
+      gatewayCatalogFetch: {
+        gateway: gatewayId,
+        servedStale: true,
+      },
+      attributes: {
+        gatewayCatalogFetch: {
+          error: exceptionMessage(exception),
+        },
+      },
+    })
+
+    return cached.models
+  }
+}

--- a/shared/types/gateways.d.ts
+++ b/shared/types/gateways.d.ts
@@ -1,0 +1,12 @@
+export type GatewayId = 'vercel' | 'cloudflare' | 'openrouter'
+
+export interface GatewayModel {
+  id: string
+  name: string
+  description?: string
+  contextLength?: number
+  maxOutputTokens?: number
+  pricing?: { input: string, output: string }
+  modalities?: { input: string[], output: string[] }
+  supportsTools?: boolean
+}

--- a/shared/types/gateways.d.ts
+++ b/shared/types/gateways.d.ts
@@ -6,6 +6,11 @@ export interface GatewayModel {
   description?: string
   contextLength?: number
   maxOutputTokens?: number
+  /**
+   * PER-TOKEN USD decimal strings (e.g. `"0.0000025"`) straight from the
+   * gateway's raw API — unlike `Model.price` in `providers.d`, which is
+   * per-million-token. Do not divide/multiply the two the same way.
+   */
   pricing?: { input: string, output: string }
   modalities?: { input: string[], output: string[] }
   supportsTools?: boolean

--- a/tests/integration/api/gateways-models.spec.ts
+++ b/tests/integration/api/gateways-models.spec.ts
@@ -98,13 +98,17 @@ describe('gateway models API', () => {
 
   it('rejects unauthenticated requests', async () => {
     vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue(null))
-    vi.stubGlobal('fetch', vi.fn())
+
+    const fetchMock = vi.fn()
+
+    vi.stubGlobal('fetch', fetchMock)
 
     const handler = await getHandler()
 
     await expect(handler({
       params: { gateway: 'vercel' },
     } as never)).rejects.toThrow('Unauthorized')
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('rejects an invalid gateway param', async () => {
@@ -241,4 +245,33 @@ describe('gateway models API', () => {
         'Failed to fetch Vercel AI Gateway model catalog',
       )
     })
+
+  it('returns 429 once the per-user rate limit is exceeded', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => vercelCatalogPayload,
+    })
+    const setResponseHeaderMock = vi.fn()
+
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('setResponseHeader', setResponseHeaderMock)
+
+    const handler = await getHandler()
+
+    for (let call = 0; call < 20; call++) {
+      await handler({ params: { gateway: 'vercel' } } as never)
+    }
+
+    await expect(handler({
+      params: { gateway: 'vercel' },
+    } as never)).rejects.toMatchObject({
+      message: 'Too many requests',
+      status: 429,
+    })
+    expect(setResponseHeaderMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'Retry-After',
+      expect.any(Number),
+    )
+  })
 })

--- a/tests/integration/api/gateways-models.spec.ts
+++ b/tests/integration/api/gateways-models.spec.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  loggerSet: vi.fn(),
+}))
+
+vi.mock('evlog', () => ({
+  createError: (input: {
+    message: string
+    status?: number
+    why?: string
+    fix?: string
+  }) => {
+    const exception = new Error(input.message)
+
+    Object.assign(exception, input)
+
+    return exception
+  },
+  useLogger: () => ({ set: mocks.loggerSet }),
+}))
+
+function createFakeKv() {
+  const store = new Map<string, string>()
+
+  return {
+    async get(key: string) {
+      return store.get(key) ?? null
+    },
+    async put(key: string, value: string) {
+      store.set(key, value)
+    },
+    async delete(key: string) {
+      store.delete(key)
+    },
+  }
+}
+
+function createFakeCache() {
+  const store = new Map<string, unknown>()
+
+  return {
+    async getItem(key: string) {
+      return store.get(key) ?? null
+    },
+    async setItem(key: string, value: unknown) {
+      store.set(key, value)
+    },
+  }
+}
+
+async function getHandler() {
+  const module = await import(
+    '../../../server/api/v1/gateways/[gateway]/models.get'
+  )
+
+  return module.default
+}
+
+const vercelCatalogPayload = {
+  data: [
+    {
+      id: 'openai/gpt-4o',
+      name: 'GPT-4o',
+      type: 'language',
+      context_window: 128000,
+      max_tokens: 16384,
+      supported_parameters: ['tools'],
+      pricing: { input: '0.0000025', output: '0.00001' },
+      modalities: { input: ['text'], output: ['text'] },
+    },
+  ],
+}
+
+describe('gateway models API', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+
+    const fakeKv = createFakeKv()
+
+    vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+    vi.stubGlobal('setResponseHeader', vi.fn())
+    vi.stubGlobal('useKV', () => fakeKv)
+    vi.stubGlobal('useStorage', () => createFakeCache())
+    vi.stubGlobal('getValidatedRouterParams', async (
+      event: { params: unknown },
+      parser: (params: unknown) => unknown,
+    ) => parser(event.params))
+    vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue({
+      user: { id: '1' },
+    }))
+    vi.stubGlobal('useUnauthorizedError', vi.fn(() => {
+      throw new Error('Unauthorized')
+    }))
+  })
+
+  it('rejects unauthenticated requests', async () => {
+    vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue(null))
+    vi.stubGlobal('fetch', vi.fn())
+
+    const handler = await getHandler()
+
+    await expect(handler({
+      params: { gateway: 'vercel' },
+    } as never)).rejects.toThrow('Unauthorized')
+  })
+
+  it('rejects an invalid gateway param', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+
+    const handler = await getHandler()
+
+    await expect(handler({
+      params: { gateway: 'not-a-gateway' },
+    } as never)).rejects.toThrow('Invalid request parameters')
+  })
+
+  it('rejects cloudflare as not yet supported', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+
+    const handler = await getHandler()
+
+    await expect(handler({
+      params: { gateway: 'cloudflare' },
+    } as never)).rejects.toThrow(
+      'Cloudflare AI Gateway is not yet supported',
+    )
+  })
+
+  it('returns a normalized catalog for a valid gateway', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => vercelCatalogPayload,
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const handler = await getHandler()
+
+    const response = await handler({
+      params: { gateway: 'vercel' },
+    } as never)
+
+    expect(response).toEqual({
+      gateway: 'vercel',
+      models: [
+        {
+          id: 'openai/gpt-4o',
+          name: 'GPT-4o',
+          description: undefined,
+          contextLength: 128000,
+          maxOutputTokens: 16384,
+          pricing: { input: '0.0000025', output: '0.00001' },
+          modalities: { input: ['text'], output: ['text'] },
+          supportsTools: true,
+        },
+      ],
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves the second request within the TTL from cache', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => vercelCatalogPayload,
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const cache = createFakeCache()
+
+    vi.stubGlobal('useStorage', () => cache)
+
+    const handler = await getHandler()
+
+    const first = await handler({ params: { gateway: 'vercel' } } as never)
+    const second = await handler({ params: { gateway: 'vercel' } } as never)
+
+    expect(first).toEqual(second)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/integration/api/gateways-models.spec.ts
+++ b/tests/integration/api/gateways-models.spec.ts
@@ -181,4 +181,64 @@ describe('gateway models API', () => {
     expect(first).toEqual(second)
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
+
+  it('serves a stale cached catalog when the upstream fetch fails',
+    async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: async () => 'Service unavailable',
+      })
+
+      vi.stubGlobal('fetch', fetchMock)
+
+      const cache = createFakeCache()
+      const staleModels = [{
+        id: 'openai/gpt-4o',
+        name: 'GPT-4o (stale)',
+      }]
+
+      await cache.setItem('gateway-catalog:vercel', {
+        models: staleModels,
+        cachedAt: Date.now() - (2 * 60 * 60 * 1000),
+      })
+
+      vi.stubGlobal('useStorage', () => cache)
+
+      const handler = await getHandler()
+
+      const response = await handler({
+        params: { gateway: 'vercel' },
+      } as never)
+
+      expect(response).toEqual({ gateway: 'vercel', models: staleModels })
+      expect(mocks.loggerSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gatewayCatalogFetch: {
+            gateway: 'vercel',
+            servedStale: true,
+          },
+        }),
+      )
+    })
+
+  it('propagates a clean error when there is no cache and the fetch fails',
+    async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: async () => 'Service unavailable',
+      })
+
+      vi.stubGlobal('fetch', fetchMock)
+      vi.stubGlobal('useStorage', () => createFakeCache())
+
+      const handler = await getHandler()
+
+      await expect(handler({
+        params: { gateway: 'vercel' },
+      } as never)).rejects.toThrow(
+        'Failed to fetch Vercel AI Gateway model catalog',
+      )
+    })
 })

--- a/tests/unit/utils/gateway-catalog-normalize.spec.ts
+++ b/tests/unit/utils/gateway-catalog-normalize.spec.ts
@@ -1,0 +1,306 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('evlog', () => ({
+  createError: (input: { message: string, status?: number }) => {
+    const exception = new Error(input.message)
+
+    Object.assign(exception, input)
+
+    return exception
+  },
+}))
+
+async function getFetchers() {
+  const module = await import('../../../server/utils/gateways/catalog')
+
+  return {
+    fetchVercelGatewayCatalog: module.fetchVercelGatewayCatalog,
+    fetchOpenRouterCatalog: module.fetchOpenRouterCatalog,
+  }
+}
+
+function mockFetchOnce(payload: unknown, ok = true, status = 200) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  }))
+}
+
+describe('fetchVercelGatewayCatalog', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it('normalizes a full language model', async () => {
+    mockFetchOnce({
+      data: [
+        {
+          id: 'openai/gpt-4o',
+          name: 'GPT-4o',
+          description: 'GPT-4o from OpenAI.',
+          context_window: 128000,
+          max_tokens: 16384,
+          type: 'language',
+          modalities: {
+            input: ['text', 'image', 'pdf'],
+            output: ['text'],
+          },
+          supported_parameters: [
+            'max_tokens',
+            'temperature',
+            'stop',
+            'tools',
+            'tool_choice',
+          ],
+          pricing: {
+            input: '0.0000025',
+            output: '0.00001',
+            input_cache_read: '0.00000125',
+            web_search: '10',
+          },
+        },
+      ],
+    })
+
+    const { fetchVercelGatewayCatalog } = await getFetchers()
+    const models = await fetchVercelGatewayCatalog()
+
+    expect(models).toEqual([
+      {
+        id: 'openai/gpt-4o',
+        name: 'GPT-4o',
+        description: 'GPT-4o from OpenAI.',
+        contextLength: 128000,
+        maxOutputTokens: 16384,
+        pricing: { input: '0.0000025', output: '0.00001' },
+        modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+        supportsTools: true,
+      },
+    ])
+  })
+
+  it('excludes non-language models from the catalog', async () => {
+    mockFetchOnce({
+      data: [
+        {
+          id: 'openai/gpt-4o',
+          name: 'GPT-4o',
+          type: 'language',
+          context_window: 128000,
+        },
+        {
+          id: 'openai/text-embedding-3-small',
+          name: 'Text Embedding 3 Small',
+          type: 'embedding',
+        },
+      ],
+    })
+
+    const { fetchVercelGatewayCatalog } = await getFetchers()
+    const models = await fetchVercelGatewayCatalog()
+
+    expect(models).toHaveLength(1)
+    expect(models[0]?.id).toBe('openai/gpt-4o')
+  })
+
+  it('handles a model missing pricing and modalities', async () => {
+    mockFetchOnce({
+      data: [
+        {
+          id: 'test-provider/bare-model',
+          name: 'Bare Model',
+          type: 'language',
+          context_window: 32000,
+        },
+      ],
+    })
+
+    const { fetchVercelGatewayCatalog } = await getFetchers()
+    const models = await fetchVercelGatewayCatalog()
+
+    expect(models).toEqual([
+      {
+        id: 'test-provider/bare-model',
+        name: 'Bare Model',
+        description: undefined,
+        contextLength: 32000,
+        maxOutputTokens: undefined,
+        pricing: undefined,
+        modalities: undefined,
+        supportsTools: undefined,
+      },
+    ])
+  })
+
+  it('throws a clean error when the upstream fetch fails', async () => {
+    mockFetchOnce({}, false, 502)
+
+    const { fetchVercelGatewayCatalog } = await getFetchers()
+
+    await expect(fetchVercelGatewayCatalog()).rejects.toThrow(
+      'Failed to fetch Vercel AI Gateway model catalog',
+    )
+  })
+})
+
+describe('fetchOpenRouterCatalog', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it('normalizes a full model with tool support', async () => {
+    mockFetchOnce({
+      data: [
+        {
+          id: 'openai/gpt-4o-2024-11-20',
+          name: 'OpenAI: GPT-4o (2024-11-20)',
+          description: 'The 2024-11-20 version of GPT-4o.',
+          context_length: 128000,
+          architecture: {
+            modality: 'text+image+file->text',
+            input_modalities: ['text', 'image', 'file'],
+            output_modalities: ['text'],
+          },
+          pricing: {
+            prompt: '0.0000025',
+            completion: '0.00001',
+            input_cache_read: '0.00000125',
+          },
+          top_provider: {
+            context_length: 128000,
+            max_completion_tokens: 16384,
+            is_moderated: true,
+          },
+          supported_parameters: [
+            'frequency_penalty',
+            'tool_choice',
+            'tools',
+            'top_p',
+          ],
+        },
+      ],
+    })
+
+    const { fetchOpenRouterCatalog } = await getFetchers()
+    const models = await fetchOpenRouterCatalog()
+
+    expect(models).toEqual([
+      {
+        id: 'openai/gpt-4o-2024-11-20',
+        name: 'OpenAI: GPT-4o (2024-11-20)',
+        description: 'The 2024-11-20 version of GPT-4o.',
+        contextLength: 128000,
+        maxOutputTokens: 16384,
+        pricing: { input: '0.0000025', output: '0.00001' },
+        modalities: {
+          input: ['text', 'image', 'file'],
+          output: ['text'],
+        },
+        supportsTools: true,
+      },
+    ])
+  })
+
+  it('preserves free-tier ids and zero pricing', async () => {
+    mockFetchOnce({
+      data: [
+        {
+          id: 'inclusionai/ling-3.0-tiny:free',
+          name: 'inclusionAI: Ling 3.0 Tiny (free)',
+          description: 'A mixture-of-experts model from InclusionAI.',
+          context_length: 262144,
+          architecture: {
+            input_modalities: ['text'],
+            output_modalities: ['text'],
+          },
+          pricing: { prompt: '0', completion: '0' },
+          top_provider: {
+            context_length: 262144,
+            max_completion_tokens: 32768,
+            is_moderated: false,
+          },
+          supported_parameters: ['tools', 'reasoning'],
+        },
+      ],
+    })
+
+    const { fetchOpenRouterCatalog } = await getFetchers()
+    const models = await fetchOpenRouterCatalog()
+
+    expect(models[0]?.id).toBe('inclusionai/ling-3.0-tiny:free')
+    expect(models[0]?.pricing).toEqual({ input: '0', output: '0' })
+  })
+
+  it('falls back to undefined maxOutputTokens when top_provider caps it null',
+    async () => {
+      mockFetchOnce({
+        data: [
+          {
+            id: 'meta/muse-spark-1.2',
+            name: 'Meta: Muse Spark 1.2',
+            context_length: 1048576,
+            architecture: {
+              input_modalities: ['text'],
+              output_modalities: ['text'],
+            },
+            pricing: { prompt: '0.000001', completion: '0.000002' },
+            top_provider: {
+              context_length: 1048576,
+              max_completion_tokens: null,
+              is_moderated: true,
+            },
+            supported_parameters: ['max_tokens'],
+          },
+        ],
+      })
+
+      const { fetchOpenRouterCatalog } = await getFetchers()
+      const models = await fetchOpenRouterCatalog()
+
+      expect(models[0]?.maxOutputTokens).toBeUndefined()
+      expect(models[0]?.supportsTools).toBe(false)
+    })
+
+  it('handles a model missing pricing, architecture, and top_provider',
+    async () => {
+      mockFetchOnce({
+        data: [
+          {
+            id: 'test-author/bare-model',
+            name: 'Bare Model',
+            context_length: 8192,
+          },
+        ],
+      })
+
+      const { fetchOpenRouterCatalog } = await getFetchers()
+      const models = await fetchOpenRouterCatalog()
+
+      expect(models).toEqual([
+        {
+          id: 'test-author/bare-model',
+          name: 'Bare Model',
+          description: undefined,
+          contextLength: 8192,
+          maxOutputTokens: undefined,
+          pricing: undefined,
+          modalities: undefined,
+          supportsTools: undefined,
+        },
+      ])
+    })
+
+  it('throws a clean error when the upstream fetch fails', async () => {
+    mockFetchOnce({}, false, 500)
+
+    const { fetchOpenRouterCatalog } = await getFetchers()
+
+    await expect(fetchOpenRouterCatalog()).rejects.toThrow(
+      'Failed to fetch OpenRouter model catalog',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a normalized, KV-cached model-catalog fetch layer for two BYOK AI gateways: Vercel AI Gateway and OpenRouter (Cloudflare AI Gateway follows in a later PR once its catalog endpoint is verified).
- Both upstream APIs are public/unauthenticated; this app caches globally per gateway (1h freshness window, stale-on-upstream-error fallback) and rate-limits the new endpoint per user.
- New `GatewayModel`/`GatewayId` shared types, `GET /api/v1/gateways/[gateway]/models`, and a `useGatewayCatalog()` composable for later picker UI work to consume.

Part 3 of a 7-PR stacked initiative (see `docs/_wip-plan-providers-gateways.md` on the parent branch for full context). This PR has no dependency on any sibling PR in the stack.

## Test plan
- [x] `pnpm run format` / `pnpm run typecheck` clean
- [x] New unit + integration tests (17 total) passing, registered in `scripts/test-affected-check.mjs`
- [x] Code-reviewed; findings (pricing-unit documentation, cache-write-failure handling, rate-limit test coverage, auth-security.md update) fixed
- [ ] CI green on this PR