### PR TITLE
feat: model picker gateway mode + per-gateway favorites

### DIFF
--- a/.drizzle/migrations/20260809021640_vengeful_lifeguard/migration.sql
+++ b/.drizzle/migrations/20260809021640_vengeful_lifeguard/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_settings` ADD `favorite_gateway_models` text;

--- a/.drizzle/migrations/20260809021640_vengeful_lifeguard/snapshot.json
+++ b/.drizzle/migrations/20260809021640_vengeful_lifeguard/snapshot.json
@@ -1,0 +1,2920 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "363b10cc-ddf4-4281-b32f-8f064af8adaa",
+  "prevIds": [
+    "a6ae6582-6ebf-465f-afc6-d14c9fe210b6"
+  ],
+  "ddl": [
+    {
+      "name": "accounts",
+      "entityType": "tables"
+    },
+    {
+      "name": "sessions",
+      "entityType": "tables"
+    },
+    {
+      "name": "users",
+      "entityType": "tables"
+    },
+    {
+      "name": "verifications",
+      "entityType": "tables"
+    },
+    {
+      "name": "user_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "projects",
+      "entityType": "tables"
+    },
+    {
+      "name": "chats",
+      "entityType": "tables"
+    },
+    {
+      "name": "messages",
+      "entityType": "tables"
+    },
+    {
+      "name": "keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "files",
+      "entityType": "tables"
+    },
+    {
+      "name": "chat_share_files",
+      "entityType": "tables"
+    },
+    {
+      "name": "chat_shares",
+      "entityType": "tables"
+    },
+    {
+      "name": "storages",
+      "entityType": "tables"
+    },
+    {
+      "name": "image_transform_usage_monthly",
+      "entityType": "tables"
+    },
+    {
+      "name": "image_generation_locks",
+      "entityType": "tables"
+    },
+    {
+      "name": "push_subscriptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "research_jobs",
+      "entityType": "tables"
+    },
+    {
+      "name": "two_factors",
+      "entityType": "tables"
+    },
+    {
+      "name": "passkeys",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "accounts"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_login_method",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "two_factor_enabled",
+      "entityType": "columns",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verifications"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "reasoning_expanded",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "reasoning_auto_hide",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "allow_external_links",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "notification_prompt_state",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sidebar_pinned",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "favorite_models",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "favorite_gateway_models",
+      "entityType": "columns",
+      "table": "user_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "instructions",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'idle'",
+      "generated": null,
+      "name": "memory_status",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_updated_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_dirty_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_provider",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_model",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "memory_error",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pinned_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activity_at",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "''",
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shared",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branched_from_share_slug",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pinned_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_memory_summary",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_memory_summary_updated_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activity_at",
+      "entityType": "columns",
+      "table": "chats"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "parts",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "tools",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'off'",
+      "generated": null,
+      "name": "reasoning",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "usage",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_id",
+      "entityType": "columns",
+      "table": "messages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "api_key",
+      "entityType": "columns",
+      "table": "keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_key",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "size",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_message_id",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_provider",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin_model",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generation_cost",
+      "entityType": "columns",
+      "table": "files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_share_id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_id",
+      "entityType": "columns",
+      "table": "chat_share_files"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "revoked",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "indexable",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "show_files",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "show_metadata",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "show_author_avatar",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "allow_branch",
+      "entityType": "columns",
+      "table": "chat_shares"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "20971520",
+      "generated": null,
+      "name": "storage",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'free'",
+      "generated": null,
+      "name": "tier",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "10",
+      "generated": null,
+      "name": "max_files_per_message",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1048576000",
+      "generated": null,
+      "name": "max_message_files_bytes",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "30",
+      "generated": null,
+      "name": "file_retention_days",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "image_transform_limit_total",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "image_transform_used_total",
+      "entityType": "columns",
+      "table": "storages"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "month_key",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "transforms_used",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1000",
+      "generated": null,
+      "name": "transforms_limit",
+      "entityType": "columns",
+      "table": "image_transform_usage_monthly"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "image_generation_locks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "endpoint",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "p256dh_key",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "auth_key",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin",
+      "entityType": "columns",
+      "table": "push_subscriptions"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_message_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "level",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_job_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "origin",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "answers",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "usage",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "result_message_id",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "table": "research_jobs"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "two_factors"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "two_factors"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "two_factors"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "secret",
+      "entityType": "columns",
+      "table": "two_factors"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backup_codes",
+      "entityType": "columns",
+      "table": "two_factors"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "two_factors"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "verified",
+      "entityType": "columns",
+      "table": "two_factors"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failed_verification_count",
+      "entityType": "columns",
+      "table": "two_factors"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "two_factors"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "counter",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transports",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "table": "passkeys"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "accounts_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "accounts"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sessions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "user_settings_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "user_settings"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "projects_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chats_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "projects",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "chats_project_id_projects_id_fk",
+      "entityType": "fks",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "messages_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "messages"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "keys_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "files_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "files"
+    },
+    {
+      "columns": [
+        "origin_message_id"
+      ],
+      "tableTo": "messages",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "files_origin_message_id_messages_id_fk",
+      "entityType": "fks",
+      "table": "files"
+    },
+    {
+      "columns": [
+        "chat_share_id"
+      ],
+      "tableTo": "chat_shares",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_share_files_chat_share_id_chat_shares_id_fk",
+      "entityType": "fks",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        "file_id"
+      ],
+      "tableTo": "files",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_share_files_file_id_files_id_fk",
+      "entityType": "fks",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "chat_shares_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "storages_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "storages"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "push_subscriptions_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        "chat_id"
+      ],
+      "tableTo": "chats",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_research_jobs_chat_id_chats_id_fk",
+      "entityType": "fks",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_two_factors_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "two_factors"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_passkeys_user_id_users_id_fk",
+      "entityType": "fks",
+      "table": "passkeys"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pk",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pk",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pk",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pk",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_settings_pk",
+      "table": "user_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pk",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chats_pk",
+      "table": "chats",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "messages_pk",
+      "table": "messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "keys_pk",
+      "table": "keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "files_pk",
+      "table": "files",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chat_share_files_pk",
+      "table": "chat_share_files",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "chat_shares_pk",
+      "table": "chat_shares",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "storages_pk",
+      "table": "storages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "month_key"
+      ],
+      "nameExplicit": false,
+      "name": "image_transform_usage_monthly_pk",
+      "table": "image_transform_usage_monthly",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "image_generation_locks_pk",
+      "table": "image_generation_locks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "push_subscriptions_pk",
+      "table": "push_subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "research_jobs_pk",
+      "table": "research_jobs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "two_factors_pk",
+      "table": "two_factors",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "passkeys_pk",
+      "table": "passkeys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "table": "accounts"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "table": "verifications"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_user_settings_user",
+      "entityType": "indexes",
+      "table": "user_settings"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_project_user",
+      "entityType": "indexes",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        {
+          "value": "activity_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_projects_activity_at",
+      "entityType": "indexes",
+      "table": "projects"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_user",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_slug",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "activity_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_chats_activity_at",
+      "entityType": "indexes",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "chat_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_message_chat",
+      "entityType": "indexes",
+      "table": "messages"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_key_user",
+      "entityType": "indexes",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_key_user_provider",
+      "entityType": "indexes",
+      "table": "keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "id",
+          "isExpression": false
+        },
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_file_user",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "storage_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_file_storageKey",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_files_expires_at",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_files_user_id",
+      "entityType": "indexes",
+      "table": "files"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_share_id",
+          "isExpression": false
+        },
+        {
+          "value": "file_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_file",
+      "entityType": "indexes",
+      "table": "chat_share_files"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_chat",
+      "entityType": "indexes",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_slug",
+      "entityType": "indexes",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_chat_share_chat_id",
+      "entityType": "indexes",
+      "table": "chat_shares"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_storage_user",
+      "entityType": "indexes",
+      "table": "storages"
+    },
+    {
+      "columns": [
+        {
+          "value": "endpoint",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "uq_push_subscriptions_endpoint",
+      "entityType": "indexes",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_push_subscriptions_user_id",
+      "entityType": "indexes",
+      "table": "push_subscriptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "chat_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "status in ('pending', 'running')",
+      "origin": "manual",
+      "name": "uq_research_jobs_chat_active",
+      "entityType": "indexes",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_research_jobs_status_created",
+      "entityType": "indexes",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_research_jobs_user",
+      "entityType": "indexes",
+      "table": "research_jobs"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_two_factors_user_id",
+      "entityType": "indexes",
+      "table": "two_factors"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_passkeys_user_id",
+      "entityType": "indexes",
+      "table": "passkeys"
+    },
+    {
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_passkeys_credential_id",
+      "entityType": "indexes",
+      "table": "passkeys"
+    },
+    {
+      "columns": [
+        "token"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_token_unique",
+      "entityType": "uniques",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "email"
+      ],
+      "nameExplicit": false,
+      "name": "users_email_unique",
+      "entityType": "uniques",
+      "table": "users"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "chats_slug_unique",
+      "entityType": "uniques",
+      "table": "chats"
+    },
+    {
+      "columns": [
+        "public_id"
+      ],
+      "nameExplicit": false,
+      "name": "messages_public_id_unique",
+      "entityType": "uniques",
+      "table": "messages"
+    }
+  ],
+  "renames": []
+}

--- a/app/components/ChatInput/ModelsTrigger.vue
+++ b/app/components/ChatInput/ModelsTrigger.vue
@@ -16,12 +16,12 @@
       @click="toggle"
     >
       <ProviderIcon
-        v-if="triggerProviderId"
-        :provider-id="triggerProviderId"
+        v-if="selectedIconProviderId"
+        :provider-id="selectedIconProviderId"
         class="w-4 fill-base-content/40"
       />
       <span class="block truncate text-left min-w-0">
-        {{ getModelName(toValue(userModel)) }}
+        {{ selectedModelName }}
       </span>
       <Icon
         name="lucide:chevron-down"
@@ -46,6 +46,34 @@
             class="bubble-without-background flex flex-col max-h-[60dvh] bg-base-100 border border-base-content/10 shadow-xl"
           >
             <div
+              v-if="activeGateway"
+              data-testid="models-picker-gateway-banner"
+              class="shrink-0 flex items-center gap-2 px-2.5 py-2 border-b border-accent/30 bg-accent/10"
+            >
+              <ProviderIcon
+                :provider-id="activeGateway.id"
+                :label="activeGateway.label"
+                class="w-4 shrink-0 fill-accent"
+              />
+              <span
+                class="grow min-w-0 truncate text-xs font-semibold text-accent"
+              >
+                {{ activeGateway.label }}
+              </span>
+              <button
+                type="button"
+                data-testid="models-picker-gateway-exit"
+                class="btn btn-ghost btn-xs shrink-0 gap-1 rounded-full"
+                @click="setProviderMode"
+              >
+                <Icon
+                  name="lucide:arrow-left"
+                  size="12"
+                />
+                Providers
+              </button>
+            </div>
+            <div
               class="shrink-0 flex items-center gap-1 p-2 border-b border-base-content/10"
             >
               <ChatInputModelsTriggerSearch
@@ -57,13 +85,14 @@
                 @keydown="onSearchKeydown"
               />
               <ChatInputModelsTriggerFilterDropdown
+                v-if="!activeGateway"
                 v-model="activeCategory"
               />
             </div>
             <div class="flex flex-1 min-h-0">
               <ChatInputModelsTriggerProviderRail
-                v-if="!isSearching"
-                :providers="providers"
+                v-if="isRailVisible"
+                :providers="railProviders"
                 :active-provider-id="activeProviderId"
                 :is-favorites-only="isFavoritesOnly"
                 :has-favorites="hasFavorites"
@@ -73,47 +102,132 @@
               <div
                 ref="resultsContainer"
                 class="flex-1 min-h-[14rem] overflow-y-auto p-1.5"
-                :class="{ 'pb-9': filteredModels.length }"
+                :class="{ 'pb-9': !activeGateway && filteredModels.length }"
               >
-                <div
-                  :id="listboxId"
-                  role="listbox"
-                  aria-label="Models"
-                >
-                  <template
-                    v-for="section in sections"
-                    :key="section.id"
+                <ChatInputModelsTriggerGatewayModelList
+                  v-if="activeGateway"
+                  ref="gatewayList"
+                  :key="activeGateway.id"
+                  :gateway-id="activeGateway.id"
+                  :gateway-label="activeGateway.label"
+                  :search-term="searchTerm"
+                  :is-favorites-only="isFavoritesOnly"
+                  :favorite-model-ids="activeGatewayFavorites"
+                  :selected-model-id="selectedGatewayModelId"
+                  :detail-model-id="detailModelId"
+                  :listbox-id="listboxId"
+                  @select="selectGatewayModel"
+                  @toggle-favorite="toggleGatewayFavorite"
+                  @toggle-detail="toggleDetail"
+                  @close-detail="closeDetail"
+                  @highlight="onGatewayHighlight"
+                  @pending-change="onGatewayPendingChange"
+                />
+                <template v-else>
+                  <div
+                    :id="listboxId"
+                    role="listbox"
+                    aria-label="Models"
                   >
-                    <p
-                      v-if="section.label"
-                      :id="`${section.id}-label`"
-                      class="px-2 pt-1.5 pb-1 text-[0.65rem] font-semibold uppercase tracking-wide opacity-50"
+                    <template
+                      v-for="section in sections"
+                      :key="section.id"
                     >
-                      {{ section.label }}
-                    </p>
+                      <p
+                        v-if="section.label"
+                        :id="`${section.id}-label`"
+                        class="px-2 pt-1.5 pb-1 text-[0.65rem] font-semibold uppercase tracking-wide opacity-50"
+                      >
+                        {{ section.label }}
+                      </p>
+                      <ul
+                        class="flex flex-col gap-0.5"
+                        :role="section.label ? 'group' : 'presentation'"
+                        :aria-labelledby="section.label
+                          ? `${section.id}-label`
+                          : undefined
+                        "
+                      >
+                        <template
+                          v-for="entry in section.entries"
+                          :key="entry.model.id"
+                        >
+                          <ChatInputModelsTriggerModelItem
+                            :model="entry.model"
+                            :provider-id="entry.providerId"
+                            :is-selected="
+                              selectedProviderModelId === entry.model.id
+                            "
+                            :is-highlighted="
+                              highlightedModelId === entry.model.id
+                            "
+                            :is-favorite="
+                              favoriteModels.includes(entry.model.id)
+                            "
+                            :is-detail-open="detailModelId === entry.model.id"
+                            @select="selectModel(entry.model.id)"
+                            @toggle-favorite="
+                              toggleFavoriteModel(entry.model.id)
+                            "
+                            @toggle-detail="toggleDetail(entry.model.id)"
+                          />
+                          <li
+                            v-if="detailModelId === entry.model.id"
+                            role="presentation"
+                            class="py-0.5"
+                          >
+                            <ChatInputModelsTriggerModelDetail
+                              :model="entry.model"
+                              :provider-name="entry.providerName"
+                              @close="closeDetail"
+                            />
+                          </li>
+                        </template>
+                      </ul>
+                    </template>
+                  </div>
+                  <div
+                    v-if="legacyModels.length"
+                    data-testid="models-picker-legacy"
+                    class="mt-1 pt-1 border-t border-base-content/10"
+                  >
+                    <button
+                      :id="legacyLabelId"
+                      type="button"
+                      data-testid="models-picker-legacy-toggle"
+                      class="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-xl text-[0.65rem] font-semibold uppercase tracking-wide opacity-50 cursor-pointer transition-colors hover:bg-base-content/5 hover:opacity-80"
+                      :aria-expanded="isLegacyExpanded"
+                      :aria-controls="legacyListId"
+                      @click="toggleLegacy"
+                    >
+                      <Icon
+                        name="lucide:chevron-right"
+                        size="12"
+                        class="transition-transform"
+                        :class="{ 'rotate-90': isLegacyExpanded }"
+                      />
+                      {{ legacyLabel }}
+                    </button>
                     <ul
+                      v-show="isLegacyExpanded"
+                      :id="legacyListId"
+                      data-testid="models-picker-legacy-list"
+                      role="listbox"
+                      :aria-labelledby="legacyLabelId"
                       class="flex flex-col gap-0.5"
-                      :role="section.label ? 'group' : 'presentation'"
-                      :aria-labelledby="section.label
-                        ? `${section.id}-label`
-                        : undefined
-                      "
                     >
                       <template
-                        v-for="entry in section.entries"
+                        v-for="entry in legacyModels"
                         :key="entry.model.id"
                       >
                         <ChatInputModelsTriggerModelItem
                           :model="entry.model"
                           :provider-id="entry.providerId"
-                          :is-selected="userModel === entry.model.id"
-                          :is-highlighted="
-                            highlightedModelId === entry.model.id
-                          "
-                          :is-favorite="favoriteModels.includes(entry.model.id)"
+                          is-legacy
+                          :is-selected="false"
+                          :is-highlighted="false"
+                          :is-favorite="false"
                           :is-detail-open="detailModelId === entry.model.id"
-                          @select="selectModel(entry.model.id)"
-                          @toggle-favorite="toggleFavoriteModel(entry.model.id)"
                           @toggle-detail="toggleDetail(entry.model.id)"
                         />
                         <li
@@ -129,91 +243,39 @@
                         </li>
                       </template>
                     </ul>
-                  </template>
-                </div>
-                <div
-                  v-if="legacyModels.length"
-                  data-testid="models-picker-legacy"
-                  class="mt-1 pt-1 border-t border-base-content/10"
-                >
-                  <button
-                    :id="legacyLabelId"
-                    type="button"
-                    data-testid="models-picker-legacy-toggle"
-                    class="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-xl text-[0.65rem] font-semibold uppercase tracking-wide opacity-50 cursor-pointer transition-colors hover:bg-base-content/5 hover:opacity-80"
-                    :aria-expanded="isLegacyExpanded"
-                    :aria-controls="legacyListId"
-                    @click="toggleLegacy"
+                  </div>
+                  <div
+                    v-if="!filteredModels.length && !legacyModels.length"
+                    data-testid="models-picker-empty"
+                    class="min-h-full flex flex-col items-center justify-center gap-2 px-4 py-10 text-center"
                   >
                     <Icon
-                      name="lucide:chevron-right"
-                      size="12"
-                      class="transition-transform"
-                      :class="{ 'rotate-90': isLegacyExpanded }"
+                      name="lucide:search-x"
+                      size="24"
+                      class="opacity-40"
                     />
-                    {{ legacyLabel }}
-                  </button>
-                  <ul
-                    v-show="isLegacyExpanded"
-                    :id="legacyListId"
-                    data-testid="models-picker-legacy-list"
-                    role="listbox"
-                    :aria-labelledby="legacyLabelId"
-                    class="flex flex-col gap-0.5"
-                  >
-                    <template
-                      v-for="entry in legacyModels"
-                      :key="entry.model.id"
+                    <p class="text-xs opacity-60">
+                      {{ emptyMessage }}
+                    </p>
+                    <button
+                      v-if="hasActiveFilters"
+                      type="button"
+                      data-testid="models-picker-clear-filters"
+                      class="btn btn-ghost btn-xs rounded-full text-accent"
+                      @click="clearFilters"
                     >
-                      <ChatInputModelsTriggerModelItem
-                        :model="entry.model"
-                        :provider-id="entry.providerId"
-                        is-legacy
-                        :is-selected="false"
-                        :is-highlighted="false"
-                        :is-favorite="false"
-                        :is-detail-open="detailModelId === entry.model.id"
-                        @toggle-detail="toggleDetail(entry.model.id)"
-                      />
-                      <li
-                        v-if="detailModelId === entry.model.id"
-                        role="presentation"
-                        class="py-0.5"
-                      >
-                        <ChatInputModelsTriggerModelDetail
-                          :model="entry.model"
-                          :provider-name="entry.providerName"
-                          @close="closeDetail"
-                        />
-                      </li>
-                    </template>
-                  </ul>
-                </div>
-                <div
-                  v-if="!filteredModels.length && !legacyModels.length"
-                  data-testid="models-picker-empty"
-                  class="min-h-full flex flex-col items-center justify-center gap-2 px-4 py-10 text-center"
-                >
-                  <Icon
-                    name="lucide:search-x"
-                    size="24"
-                    class="opacity-40"
-                  />
-                  <p class="text-xs opacity-60">
-                    {{ emptyMessage }}
-                  </p>
-                  <button
-                    v-if="hasActiveFilters"
-                    type="button"
-                    data-testid="models-picker-clear-filters"
-                    class="btn btn-ghost btn-xs rounded-full text-accent"
-                    @click="clearFilters"
-                  >
-                    Clear filters
-                  </button>
-                </div>
+                      Clear filters
+                    </button>
+                  </div>
+                </template>
               </div>
             </div>
+            <ChatInputModelsTriggerGatewayRail
+              :gateways="gatewayRailItems"
+              :active-gateway-id="activeGateway?.id ?? null"
+              :is-pending="isGatewayCatalogPending"
+              @toggle-gateway="toggleGateway"
+            />
           </div>
         </div>
       </Transition>
@@ -222,11 +284,22 @@
 </template>
 
 <script setup lang="ts">
+import type { GatewayId } from '#shared/types/gateways.d'
+import type { Providers } from '#shared/types/providers.d'
 import type {
   ModelCategory,
+  PickerMode,
   PickerModel,
   PickerSection,
 } from '~/types/models-picker'
+import { enabledGateways, providerMeta } from '#shared/utils/provider-meta'
+
+interface GatewayListHandle {
+  moveHighlight: (step: number) => void
+  highlightFirst: () => void
+  highlightLast: () => void
+  selectHighlighted: () => void
+}
 
 defineProps<{
   isWebSearchEnabled: boolean
@@ -234,10 +307,23 @@ defineProps<{
   isReasoningEnabled: boolean
 }>()
 
-const { userModel } = useUserModel()
+const { selection } = useUserModel()
 const { providers } = getProviders()
-const { favoriteModels, toggleFavoriteModel } = useUserSetting()
+const {
+  favoriteModels,
+  toggleFavoriteModel,
+  getFavoriteGatewayModels,
+  toggleFavoriteGatewayModel,
+} = useUserSetting()
+const {
+  name: selectedModelName,
+  iconProviderId: selectedIconProviderId,
+} = useSelectedModelInfo()
 
+const pickerMode = shallowRef<PickerMode>({ source: 'provider' })
+const gatewayHighlightedOptionId = shallowRef<string | null>(null)
+const isGatewayCatalogPending = shallowRef<boolean>(false)
+const gatewayList = useTemplateRef<GatewayListHandle>('gatewayList')
 const isOpen = shallowRef<boolean>(false)
 const searchQuery = shallowRef<string>('')
 const activeProviderId = shallowRef<string | null>(null)
@@ -254,8 +340,61 @@ const listboxId = useId()
 const legacyListId = useId()
 const legacyLabelId = useId()
 
-const triggerProviderId = computed<string | null>(() => {
-  return getModel(toValue(userModel)).provider?.id ?? null
+const gatewayRailItems = computed(() => {
+  return enabledGateways.map((gatewayId) => {
+    return {
+      id: gatewayId,
+      label: providerMeta[gatewayId]?.label ?? gatewayId,
+    }
+  })
+})
+
+/**
+ * Null whenever the picker is browsing the curated catalog, which includes a
+ * stored selection pointing at a gateway that is not enabled yet — that falls
+ * back to provider mode rather than rendering a rail button nothing can serve.
+ */
+const activeGateway = computed(() => {
+  const mode = pickerMode.value
+
+  if (mode.source !== 'gateway') {
+    return null
+  }
+
+  return gatewayRailItems.value.find((item) => {
+    return item.id === mode.gatewayId
+  }) ?? null
+})
+
+const activeGatewayFavorites = computed<string[]>(() => {
+  const gateway = activeGateway.value
+
+  return gateway ? getFavoriteGatewayModels(gateway.id) : []
+})
+
+const selectedProviderModelId = computed<string | null>(() => {
+  const current = selection.value
+
+  return current.source === 'provider' ? current.modelId : null
+})
+
+const selectedGatewayModelId = computed<string | null>(() => {
+  const gateway = activeGateway.value
+  const current = selection.value
+
+  if (
+    !gateway
+    || current.source !== 'gateway'
+    || current.gatewayId !== gateway.id
+  ) {
+    return null
+  }
+
+  return current.modelId
+})
+
+const railProviders = computed<Providers>(() => {
+  return activeGateway.value ? [] : providers
 })
 
 const allModels = computed<PickerModel[]>(() => {
@@ -279,7 +418,23 @@ const isSearching = computed<boolean>(() => {
 })
 
 const hasFavorites = computed<boolean>(() => {
+  if (activeGateway.value) {
+    return activeGatewayFavorites.value.length > 0
+  }
+
   return favoriteModels.value.length > 0
+})
+
+const isRailVisible = computed<boolean>(() => {
+  if (isSearching.value) {
+    return false
+  }
+
+  if (activeGateway.value) {
+    return hasFavorites.value
+  }
+
+  return true
 })
 
 const isRailFilterApplied = computed<boolean>(() => {
@@ -361,6 +516,10 @@ const sections = computed<PickerSection[]>(() => {
 })
 
 const highlightedOptionId = computed<string | undefined>(() => {
+  if (activeGateway.value) {
+    return gatewayHighlightedOptionId.value ?? undefined
+  }
+
   if (!highlightedModelId.value) {
     return undefined
   }
@@ -379,6 +538,7 @@ const emptyMessage = computed<string>(() => {
 function close() {
   isOpen.value = false
   highlightedModelId.value = null
+  gatewayHighlightedOptionId.value = null
   searchQuery.value = ''
   isLegacyExpanded.value = false
   closeDetail()
@@ -394,6 +554,24 @@ function closeAndRestoreFocus() {
   trigger.value?.focus()
 }
 
+/**
+ * Re-derived on every open rather than once at setup: the picker mounts with
+ * the chat input and stays mounted, so a selection made elsewhere would leave
+ * setup-time mode state stale.
+ */
+function getModeFromSelection(): PickerMode {
+  const current = selection.value
+
+  if (
+    current.source !== 'gateway'
+    || !enabledGateways.includes(current.gatewayId)
+  ) {
+    return { source: 'provider' }
+  }
+
+  return { source: 'gateway', gatewayId: current.gatewayId }
+}
+
 function toggle() {
   if (isOpen.value) {
     close()
@@ -401,8 +579,45 @@ function toggle() {
     return
   }
 
+  pickerMode.value = getModeFromSelection()
   isOpen.value = true
+
+  if (activeGateway.value) {
+    return
+  }
+
   setHighlight(getInitialHighlight())
+}
+
+function switchMode(mode: PickerMode) {
+  pickerMode.value = mode
+  isGatewayCatalogPending.value = false
+  gatewayHighlightedOptionId.value = null
+  searchQuery.value = ''
+  activeCategory.value = null
+  activeProviderId.value = null
+  isFavoritesOnly.value = false
+  isLegacyExpanded.value = false
+  highlightedModelId.value = null
+  closeDetail()
+
+  if (mode.source === 'gateway') {
+    return
+  }
+
+  setHighlight(getInitialHighlight())
+}
+
+function setProviderMode() {
+  switchMode({ source: 'provider' })
+}
+
+function toggleGateway(gatewayId: GatewayId) {
+  switchMode(
+    activeGateway.value?.id === gatewayId
+      ? { source: 'provider' }
+      : { source: 'gateway', gatewayId },
+  )
 }
 
 /**
@@ -411,7 +626,7 @@ function toggle() {
  * outside the listbox the search input controls.
  */
 function getInitialHighlight(): string | null {
-  const selectedId = toValue(userModel)
+  const selectedId = selectedProviderModelId.value
   const isSelectable = filteredModels.value.some(({ model }) => {
     return model.id === selectedId
   })
@@ -451,8 +666,37 @@ function toggleDetail(modelId: string) {
 }
 
 function selectModel(modelId: string) {
-  userModel.value = modelId
+  selection.value = { source: 'provider', modelId }
   closeAndRestoreFocus()
+}
+
+function selectGatewayModel(modelId: string) {
+  const gateway = activeGateway.value
+
+  if (!gateway) {
+    return
+  }
+
+  selection.value = { source: 'gateway', gatewayId: gateway.id, modelId }
+  closeAndRestoreFocus()
+}
+
+function toggleGatewayFavorite(modelId: string) {
+  const gateway = activeGateway.value
+
+  if (!gateway) {
+    return
+  }
+
+  toggleFavoriteGatewayModel(gateway.id, modelId)
+}
+
+function onGatewayHighlight(optionId: string | null) {
+  gatewayHighlightedOptionId.value = optionId
+}
+
+function onGatewayPendingChange(isPending: boolean) {
+  isGatewayCatalogPending.value = isPending
 }
 
 async function scrollHighlightedIntoView() {
@@ -515,38 +759,86 @@ function selectHighlighted() {
   selectModel(highlightedModelId.value)
 }
 
+function moveHighlightInActiveList(step: number) {
+  const list = gatewayList.value
+
+  if (list) {
+    list.moveHighlight(step)
+
+    return
+  }
+
+  moveHighlight(step)
+}
+
+function highlightFirstInActiveList() {
+  const list = gatewayList.value
+
+  if (list) {
+    list.highlightFirst()
+
+    return
+  }
+
+  highlightFirst()
+}
+
+function highlightLastInActiveList() {
+  const list = gatewayList.value
+
+  if (list) {
+    list.highlightLast()
+
+    return
+  }
+
+  highlightLast()
+}
+
+function selectHighlightedInActiveList() {
+  const list = gatewayList.value
+
+  if (list) {
+    list.selectHighlighted()
+
+    return
+  }
+
+  selectHighlighted()
+}
+
 function onSearchKeydown(event: KeyboardEvent) {
   if (event.key === 'ArrowDown') {
     event.preventDefault()
-    moveHighlight(1)
+    moveHighlightInActiveList(1)
 
     return
   }
 
   if (event.key === 'ArrowUp') {
     event.preventDefault()
-    moveHighlight(-1)
+    moveHighlightInActiveList(-1)
 
     return
   }
 
   if (event.key === 'Home') {
     event.preventDefault()
-    highlightFirst()
+    highlightFirstInActiveList()
 
     return
   }
 
   if (event.key === 'End') {
     event.preventDefault()
-    highlightLast()
+    highlightLastInActiveList()
 
     return
   }
 
   if (event.key === 'Enter') {
     event.preventDefault()
-    selectHighlighted()
+    selectHighlightedInActiveList()
   }
 }
 
@@ -560,6 +852,11 @@ watch(hasFavorites, (value) => {
 
 watch([searchTerm, activeCategory, activeProviderId, isFavoritesOnly], () => {
   closeDetail()
+
+  if (activeGateway.value) {
+    return
+  }
+
   highlightedModelId.value = filteredModels.value[0]?.model.id ?? null
 })
 

--- a/app/components/ChatInput/ModelsTrigger/GatewayModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/GatewayModelDetail.vue
@@ -1,0 +1,155 @@
+<template>
+  <div
+    :id="detailId"
+    data-testid="gateway-model-detail-panel"
+    class="p-3 rounded-2xl bg-base-100/95 backdrop-blur-lg border border-base-content/10 shadow-xl"
+  >
+    <div class="flex items-center gap-2">
+      <h3 class="grow text-sm font-semibold">
+        {{ model.name }}
+      </h3>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs btn-circle shrink-0 hitslop"
+        aria-label="Close model details"
+        @click="emit('close')"
+      >
+        <Icon
+          name="lucide:x"
+          size="12"
+        />
+      </button>
+    </div>
+    <p
+      v-if="model.description"
+      class="mt-1.5 text-xs opacity-70"
+    >
+      {{ model.description }}
+    </p>
+    <div
+      v-if="capabilities.length"
+      data-testid="gateway-model-detail-capabilities"
+      class="mt-2.5 flex flex-wrap gap-1"
+    >
+      <span
+        v-for="capability in capabilities"
+        :key="capability.label"
+        class="badge badge-sm badge-soft"
+        :class="capability.class"
+      >
+        <Icon
+          :name="capability.icon"
+          size="11"
+        />
+        {{ capability.label }}
+      </span>
+    </div>
+    <dl
+      class="mt-3 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs"
+      data-testid="gateway-model-detail-specs"
+    >
+      <template
+        v-for="row in rows"
+        :key="row.label"
+      >
+        <dt class="opacity-50">
+          {{ row.label }}
+        </dt>
+        <dd class="text-right break-words">
+          {{ row.value }}
+        </dd>
+      </template>
+    </dl>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { GatewayModel } from '#shared/types/gateways.d'
+
+interface CapabilityBadge {
+  label: string
+  icon: string
+  class: string
+}
+
+interface SpecRow {
+  label: string
+  value: string
+}
+
+const props = defineProps<{
+  model: GatewayModel
+  gatewayLabel: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const detailId = computed<string>(() => {
+  return `gateway-model-detail-${props.model.id}`
+})
+
+const capabilities = computed<CapabilityBadge[]>(() => {
+  const { model } = props
+  const badges: CapabilityBadge[] = []
+
+  if (model.supportsTools) {
+    badges.push({
+      label: 'Tool calling',
+      icon: 'lucide:wrench',
+      class: 'badge-info',
+    })
+  }
+
+  if (model.modalities?.input.includes('image')) {
+    badges.push({
+      label: 'Image input',
+      icon: 'lucide:image',
+      class: '[--badge-color:var(--color-violet-700)] '
+        + 'dark:[--badge-color:var(--color-violet-200)]',
+    })
+  }
+
+  return badges
+})
+
+const rows = computed<SpecRow[]>(() => {
+  const { model, gatewayLabel } = props
+  const contextLength = formatModelTokenLimit(model.contextLength ?? 0)
+  const maxOutputTokens = formatModelTokenLimit(model.maxOutputTokens ?? 0)
+  const price = formatGatewayPriceDetail(model.pricing)
+  const specs: SpecRow[] = [
+    { label: 'Gateway', value: gatewayLabel },
+    { label: 'Model ID', value: model.id },
+  ]
+
+  if (contextLength) {
+    specs.push({ label: 'Context', value: contextLength })
+  }
+
+  if (maxOutputTokens) {
+    specs.push({ label: 'Max output', value: maxOutputTokens })
+  }
+
+  if (model.modalities?.input.length) {
+    specs.push({
+      label: 'Input',
+      value: model.modalities.input.join(', '),
+    })
+  }
+
+  if (model.modalities?.output.length) {
+    specs.push({
+      label: 'Output',
+      value: model.modalities.output.join(', '),
+    })
+  }
+
+  if (price) {
+    specs.push({ label: 'Price', value: price })
+  }
+
+  return specs
+})
+</script>

--- a/app/components/ChatInput/ModelsTrigger/GatewayModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/GatewayModelItem.vue
@@ -1,0 +1,144 @@
+<template>
+  <li
+    :id="optionId"
+    role="option"
+    :aria-selected="isSelected"
+  >
+    <div
+      class="flex items-center gap-1 rounded-xl pl-2 pr-1 py-1 transition-colors"
+      :class="{
+        'bg-accent/15': isSelected,
+        'bg-base-content/10': isHighlighted && !isSelected,
+        'hover:bg-base-content/5': !isSelected && !isHighlighted
+      }"
+    >
+      <button
+        type="button"
+        :aria-label="`Choose ${model.name}`"
+        class="grow min-w-0 flex flex-wrap xs:flex-nowrap items-center gap-x-2 gap-y-1 py-1 text-left cursor-pointer"
+        @click="emit('select')"
+      >
+        <span class="w-full xs:w-auto min-w-0 flex items-center gap-1.5">
+          <span
+            class="truncate text-sm font-medium"
+            :class="{ 'text-accent': isSelected }"
+          >
+            {{ model.name }}
+          </span>
+        </span>
+        <span
+          v-if="priceLabel"
+          data-testid="gateway-model-price"
+          class="shrink-0 text-[0.65rem] font-medium tabular-nums opacity-60"
+        >
+          {{ priceLabel }}
+        </span>
+        <span
+          v-if="hasCapabilities"
+          data-testid="gateway-model-capabilities"
+          class="shrink-0 flex gap-1 items-center xs:ml-auto"
+        >
+          <span
+            v-if="model.supportsTools"
+            class="capability-chip shrink-0 flex items-center p-0.5 rounded-full text-info"
+            :class="{ 'tooltip tooltip-soft tooltip-bottom': isDesktop }"
+            data-tip="Tool calling"
+          >
+            <Icon name="lucide:wrench" />
+          </span>
+          <span
+            v-if="supportsImageInput"
+            class="capability-chip shrink-0 flex items-center p-0.5 rounded-full text-violet-700 dark:text-violet-200"
+            :class="{ 'tooltip tooltip-soft tooltip-bottom': isDesktop }"
+            data-tip="Image input"
+          >
+            <Icon name="lucide:image" />
+          </span>
+        </span>
+      </button>
+      <span
+        data-testid="gateway-model-actions"
+        class="shrink-0 flex items-center gap-1 max-xs:flex-col"
+      >
+        <button
+          type="button"
+          data-testid="gateway-model-info-trigger"
+          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)] hitslop"
+          :class="{ 'text-accent': isDetailOpen, 'btn-active': isDetailOpen }"
+          :aria-label="`About ${model.name}`"
+          :aria-expanded="isDetailOpen"
+          :aria-controls="isDetailOpen ? detailId : undefined"
+          @click.stop="emit('toggleDetail')"
+        >
+          <Icon
+            name="lucide:info"
+            size="14"
+          />
+        </button>
+        <button
+          type="button"
+          data-testid="gateway-model-favorite-toggle"
+          class="btn btn-ghost btn-xs btn-circle shrink-0 max-xs:[--size:calc(var(--size-field)_*_7)] tooltip tooltip-left"
+          :class="{ 'text-warning': isFavorite }"
+          :aria-label="isFavorite
+            ? `Remove ${model.name} from favorites`
+            : `Add ${model.name} to favorites`
+          "
+          :aria-pressed="isFavorite"
+          :data-tip="isFavorite
+            ? 'Remove from favorites'
+            : 'Add to favorites'
+          "
+          @click.stop="emit('toggleFavorite')"
+        >
+          <Icon
+            name="lucide:star"
+            mode="svg"
+            size="14"
+            :class="{ '[&_path]:fill-current': isFavorite }"
+          />
+        </button>
+      </span>
+    </div>
+  </li>
+</template>
+
+<script setup lang="ts">
+import type { GatewayModel } from '#shared/types/gateways.d'
+
+const props = defineProps<{
+  model: GatewayModel
+  isSelected: boolean
+  isHighlighted: boolean
+  isFavorite: boolean
+  isDetailOpen: boolean
+}>()
+
+const emit = defineEmits<{
+  select: []
+  toggleFavorite: []
+  toggleDetail: []
+}>()
+
+const { isDesktop } = useDevice()
+
+const priceLabel = computed<string | undefined>(() => {
+  return formatGatewayPrice(props.model.pricing)
+})
+
+const supportsImageInput = computed<boolean>(() => {
+  return !!props.model.modalities?.input.includes('image')
+})
+
+const hasCapabilities = computed<boolean>(() => {
+  return !!props.model.supportsTools || supportsImageInput.value
+})
+
+const optionId = computed<string>(() => {
+  return `gateway-model-option-${props.model.id}`
+})
+
+const detailId = computed<string>(() => {
+  return `gateway-model-detail-${props.model.id}`
+})
+</script>

--- a/app/components/ChatInput/ModelsTrigger/GatewayModelList.vue
+++ b/app/components/ChatInput/ModelsTrigger/GatewayModelList.vue
@@ -1,0 +1,278 @@
+<template>
+  <div ref="root">
+    <div
+      v-if="isPending"
+      data-testid="gateway-models-loading"
+      class="min-h-full flex flex-col items-center justify-center gap-2 px-4 py-10 text-center"
+    >
+      <span class="loading loading-spinner loading-md opacity-40" />
+      <p class="text-xs opacity-60">
+        Loading {{ gatewayLabel }} models…
+      </p>
+    </div>
+    <div
+      v-else-if="error"
+      data-testid="gateway-models-error"
+      class="min-h-full flex flex-col items-center justify-center gap-2 px-4 py-10 text-center"
+    >
+      <Icon
+        name="lucide:cloud-alert"
+        size="24"
+        class="opacity-40"
+      />
+      <p class="text-xs opacity-60">
+        Could not load {{ gatewayLabel }} models.
+      </p>
+      <button
+        type="button"
+        data-testid="gateway-models-retry"
+        class="btn btn-ghost btn-xs rounded-full text-accent"
+        @click="refresh()"
+      >
+        Try again
+      </button>
+    </div>
+    <template v-else-if="filteredModels.length">
+      <div
+        :id="listboxId"
+        role="listbox"
+        :aria-label="`${gatewayLabel} models`"
+      >
+        <template
+          v-for="section in sections"
+          :key="section.id"
+        >
+          <p
+            v-if="section.label"
+            :id="`${sectionLabelId}-${section.id}`"
+            class="px-2 pt-1.5 pb-1 text-[0.65rem] font-semibold uppercase tracking-wide opacity-50"
+          >
+            {{ section.label }}
+          </p>
+          <ul
+            class="flex flex-col gap-0.5"
+            :role="section.label ? 'group' : 'presentation'"
+            :aria-labelledby="section.label
+              ? `${sectionLabelId}-${section.id}`
+              : undefined
+            "
+          >
+            <template
+              v-for="model in section.entries"
+              :key="model.id"
+            >
+              <ChatInputModelsTriggerGatewayModelItem
+                :model="model"
+                :is-selected="selectedModelId === model.id"
+                :is-highlighted="highlightedModelId === model.id"
+                :is-favorite="favoriteModelIds.includes(model.id)"
+                :is-detail-open="detailModelId === model.id"
+                @select="emit('select', model.id)"
+                @toggle-favorite="emit('toggleFavorite', model.id)"
+                @toggle-detail="emit('toggleDetail', model.id)"
+              />
+              <li
+                v-if="detailModelId === model.id"
+                role="presentation"
+                class="py-0.5"
+              >
+                <ChatInputModelsTriggerGatewayModelDetail
+                  :model="model"
+                  :gateway-label="gatewayLabel"
+                  @close="emit('closeDetail')"
+                />
+              </li>
+            </template>
+          </ul>
+        </template>
+      </div>
+    </template>
+    <div
+      v-else
+      data-testid="gateway-models-empty"
+      class="min-h-full flex flex-col items-center justify-center gap-2 px-4 py-10 text-center"
+    >
+      <Icon
+        name="lucide:search-x"
+        size="24"
+        class="opacity-40"
+      />
+      <p class="text-xs opacity-60">
+        {{ emptyMessage }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { GatewayId, GatewayModel } from '#shared/types/gateways.d'
+import type { GatewayPickerSection } from '~/types/models-picker'
+
+const props = defineProps<{
+  gatewayId: GatewayId
+  gatewayLabel: string
+  searchTerm: string
+  isFavoritesOnly: boolean
+  favoriteModelIds: string[]
+  selectedModelId: string | null
+  detailModelId: string | null
+  listboxId: string
+}>()
+
+const emit = defineEmits<{
+  select: [modelId: string]
+  toggleFavorite: [modelId: string]
+  toggleDetail: [modelId: string]
+  closeDetail: []
+  highlight: [optionId: string | null]
+  pendingChange: [isPending: boolean]
+}>()
+
+const { models, pending, error, refresh } = useGatewayCatalog(
+  toRef(props, 'gatewayId'),
+)
+
+const highlightedModelId = shallowRef<string | null>(null)
+const root = useTemplateRef<HTMLDivElement>('root')
+const sectionLabelId = useId()
+
+const isPending = computed<boolean>(() => {
+  return pending.value && !models.value.length
+})
+
+const filteredModels = computed<GatewayModel[]>(() => {
+  const term = props.searchTerm.trim().toLowerCase()
+
+  return models.value.filter((model) => {
+    if (props.isFavoritesOnly && !props.favoriteModelIds.includes(model.id)) {
+      return false
+    }
+
+    if (!term) {
+      return true
+    }
+
+    return model.name.toLowerCase().includes(term)
+      || model.id.toLowerCase().includes(term)
+  })
+})
+
+const sections = computed<GatewayPickerSection[]>(() => {
+  const favorites = filteredModels.value.filter((model) => {
+    return props.favoriteModelIds.includes(model.id)
+  })
+  const others = filteredModels.value.filter((model) => {
+    return !props.favoriteModelIds.includes(model.id)
+  })
+
+  if (!favorites.length || !others.length) {
+    return [{ id: 'all', label: '', entries: [...favorites, ...others] }]
+  }
+
+  return [
+    { id: 'favorites', label: 'Favorites', entries: favorites },
+    { id: 'others', label: 'Other models', entries: others },
+  ]
+})
+
+const emptyMessage = computed<string>(() => {
+  if (props.isFavoritesOnly) {
+    return `No favorite ${props.gatewayLabel} models yet.`
+  }
+
+  if (props.searchTerm.trim()) {
+    return `No models match “${props.searchTerm.trim()}”.`
+  }
+
+  return `${props.gatewayLabel} returned no models.`
+})
+
+async function scrollHighlightedIntoView() {
+  await nextTick()
+
+  if (!highlightedModelId.value) {
+    return
+  }
+
+  const element = root.value?.querySelector<HTMLElement>(
+    `[id="gateway-model-option-${highlightedModelId.value}"]`,
+  )
+
+  element?.scrollIntoView?.({ block: 'nearest' })
+}
+
+function setHighlight(modelId: string | null) {
+  emit('closeDetail')
+  highlightedModelId.value = modelId
+  scrollHighlightedIntoView()
+}
+
+function highlightFirst() {
+  setHighlight(filteredModels.value[0]?.id ?? null)
+}
+
+function highlightLast() {
+  const entries = filteredModels.value
+
+  setHighlight(entries[entries.length - 1]?.id ?? null)
+}
+
+function moveHighlight(step: number) {
+  const entries = filteredModels.value
+
+  if (!entries.length) {
+    return
+  }
+
+  const currentIndex = entries.findIndex((model) => {
+    return model.id === highlightedModelId.value
+  })
+
+  const nextIndex = currentIndex === -1
+    ? 0
+    : (currentIndex + step + entries.length) % entries.length
+
+  setHighlight(entries[nextIndex]?.id ?? null)
+}
+
+function selectHighlighted() {
+  if (!highlightedModelId.value) {
+    return
+  }
+
+  emit('select', highlightedModelId.value)
+}
+
+watch(highlightedModelId, (value) => {
+  emit('highlight', value ? `gateway-model-option-${value}` : null)
+}, { immediate: true })
+
+watch(isPending, (value) => {
+  emit('pendingChange', value)
+}, { immediate: true })
+
+watch(filteredModels, (entries) => {
+  const stillVisible = entries.some((model) => {
+    return model.id === highlightedModelId.value
+  })
+
+  if (stillVisible) {
+    return
+  }
+
+  const selectedIsVisible = entries.some((model) => {
+    return model.id === props.selectedModelId
+  })
+
+  highlightedModelId.value = selectedIsVisible
+    ? props.selectedModelId
+    : entries[0]?.id ?? null
+}, { immediate: true })
+
+defineExpose({
+  moveHighlight,
+  highlightFirst,
+  highlightLast,
+  selectHighlighted,
+})
+</script>

--- a/app/components/ChatInput/ModelsTrigger/GatewayRail.vue
+++ b/app/components/ChatInput/ModelsTrigger/GatewayRail.vue
@@ -1,0 +1,56 @@
+<template>
+  <div
+    data-testid="models-picker-gateway-rail"
+    class="shrink-0 flex items-center gap-2 px-2 py-1.5 border-t border-base-content/10 bg-base-200/40"
+  >
+    <span
+      class="shrink-0 px-1 text-[0.65rem] font-semibold uppercase tracking-wide opacity-50"
+    >
+      Gateways
+    </span>
+    <div class="grow min-w-0 flex items-center gap-1 overflow-x-auto">
+      <button
+        v-for="gateway in gateways"
+        :key="gateway.id"
+        type="button"
+        :data-testid="`models-picker-gateway-${gateway.id}`"
+        class="btn btn-xs shrink-0 gap-1.5 rounded-full"
+        :class="activeGatewayId === gateway.id ? 'btn-accent' : 'btn-ghost'"
+        :aria-pressed="activeGatewayId === gateway.id"
+        :aria-label="activeGatewayId === gateway.id
+          ? `Leave ${gateway.label} and show provider models`
+          : `Browse ${gateway.label} models`
+        "
+        @click="emit('toggleGateway', gateway.id)"
+      >
+        <ProviderIcon
+          :provider-id="gateway.id"
+          :label="gateway.label"
+          class="w-3.5 shrink-0 fill-current"
+        />
+        <span class="truncate">
+          {{ gateway.label }}
+        </span>
+        <span
+          v-if="isPending && activeGatewayId === gateway.id"
+          data-testid="models-picker-gateway-pending"
+          class="loading loading-spinner loading-xs shrink-0"
+        />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { GatewayId } from '#shared/types/gateways.d'
+
+defineProps<{
+  gateways: Array<{ id: GatewayId, label: string }>
+  activeGatewayId: GatewayId | null
+  isPending: boolean
+}>()
+
+const emit = defineEmits<{
+  toggleGateway: [gatewayId: GatewayId]
+}>()
+</script>

--- a/app/composables/gateway-catalog.ts
+++ b/app/composables/gateway-catalog.ts
@@ -1,18 +1,32 @@
 import type { GatewayId, GatewayModel } from '#shared/types/gateways.d'
 
-type SupportedGatewayId = Exclude<GatewayId, 'cloudflare'>
-
 interface GatewayModelsResponse {
   gateway: GatewayId
   models: GatewayModel[]
 }
 
+/**
+ * Shared catalog state, readable without mounting a fetch — lets UI that only
+ * needs a label for an already-selected gateway model (the picker trigger)
+ * avoid pulling a whole catalog on every page load.
+ */
+export function useGatewayCatalogCache() {
+  return useState<Partial<Record<GatewayId, GatewayModel[]>>>(
+    'gateway-catalog-cache',
+    () => ({}),
+  )
+}
+
+/**
+ * Accepts any `GatewayId`: the models route, not this wrapper, decides which
+ * gateways it can serve, and answers an unsupported one with an error the
+ * caller already renders. Keeping the narrower type here would only force a
+ * cast at every call site that iterates `enabledGateways`.
+ */
 export function useGatewayCatalog(
-  gatewayId: Ref<SupportedGatewayId> | SupportedGatewayId,
+  gatewayId: Ref<GatewayId> | GatewayId,
 ) {
-  const gatewayCatalogCache = useState<
-    Partial<Record<GatewayId, GatewayModel[]>>
-  >('gateway-catalog-cache', () => ({}))
+  const gatewayCatalogCache = useGatewayCatalogCache()
 
   const { data, pending, error, refresh } = useLazyFetch<
     GatewayModelsResponse

--- a/app/composables/model.ts
+++ b/app/composables/model.ts
@@ -1,20 +1,35 @@
+import type { ModelSelection } from '#shared/types/model-selection.d'
+
 export function useUserModel() {
   const { defaultModel } = useRuntimeConfig().public
   const prefStorage = usePreferenceStorage()
 
-  const userModel = customRef<string>((track, trigger) => ({
+  const selection = customRef<ModelSelection>((track, trigger) => ({
     get() {
       track()
 
-      return prefStorage.getItem('model') ?? (defaultModel as string)
+      return parseModelSelection(
+        prefStorage.getItem('model'),
+        defaultModel as string,
+      )
     },
     set(value) {
-      prefStorage.setItem('model', value)
+      prefStorage.setItem('model', serializeModelSelection(value))
       trigger()
     },
   }))
 
+  const userModel = computed<string>({
+    get() {
+      return selection.value.modelId
+    },
+    set(value) {
+      selection.value = { source: 'provider', modelId: value }
+    },
+  })
+
   return {
+    selection,
     userModel,
   }
 }

--- a/app/composables/selected-model-info.ts
+++ b/app/composables/selected-model-info.ts
@@ -1,0 +1,65 @@
+import type { GatewayModel } from '#shared/types/gateways.d'
+
+/**
+ * Resolves what the currently-selected model should be called, from whichever
+ * catalog owns it. Gateway names come from already-cached catalog data only —
+ * resolving a label must not be a reason to fetch hundreds of models on every
+ * page load, so an unfetched gateway model falls back to its id, which every
+ * gateway renders in readable `vendor/model` form.
+ */
+export function useSelectedModelInfo() {
+  const { selection } = useUserModel()
+  const gatewayCatalogCache = useGatewayCatalogCache()
+
+  const gatewayModel = computed<GatewayModel | null>(() => {
+    const current = selection.value
+
+    if (current.source !== 'gateway') {
+      return null
+    }
+
+    const models = gatewayCatalogCache.value[current.gatewayId] ?? []
+
+    return models.find((model) => {
+      return model.id === current.modelId
+    }) ?? null
+  })
+
+  const name = computed<string>(() => {
+    const current = selection.value
+
+    if (current.source === 'provider') {
+      return getModelName(current.modelId)
+    }
+
+    return gatewayModel.value?.name || current.modelId
+  })
+
+  const description = computed<string | undefined>(() => {
+    const current = selection.value
+
+    if (current.source === 'provider') {
+      return getModel(current.modelId).model?.description
+    }
+
+    return gatewayModel.value?.description
+  })
+
+  const iconProviderId = computed<string | null>(() => {
+    const current = selection.value
+
+    if (current.source === 'gateway') {
+      return current.gatewayId
+    }
+
+    return getModel(current.modelId).provider?.id ?? null
+  })
+
+  return {
+    selection,
+    gatewayModel,
+    name,
+    description,
+    iconProviderId,
+  }
+}

--- a/app/composables/user-setting.ts
+++ b/app/composables/user-setting.ts
@@ -1,4 +1,28 @@
+import type {
+  GatewayId,
+  GatewayFavoriteModels,
+} from '#shared/types/gateways.d'
 import { parseError } from 'evlog'
+
+function toGatewayFavoriteModels(parsed: unknown): GatewayFavoriteModels {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {}
+  }
+
+  const favorites: GatewayFavoriteModels = {}
+
+  for (const [gatewayId, modelIds] of Object.entries(parsed)) {
+    if (!Array.isArray(modelIds)) {
+      continue
+    }
+
+    favorites[gatewayId as GatewayId] = modelIds.filter((modelId) => {
+      return typeof modelId === 'string'
+    })
+  }
+
+  return favorites
+}
 
 export function useUserSetting() {
   const activeUserId = useState<string | null>(
@@ -33,6 +57,10 @@ export function useUserSetting() {
     'user-settings:favorite-models',
     () => null,
   )
+  const serverFavoriteGatewayModels = useState<GatewayFavoriteModels | null>(
+    'user-settings:favorite-gateway-models',
+    () => null,
+  )
   const isLoadingSettings = useState<boolean>(
     'user-settings:is-loading',
     () => false,
@@ -51,6 +79,10 @@ export function useUserSetting() {
   )
   const lastFavoriteModelsRequestToken = useState<number>(
     'user-settings:favorite-models-request-token',
+    () => 0,
+  )
+  const lastFavoriteGatewayModelsRequestToken = useState<number>(
+    'user-settings:favorite-gateway-models-request-token',
     () => 0,
   )
   const prefStorage = usePreferenceStorage()
@@ -116,6 +148,32 @@ export function useUserSetting() {
       trigger()
     },
   }))
+  const fallbackFavoriteGatewayModels = customRef<GatewayFavoriteModels>(
+    (track, trigger) => ({
+      get() {
+        track()
+
+        const raw = prefStorage.getItem('settings_favorite_gateway_models')
+
+        if (raw === null) {
+          return {}
+        }
+
+        try {
+          return toGatewayFavoriteModels(JSON.parse(raw))
+        } catch {
+          return {}
+        }
+      },
+      set(value) {
+        prefStorage.setItem(
+          'settings_favorite_gateway_models',
+          JSON.stringify(value),
+        )
+        trigger()
+      },
+    }),
+  )
 
   const reasoningExpanded = computed<boolean>(() => {
     if (
@@ -214,6 +272,27 @@ export function useUserSetting() {
     })
   })
 
+  // Intentionally NOT filtered against a catalog, unlike favoriteModels
+  // above: gateway catalogs are fetched at runtime, so any catalog-based
+  // filter here would read as "empty" while a fetch is pending and wipe the
+  // favorites it then persists. Callers scope these ids by only rendering
+  // rows a loaded catalog actually returned.
+  const favoriteGatewayModels = computed<GatewayFavoriteModels>(() => {
+    if (
+      !activeUserId.value
+      || loadedUserId.value !== activeUserId.value
+      || serverFavoriteGatewayModels.value === null
+    ) {
+      return fallbackFavoriteGatewayModels.value
+    }
+
+    return serverFavoriteGatewayModels.value
+  })
+
+  function getFavoriteGatewayModels(gatewayId: GatewayId): string[] {
+    return favoriteGatewayModels.value[gatewayId] ?? []
+  }
+
   async function syncForUser(userId: string) {
     activeUserId.value = userId
     settingsError.value = null
@@ -266,6 +345,12 @@ export function useUserSetting() {
       const nextFavoriteModels = response.favoriteModels ?? []
       serverFavoriteModels.value = nextFavoriteModels
       fallbackFavoriteModels.value = nextFavoriteModels
+
+      const nextFavoriteGatewayModels = toGatewayFavoriteModels(
+        response.favoriteGatewayModels,
+      )
+      serverFavoriteGatewayModels.value = nextFavoriteGatewayModels
+      fallbackFavoriteGatewayModels.value = nextFavoriteGatewayModels
     } catch (exception) {
       if (
         activeUserId.value !== userId
@@ -281,6 +366,7 @@ export function useUserSetting() {
       serverNotificationPromptState.value = null
       serverSidebarPinned.value = null
       serverFavoriteModels.value = null
+      serverFavoriteGatewayModels.value = null
 
       const parsedException = parseError(exception)
 
@@ -605,6 +691,88 @@ export function useUserSetting() {
     await setFavoriteModels(next)
   }
 
+  async function setFavoriteGatewayModels(
+    favoriteGatewayModels: GatewayFavoriteModels,
+  ) {
+    settingsError.value = null
+
+    const previousFallbackFavoriteGatewayModels
+      = fallbackFavoriteGatewayModels.value
+    fallbackFavoriteGatewayModels.value = favoriteGatewayModels
+
+    if (!activeUserId.value) {
+      return
+    }
+
+    const currentUserId = activeUserId.value as string
+    const previousServerFavoriteGatewayModels
+      = serverFavoriteGatewayModels.value as GatewayFavoriteModels
+
+    serverFavoriteGatewayModels.value = favoriteGatewayModels
+    isSavingSettings.value = true
+
+    const requestToken = lastFavoriteGatewayModelsRequestToken.value + 1
+    lastFavoriteGatewayModelsRequestToken.value = requestToken
+
+    try {
+      await $fetch('/api/v1/profiles/settings', {
+        method: 'PATCH',
+        body: {
+          favoriteGatewayModels,
+        },
+      })
+
+      if (
+        activeUserId.value !== currentUserId
+        || lastFavoriteGatewayModelsRequestToken.value !== requestToken
+      ) {
+        return
+      }
+
+      loadedUserId.value = currentUserId
+      serverFavoriteGatewayModels.value = favoriteGatewayModels
+      fallbackFavoriteGatewayModels.value = favoriteGatewayModels
+    } catch (exception) {
+      if (
+        activeUserId.value !== currentUserId
+        || lastFavoriteGatewayModelsRequestToken.value !== requestToken
+      ) {
+        return
+      }
+
+      serverFavoriteGatewayModels.value = previousServerFavoriteGatewayModels
+      fallbackFavoriteGatewayModels.value
+        = previousFallbackFavoriteGatewayModels
+
+      const parsedException = parseError(exception)
+
+      settingsError.value = parsedException.message
+        || 'Failed to save profile settings'
+    } finally {
+      if (lastFavoriteGatewayModelsRequestToken.value === requestToken) {
+        isSavingSettings.value = false
+      }
+    }
+  }
+
+  async function toggleFavoriteGatewayModel(
+    gatewayId: GatewayId,
+    modelId: string,
+  ) {
+    const current = favoriteGatewayModels.value
+    const currentForGateway = current[gatewayId] ?? []
+    const nextForGateway = currentForGateway.includes(modelId)
+      ? currentForGateway.filter((id) => {
+        return id !== modelId
+      })
+      : [...currentForGateway, modelId]
+
+    await setFavoriteGatewayModels({
+      ...current,
+      [gatewayId]: nextForGateway,
+    })
+  }
+
   function clearUserContext() {
     activeUserId.value = null
     loadedUserId.value = null
@@ -614,6 +782,7 @@ export function useUserSetting() {
     serverNotificationPromptState.value = null
     serverSidebarPinned.value = null
     serverFavoriteModels.value = null
+    serverFavoriteGatewayModels.value = null
     settingsError.value = null
     isLoadingSettings.value = false
     isSavingSettings.value = false
@@ -627,6 +796,8 @@ export function useUserSetting() {
     notificationPromptState,
     sidebarPinned,
     favoriteModels,
+    favoriteGatewayModels,
+    getFavoriteGatewayModels,
     isLoadingSettings,
     isSavingSettings,
     settingsError,
@@ -638,6 +809,8 @@ export function useUserSetting() {
     setSidebarPinned,
     setFavoriteModels,
     toggleFavoriteModel,
+    setFavoriteGatewayModels,
+    toggleFavoriteGatewayModel,
     clearUserContext,
   }
 }

--- a/app/types/models-picker.d.ts
+++ b/app/types/models-picker.d.ts
@@ -1,3 +1,4 @@
+import type { GatewayId, GatewayModel } from '#shared/types/gateways.d'
 import type { Model } from '#shared/types/providers.d'
 
 export type ModelCategory = 'chat' | 'research' | 'image-generation'
@@ -18,4 +19,14 @@ export interface PickerSection {
   id: string
   label: string
   entries: PickerModel[]
+}
+
+export type PickerMode
+  = | { source: 'provider' }
+    | { source: 'gateway', gatewayId: GatewayId }
+
+export interface GatewayPickerSection {
+  id: string
+  label: string
+  entries: GatewayModel[]
 }

--- a/app/utils/models-picker.ts
+++ b/app/utils/models-picker.ts
@@ -1,3 +1,4 @@
+import type { GatewayModel } from '#shared/types/gateways.d'
 import type { Model, ModelPriceTier } from '#shared/types/providers.d'
 import type { ModelCategory, ModelCategoryOption } from '~/types/models-picker'
 
@@ -72,6 +73,87 @@ export function formatModelTokenLimit(count: number): string {
   }
 
   return `${count.toLocaleString('en-US')} tokens`
+}
+
+/**
+ * Gateways quote prices PER TOKEN as decimal strings, while the curated
+ * catalog quotes per million. The explicit scale-up here is what makes the
+ * two comparable; the resulting float noise (2.5e-6 * 1e6 lands on
+ * 2.4999999999999996) is absorbed by fixed-fraction formatting, never by
+ * stringifying the product.
+ */
+function formatPricePerMillionTokens(perTokenPrice: string): string | null {
+  const perToken = Number(perTokenPrice)
+
+  if (!Number.isFinite(perToken) || perToken < 0) {
+    return null
+  }
+
+  const perMillion = perToken * 1_000_000
+  const fractionDigits = perMillion > 0 && perMillion < 1 ? 3 : 2
+
+  return `$${perMillion.toLocaleString('en-US', {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })}`
+}
+
+function toPricePair(
+  pricing: GatewayModel['pricing'],
+): { input: string, output: string, isFree: boolean } | null {
+  if (!pricing) {
+    return null
+  }
+
+  const input = formatPricePerMillionTokens(pricing.input)
+  const output = formatPricePerMillionTokens(pricing.output)
+
+  if (!input || !output) {
+    return null
+  }
+
+  return {
+    input,
+    output,
+    isFree: Number(pricing.input) === 0 && Number(pricing.output) === 0,
+  }
+}
+
+/**
+ * Deliberately spells out the "per 1M" unit instead of reusing the curated
+ * catalog's `$`/`$$`/`$$$` tier badge — gateway catalogs carry no tier, and a
+ * lookalike badge would imply a comparability that does not exist.
+ */
+export function formatGatewayPrice(
+  pricing: GatewayModel['pricing'],
+): string | undefined {
+  const pair = toPricePair(pricing)
+
+  if (!pair) {
+    return undefined
+  }
+
+  if (pair.isFree) {
+    return 'Free'
+  }
+
+  return `${pair.input}/${pair.output} per 1M`
+}
+
+export function formatGatewayPriceDetail(
+  pricing: GatewayModel['pricing'],
+): string | undefined {
+  const pair = toPricePair(pricing)
+
+  if (!pair) {
+    return undefined
+  }
+
+  if (pair.isFree) {
+    return 'Free'
+  }
+
+  return `${pair.input} in / ${pair.output} out per 1M tokens`
 }
 
 /**

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -103,6 +103,7 @@ export function getAffectedTests(changedFiles) {
   ]
   const modelSelectionTests = [
     'tests/unit/composables/model.spec.ts',
+    'tests/unit/composables/selected-model-info.spec.ts',
     'tests/unit/composables/chat-input.spec.ts',
     'tests/unit/composables/chat-research.spec.ts',
   ]

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -98,7 +98,13 @@ export function getAffectedTests(changedFiles) {
     'tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts',
     'tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts',
     'tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts',
+    'tests/unit/components/ChatInput/ModelsTrigger/GatewayRail.spec.ts',
     'tests/unit/utils/models-picker.spec.ts',
+  ]
+  const modelSelectionTests = [
+    'tests/unit/composables/model.spec.ts',
+    'tests/unit/composables/chat-input.spec.ts',
+    'tests/unit/composables/chat-research.spec.ts',
   ]
   const modelCatalogTests = [
     'tests/unit/providers/merge.spec.ts',
@@ -404,8 +410,21 @@ export function getAffectedTests(changedFiles) {
     },
     {
       pattern:
-        /^(server\/utils\/gateways\/.*\.ts|server\/api\/v1\/gateways\/.*\.ts|shared\/types\/gateways\.d\.ts|app\/composables\/gateway-catalog\.ts)$/,
+        /^(server\/utils\/gateways\/.*\.ts|server\/api\/v1\/gateways\/.*\.ts|shared\/types\/gateways\.d\.ts)$/,
       tests: gatewayCatalogTests,
+    },
+    {
+      pattern: /^app\/composables\/gateway-catalog\.ts$/,
+      tests: [...gatewayCatalogTests, ...modelsTriggerTests],
+    },
+    {
+      pattern:
+        /^(app\/composables\/(model|selected-model-info)\.ts|shared\/utils\/model-selection\.ts|shared\/types\/model-selection\.d\.ts)$/,
+      tests: [...modelSelectionTests, ...modelsTriggerTests],
+    },
+    {
+      pattern: /^app\/composables\/user-setting\.ts$/,
+      tests: [...profileSettingsTests, ...modelsTriggerTests],
     },
     {
       pattern:

--- a/server/api/v1/profiles/settings/index.get.ts
+++ b/server/api/v1/profiles/settings/index.get.ts
@@ -16,6 +16,7 @@ export default defineEventHandler(async () => {
       notificationPromptState: true,
       sidebarPinned: true,
       favoriteModels: true,
+      favoriteGatewayModels: true,
     },
   })
 
@@ -26,5 +27,6 @@ export default defineEventHandler(async () => {
     notificationPromptState: settings?.notificationPromptState ?? null,
     sidebarPinned: settings?.sidebarPinned ?? false,
     favoriteModels: settings?.favoriteModels ?? [],
+    favoriteGatewayModels: settings?.favoriteGatewayModels ?? {},
   }
 })

--- a/server/api/v1/profiles/settings/index.patch.ts
+++ b/server/api/v1/profiles/settings/index.patch.ts
@@ -1,5 +1,8 @@
+import type { GatewayId } from '#shared/types/gateways.d'
 import { eq } from 'drizzle-orm'
 import * as schema from '~~/server/db/schema'
+
+const favoriteGatewayModelIds = z.array(z.string().max(100)).max(50)
 
 export default defineEventHandler(async (event) => {
   const session = await useUserSession()
@@ -15,6 +18,11 @@ export default defineEventHandler(async (event) => {
     notificationPromptState: z.boolean().nullable().optional(),
     sidebarPinned: z.boolean().optional(),
     favoriteModels: z.array(z.string().max(100)).max(50).optional(),
+    favoriteGatewayModels: z.object({
+      vercel: favoriteGatewayModelIds.optional(),
+      cloudflare: favoriteGatewayModelIds.optional(),
+      openrouter: favoriteGatewayModelIds.optional(),
+    }).optional(),
   }).safeParse)
 
   if (body.error) {
@@ -43,6 +51,7 @@ export default defineEventHandler(async (event) => {
     notificationPromptState?: boolean | null
     sidebarPinned?: boolean
     favoriteModels?: string[]
+    favoriteGatewayModels?: Partial<Record<GatewayId, string[]>>
   } = {}
 
   if (body.data.reasoningExpanded !== undefined) {
@@ -68,6 +77,22 @@ export default defineEventHandler(async (event) => {
 
   if (body.data.favoriteModels !== undefined) {
     fieldUpdates.favoriteModels = [...new Set(body.data.favoriteModels)]
+  }
+
+  if (body.data.favoriteGatewayModels !== undefined) {
+    const deduped: Partial<Record<GatewayId, string[]>> = {}
+
+    for (const [gatewayId, modelIds] of Object.entries(
+      body.data.favoriteGatewayModels,
+    )) {
+      if (!modelIds) {
+        continue
+      }
+
+      deduped[gatewayId as GatewayId] = [...new Set(modelIds)]
+    }
+
+    fieldUpdates.favoriteGatewayModels = deduped
   }
 
   if (Object.keys(fieldUpdates).length === 0) {

--- a/server/db/schemas/user-settings.ts
+++ b/server/db/schemas/user-settings.ts
@@ -1,3 +1,4 @@
+import type { GatewayId } from '#shared/types/gateways.d'
 import {
   snakeCase,
   integer,
@@ -25,6 +26,8 @@ export const userSettings = snakeCase.table(
     notificationPromptState: integer({ mode: 'boolean' }),
     sidebarPinned: integer({ mode: 'boolean' }),
     favoriteModels: text({ mode: 'json' }).$type<string[]>(),
+    favoriteGatewayModels: text({ mode: 'json' })
+      .$type<Partial<Record<GatewayId, string[]>>>(),
   },
   table => [
     uniqueIndex('uq_user_settings_user').on(table.userId),

--- a/shared/types/gateways.d.ts
+++ b/shared/types/gateways.d.ts
@@ -1,5 +1,7 @@
 export type GatewayId = 'vercel' | 'cloudflare' | 'openrouter'
 
+export type GatewayFavoriteModels = Partial<Record<GatewayId, string[]>>
+
 export interface GatewayModel {
   id: string
   name: string

--- a/shared/types/model-selection.d.ts
+++ b/shared/types/model-selection.d.ts
@@ -1,0 +1,5 @@
+import type { GatewayId } from '#shared/types/gateways.d'
+
+export type ModelSelection
+  = | { source: 'provider', modelId: string }
+    | { source: 'gateway', gatewayId: GatewayId, modelId: string }

--- a/shared/utils/model-selection.ts
+++ b/shared/utils/model-selection.ts
@@ -1,0 +1,75 @@
+import type { GatewayId } from '#shared/types/gateways.d'
+import type { ModelSelection } from '#shared/types/model-selection.d'
+
+const gatewayIds: GatewayId[] = ['vercel', 'cloudflare', 'openrouter']
+
+function isGatewayId(value: unknown): value is GatewayId {
+  return typeof value === 'string'
+    && (gatewayIds as string[]).includes(value)
+}
+
+function toGatewaySelection(parsed: unknown): ModelSelection | null {
+  if (typeof parsed !== 'object' || parsed === null) {
+    return null
+  }
+
+  const candidate = parsed as Record<string, unknown>
+
+  if (typeof candidate.modelId !== 'string' || !candidate.modelId) {
+    return null
+  }
+
+  if (candidate.source === 'provider') {
+    return { source: 'provider', modelId: candidate.modelId }
+  }
+
+  if (candidate.source !== 'gateway' || !isGatewayId(candidate.gatewayId)) {
+    return null
+  }
+
+  return {
+    source: 'gateway',
+    gatewayId: candidate.gatewayId,
+    modelId: candidate.modelId,
+  }
+}
+
+/**
+ * Reads the `'model'` preference, which predates gateways and therefore holds
+ * a bare model id for every already-stored value. Anything not starting with
+ * `{` keeps that legacy meaning so existing users need no migration; only the
+ * JSON form can carry a gateway. Unparseable or structurally invalid JSON
+ * degrades to the same bare-string reading rather than throwing.
+ */
+export function parseModelSelection(
+  raw: string | null,
+  fallbackModelId: string,
+): ModelSelection {
+  if (!raw) {
+    return { source: 'provider', modelId: fallbackModelId }
+  }
+
+  if (!raw.startsWith('{')) {
+    return { source: 'provider', modelId: raw }
+  }
+
+  try {
+    return toGatewaySelection(JSON.parse(raw))
+      ?? { source: 'provider', modelId: raw }
+  } catch {
+    return { source: 'provider', modelId: raw }
+  }
+}
+
+/**
+ * Provider selections stay bare strings so the stored value is byte-identical
+ * to what pre-gateway builds wrote. Gateway selections are JSON because
+ * OpenRouter ids contain both `:` and `/`, leaving no safe delimiter.
+ */
+export function serializeModelSelection(selection: ModelSelection): string {
+  if (selection.source === 'provider') {
+    return selection.modelId
+  }
+
+  return JSON.stringify(selection)
+}

--- a/tests/integration/api/profile-settings.spec.ts
+++ b/tests/integration/api/profile-settings.spec.ts
@@ -8,6 +8,7 @@ interface SettingsRecord {
   notificationPromptState: boolean | null
   sidebarPinned: boolean
   favoriteModels: string[] | null
+  favoriteGatewayModels: Record<string, string[]> | null
 }
 
 function createDbMock() {
@@ -24,6 +25,7 @@ function createDbMock() {
     notificationPromptState?: boolean | null
     sidebarPinned?: boolean
     favoriteModels?: string[]
+    favoriteGatewayModels?: Record<string, string[]>
   }) => {
     currentSettings = {
       id: 1,
@@ -33,6 +35,7 @@ function createDbMock() {
       notificationPromptState: values.notificationPromptState ?? null,
       sidebarPinned: values.sidebarPinned ?? false,
       favoriteModels: values.favoriteModels ?? null,
+      favoriteGatewayModels: values.favoriteGatewayModels ?? null,
     }
   })
   const insert = vi.fn(() => ({
@@ -48,6 +51,7 @@ function createDbMock() {
     notificationPromptState?: boolean | null
     sidebarPinned?: boolean
     favoriteModels?: string[]
+    favoriteGatewayModels?: Record<string, string[]>
   }) => {
     currentSettings = {
       id: 1,
@@ -68,6 +72,9 @@ function createDbMock() {
         ?? false,
       favoriteModels: values.favoriteModels
         ?? currentSettings?.favoriteModels
+        ?? null,
+      favoriteGatewayModels: values.favoriteGatewayModels
+        ?? currentSettings?.favoriteGatewayModels
         ?? null,
     }
 
@@ -183,6 +190,7 @@ describe('profile settings API', () => {
       notificationPromptState: null,
       sidebarPinned: false,
       favoriteModels: [],
+      favoriteGatewayModels: {},
     })
   })
 
@@ -229,6 +237,7 @@ describe('profile settings API', () => {
       notificationPromptState: null,
       sidebarPinned: false,
       favoriteModels: [],
+      favoriteGatewayModels: {},
     })
   })
 
@@ -263,6 +272,7 @@ describe('profile settings API', () => {
       notificationPromptState: null,
       sidebarPinned: false,
       favoriteModels: [],
+      favoriteGatewayModels: {},
     })
   })
 
@@ -297,6 +307,7 @@ describe('profile settings API', () => {
       notificationPromptState: null,
       sidebarPinned: false,
       favoriteModels: [],
+      favoriteGatewayModels: {},
     })
   })
 
@@ -331,6 +342,7 @@ describe('profile settings API', () => {
       notificationPromptState: false,
       sidebarPinned: false,
       favoriteModels: [],
+      favoriteGatewayModels: {},
     })
   })
 
@@ -365,6 +377,7 @@ describe('profile settings API', () => {
       notificationPromptState: null,
       sidebarPinned: true,
       favoriteModels: [],
+      favoriteGatewayModels: {},
     })
   })
 
@@ -399,6 +412,96 @@ describe('profile settings API', () => {
       notificationPromptState: null,
       sidebarPinned: false,
       favoriteModels: ['gpt-5.4', 'gemini-2.5-flash'],
+      favoriteGatewayModels: {},
+    })
+  })
+
+  it('saves deduped favoriteGatewayModels per gateway', async () => {
+    const patchHandler = await patchSettingsHandler()
+    const getHandler = await getSettingsHandler()
+    const dbMock = createDbMock()
+
+    vi.stubGlobal('useDb', () => dbMock.db)
+    vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue({
+      user: {
+        id: '1',
+      },
+    }))
+
+    const patchResponse = await patchHandler({
+      body: {
+        favoriteGatewayModels: {
+          vercel: ['openai/gpt-4o', 'openai/gpt-4o'],
+          openrouter: ['anthropic/claude-opus-5:free'],
+        },
+      },
+    } as any)
+
+    expect(patchResponse).toEqual({
+      favoriteGatewayModels: {
+        vercel: ['openai/gpt-4o'],
+        openrouter: ['anthropic/claude-opus-5:free'],
+      },
+    })
+
+    const getResponse = await getHandler({} as any)
+
+    expect(getResponse).toMatchObject({
+      favoriteGatewayModels: {
+        vercel: ['openai/gpt-4o'],
+        openrouter: ['anthropic/claude-opus-5:free'],
+      },
+    })
+  })
+
+  it('drops unknown gateway keys from favoriteGatewayModels', async () => {
+    const patchHandler = await patchSettingsHandler()
+    const dbMock = createDbMock()
+
+    vi.stubGlobal('useDb', () => dbMock.db)
+    vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue({
+      user: {
+        id: '1',
+      },
+    }))
+
+    const patchResponse = await patchHandler({
+      body: {
+        favoriteGatewayModels: {
+          'vercel': ['openai/gpt-4o'],
+          'not-a-gateway': ['evil/model'],
+        },
+      },
+    } as any)
+
+    expect(patchResponse).toEqual({
+      favoriteGatewayModels: {
+        vercel: ['openai/gpt-4o'],
+      },
+    })
+  })
+
+  it('rejects a favoriteGatewayModels list over the cap', async () => {
+    const patchHandler = await patchSettingsHandler()
+    const dbMock = createDbMock()
+
+    vi.stubGlobal('useDb', () => dbMock.db)
+    vi.stubGlobal('useUserSession', vi.fn().mockResolvedValue({
+      user: {
+        id: '1',
+      },
+    }))
+
+    await expect(patchHandler({
+      body: {
+        favoriteGatewayModels: {
+          vercel: Array.from({ length: 51 }, (_value, index) => {
+            return `model-${index}`
+          }),
+        },
+      },
+    } as any)).rejects.toMatchObject({
+      statusCode: 400,
     })
   })
 

--- a/tests/unit/components/ChatInput/ModelsTrigger.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.spec.ts
@@ -1,4 +1,5 @@
-import { shallowRef } from 'vue'
+import type { ModelSelection } from '#shared/types/model-selection.d'
+import { computed, shallowRef } from 'vue'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ModelsTrigger from '../../../../app/components/ChatInput/ModelsTrigger.vue'
@@ -11,7 +12,11 @@ const mocks = vi.hoisted(() => ({
   useDevice: vi.fn(),
   useUserModel: vi.fn(),
   useUserSetting: vi.fn(),
+  useGatewayCatalog: vi.fn(),
   toggleFavoriteModel: vi.fn(),
+  toggleFavoriteGatewayModel: vi.fn(),
+  getFavoriteGatewayModels: vi.fn(),
+  refreshGatewayCatalog: vi.fn(),
 }))
 
 mockNuxtImport('getModel', () => mocks.getModel)
@@ -21,6 +26,29 @@ mockNuxtImport('onClickOutside', () => mocks.onClickOutside)
 mockNuxtImport('useDevice', () => mocks.useDevice)
 mockNuxtImport('useUserModel', () => mocks.useUserModel)
 mockNuxtImport('useUserSetting', () => mocks.useUserSetting)
+mockNuxtImport('useGatewayCatalog', () => mocks.useGatewayCatalog)
+
+/**
+ * Mirrors the real composable's writable-computed bridge so assertions can
+ * keep reading `userModel` as a plain string while the component writes
+ * through the richer `selection`.
+ */
+function createSelectionMock(modelId: string) {
+  const selection = shallowRef<ModelSelection>({
+    source: 'provider',
+    modelId,
+  })
+  const userModel = computed<string>({
+    get() {
+      return selection.value.modelId
+    },
+    set(value) {
+      selection.value = { source: 'provider', modelId: value }
+    },
+  })
+
+  return { selection, userModel }
+}
 
 const imageModel = {
   id: 'image-model',
@@ -104,12 +132,20 @@ describe('ChatInput/ModelsTrigger', () => {
       isAndroid: false,
       isDesktop: true,
     })
-    mocks.useUserModel.mockReturnValue({
-      userModel: shallowRef<string>('image-model'),
-    })
+    mocks.useUserModel.mockReturnValue(createSelectionMock('image-model'))
+    mocks.getFavoriteGatewayModels.mockReturnValue([])
     mocks.useUserSetting.mockReturnValue({
       favoriteModels: shallowRef<string[]>([]),
+      favoriteGatewayModels: shallowRef({}),
+      getFavoriteGatewayModels: mocks.getFavoriteGatewayModels,
       toggleFavoriteModel: mocks.toggleFavoriteModel,
+      toggleFavoriteGatewayModel: mocks.toggleFavoriteGatewayModel,
+    })
+    mocks.useGatewayCatalog.mockReturnValue({
+      models: shallowRef([]),
+      pending: shallowRef(false),
+      error: shallowRef(null),
+      refresh: mocks.refreshGatewayCatalog,
     })
   })
 
@@ -169,9 +205,10 @@ describe('ChatInput/ModelsTrigger', () => {
   })
 
   it('selects a model and closes the picker', async () => {
-    const userModel = shallowRef<string>('other-model')
+    const selectionMock = createSelectionMock('other-model')
+    const { userModel } = selectionMock
 
-    mocks.useUserModel.mockReturnValue({ userModel })
+    mocks.useUserModel.mockReturnValue(selectionMock)
 
     const wrapper = await mountPicker()
 
@@ -281,9 +318,7 @@ describe('ChatInput/ModelsTrigger', () => {
 
   it('never aims the keyboard highlight at a deprecated selection', async () => {
     useLegacyCatalog()
-    mocks.useUserModel.mockReturnValue({
-      userModel: shallowRef<string>('legacy-model'),
-    })
+    mocks.useUserModel.mockReturnValue(createSelectionMock('legacy-model'))
 
     const wrapper = await mountPicker()
 
@@ -341,5 +376,157 @@ describe('ChatInput/ModelsTrigger', () => {
     await wrapper.get('[data-testid="model-favorite-toggle"]').trigger('click')
 
     expect(mocks.toggleFavoriteModel).toHaveBeenCalledWith('image-model')
+  })
+
+  describe('gateway mode', () => {
+    const gatewayModel = {
+      id: 'anthropic/claude-opus-5',
+      name: 'Claude Opus 5',
+      contextLength: 200_000,
+      pricing: { input: '0.0000025', output: '0.00001' },
+      supportsTools: true,
+    }
+
+    function useGatewayModels() {
+      mocks.useGatewayCatalog.mockReturnValue({
+        models: shallowRef([gatewayModel]),
+        pending: shallowRef(false),
+        error: shallowRef(null),
+        refresh: mocks.refreshGatewayCatalog,
+      })
+    }
+
+    async function openGateway() {
+      useGatewayModels()
+
+      const wrapper = await mountPicker()
+
+      await wrapper.get('[data-testid="current-model-trigger"]')
+        .trigger('click')
+      await wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+        .trigger('click')
+
+      return wrapper
+    }
+
+    it('renders a rail button per enabled gateway', async () => {
+      const wrapper = await mountPicker()
+
+      await wrapper.get('[data-testid="current-model-trigger"]')
+        .trigger('click')
+
+      expect(wrapper.find('[data-testid="models-picker-gateway-vercel"]')
+        .exists()).toBe(true)
+      expect(wrapper.find('[data-testid="models-picker-gateway-openrouter"]')
+        .exists()).toBe(true)
+      expect(wrapper.find('[data-testid="models-picker-gateway-cloudflare"]')
+        .exists()).toBe(false)
+    })
+
+    it('replaces provider browsing with an unmistakable gateway mode', async () => {
+      const wrapper = await openGateway()
+
+      expect(wrapper.get('[data-testid="models-picker-gateway-banner"]').text())
+        .toContain('Vercel AI Gateway')
+      expect(wrapper.find('[data-testid="models-picker-rail"]').exists())
+        .toBe(false)
+      expect(wrapper.find('[data-testid="models-picker-filter-trigger"]')
+        .exists()).toBe(false)
+      expect(wrapper.find('button[aria-label="Choose Image model"]').exists())
+        .toBe(false)
+      expect(wrapper.get('button[aria-label="Choose Claude Opus 5"]').exists())
+        .toBe(true)
+    })
+
+    it('returns to provider mode from the banner exit', async () => {
+      const wrapper = await openGateway()
+
+      await wrapper.get('[data-testid="models-picker-gateway-exit"]')
+        .trigger('click')
+
+      expect(wrapper.find('[data-testid="models-picker-gateway-banner"]')
+        .exists()).toBe(false)
+      expect(wrapper.get('button[aria-label="Choose Image model"]').exists())
+        .toBe(true)
+    })
+
+    it('writes a gateway selection instead of a bare model id', async () => {
+      const selectionMock = createSelectionMock('image-model')
+
+      mocks.useUserModel.mockReturnValue(selectionMock)
+
+      const wrapper = await openGateway()
+
+      await wrapper.get('button[aria-label="Choose Claude Opus 5"]')
+        .trigger('click')
+
+      expect(selectionMock.selection.value).toEqual({
+        source: 'gateway',
+        gatewayId: 'vercel',
+        modelId: 'anthropic/claude-opus-5',
+      })
+    })
+
+    it('routes favorites to the active gateway, not the curated list', async () => {
+      const wrapper = await openGateway()
+
+      await wrapper.get('[data-testid="gateway-model-favorite-toggle"]')
+        .trigger('click')
+
+      expect(mocks.toggleFavoriteGatewayModel).toHaveBeenCalledWith(
+        'vercel',
+        'anthropic/claude-opus-5',
+      )
+      expect(mocks.toggleFavoriteModel).not.toHaveBeenCalled()
+    })
+
+    it('offers a retry when the catalog fetch fails', async () => {
+      mocks.useGatewayCatalog.mockReturnValue({
+        models: shallowRef([]),
+        pending: shallowRef(false),
+        error: shallowRef(new Error('upstream down')),
+        refresh: mocks.refreshGatewayCatalog,
+      })
+
+      const wrapper = await mountPicker()
+
+      await wrapper.get('[data-testid="current-model-trigger"]')
+        .trigger('click')
+      await wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+        .trigger('click')
+      await wrapper.get('[data-testid="gateway-models-retry"]').trigger('click')
+
+      expect(mocks.refreshGatewayCatalog).toHaveBeenCalled()
+    })
+
+    it('keeps arrow-key navigation working over the gateway catalog', async () => {
+      const wrapper = await openGateway()
+      const search = wrapper.get('[data-testid="models-picker-search"]')
+
+      await search.trigger('keydown', { key: 'ArrowDown' })
+
+      expect(search.attributes('aria-activedescendant'))
+        .toBe('gateway-model-option-anthropic/claude-opus-5')
+    })
+
+    it('reopens in the mode matching the current selection', async () => {
+      useGatewayModels()
+      mocks.useUserModel.mockReturnValue({
+        selection: shallowRef<ModelSelection>({
+          source: 'gateway',
+          gatewayId: 'vercel',
+          modelId: 'anthropic/claude-opus-5',
+        }),
+        userModel: shallowRef('anthropic/claude-opus-5'),
+      })
+
+      const wrapper = await mountPicker()
+
+      await wrapper.get('[data-testid="current-model-trigger"]')
+        .trigger('click')
+
+      expect(wrapper.get('[data-testid="models-picker-gateway-banner"]').text())
+        .toContain('Vercel AI Gateway')
+    })
   })
 })

--- a/tests/unit/components/ChatInput/ModelsTrigger/GatewayRail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/GatewayRail.spec.ts
@@ -1,0 +1,123 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import type { GatewayId } from '#shared/types/gateways.d'
+import GatewayRail
+  from '../../../../../app/components/ChatInput/ModelsTrigger/GatewayRail.vue'
+
+const gateways: Array<{ id: GatewayId, label: string }> = [
+  { id: 'vercel', label: 'Vercel AI Gateway' },
+  { id: 'openrouter', label: 'OpenRouter' },
+]
+
+function mountRail(
+  props: Partial<{
+    gateways: Array<{ id: GatewayId, label: string }>
+    activeGatewayId: GatewayId | null
+    isPending: boolean
+  }> = {},
+) {
+  return mountSuspended(GatewayRail, {
+    props: {
+      gateways,
+      activeGatewayId: null,
+      isPending: false,
+      ...props,
+    },
+  })
+}
+
+describe('ChatInput/ModelsTrigger/GatewayRail', () => {
+  it('renders one labelled button per gateway', async () => {
+    const wrapper = await mountRail()
+    const vercel = wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+    const openrouter = wrapper.get(
+      '[data-testid="models-picker-gateway-openrouter"]',
+    )
+
+    expect(vercel.text()).toContain('Vercel AI Gateway')
+    expect(vercel.attributes('aria-label'))
+      .toBe('Browse Vercel AI Gateway models')
+    expect(vercel.attributes('aria-pressed')).toBe('false')
+    expect(openrouter.text()).toContain('OpenRouter')
+  })
+
+  it('renders only the gateways it is given', async () => {
+    const wrapper = await mountRail({
+      gateways: [{ id: 'vercel', label: 'Vercel AI Gateway' }],
+    })
+
+    expect(wrapper.find('[data-testid="models-picker-gateway-openrouter"]')
+      .exists()).toBe(false)
+    expect(wrapper.find('[data-testid="models-picker-gateway-cloudflare"]')
+      .exists()).toBe(false)
+  })
+
+  it('emits toggleGateway with the clicked gateway id', async () => {
+    const wrapper = await mountRail()
+
+    await wrapper.get('[data-testid="models-picker-gateway-openrouter"]')
+      .trigger('click')
+
+    expect(wrapper.emitted('toggleGateway')).toEqual([['openrouter']])
+  })
+
+  it('marks the active gateway with a solid fill, unlike the provider rail', async () => {
+    const wrapper = await mountRail({ activeGatewayId: 'vercel' })
+    const vercel = wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+    const openrouter = wrapper.get(
+      '[data-testid="models-picker-gateway-openrouter"]',
+    )
+
+    expect(vercel.attributes('aria-pressed')).toBe('true')
+    expect(vercel.classes()).toContain('btn-accent')
+    expect(vercel.classes()).not.toContain('btn-ghost')
+    expect(openrouter.attributes('aria-pressed')).toBe('false')
+    expect(openrouter.classes()).toContain('btn-ghost')
+    expect(openrouter.classes()).not.toContain('btn-accent')
+  })
+
+  it('offers leaving gateway mode through the active button', async () => {
+    const wrapper = await mountRail({ activeGatewayId: 'vercel' })
+
+    expect(
+      wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+        .attributes('aria-label'),
+    ).toBe('Leave Vercel AI Gateway and show provider models')
+  })
+
+  it('shows a spinner only on the gateway whose catalog is loading', async () => {
+    const wrapper = await mountRail({
+      activeGatewayId: 'vercel',
+      isPending: true,
+    })
+
+    expect(
+      wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+        .find('[data-testid="models-picker-gateway-pending"]').exists(),
+    ).toBe(true)
+    expect(
+      wrapper.get('[data-testid="models-picker-gateway-openrouter"]')
+        .find('[data-testid="models-picker-gateway-pending"]').exists(),
+    ).toBe(false)
+  })
+
+  it('hides the spinner when no catalog is loading', async () => {
+    const wrapper = await mountRail({ activeGatewayId: 'vercel' })
+
+    expect(wrapper.find('[data-testid="models-picker-gateway-pending"]')
+      .exists()).toBe(false)
+  })
+
+  it('renders brand marks for the known gateways', async () => {
+    const wrapper = await mountRail()
+
+    expect(
+      wrapper.get('[data-testid="models-picker-gateway-vercel"]').find('svg')
+        .exists(),
+    ).toBe(true)
+    expect(
+      wrapper.get('[data-testid="models-picker-gateway-openrouter"]')
+        .find('svg').exists(),
+    ).toBe(true)
+  })
+})

--- a/tests/unit/composables/model.spec.ts
+++ b/tests/unit/composables/model.spec.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defaultModel } from '../../../providers'
+import { useUserModel } from '../../../app/composables/model'
+import {
+  parseModelSelection,
+  serializeModelSelection,
+} from '../../../shared/utils/model-selection'
+
+const openRouterModelId = 'anthropic/claude-opus-5:free'
+
+describe('parseModelSelection', () => {
+  it('reads a legacy bare string as a provider selection', () => {
+    expect(parseModelSelection('gemini-2.5-flash', 'fallback-model')).toEqual({
+      source: 'provider',
+      modelId: 'gemini-2.5-flash',
+    })
+  })
+
+  it('falls back to the default model when nothing is stored', () => {
+    expect(parseModelSelection(null, 'fallback-model')).toEqual({
+      source: 'provider',
+      modelId: 'fallback-model',
+    })
+    expect(parseModelSelection('', 'fallback-model')).toEqual({
+      source: 'provider',
+      modelId: 'fallback-model',
+    })
+  })
+
+  it('reads a gateway selection whose id contains a colon and a slash', () => {
+    const raw = JSON.stringify({
+      source: 'gateway',
+      gatewayId: 'openrouter',
+      modelId: openRouterModelId,
+    })
+
+    expect(parseModelSelection(raw, 'fallback-model')).toEqual({
+      source: 'gateway',
+      gatewayId: 'openrouter',
+      modelId: openRouterModelId,
+    })
+  })
+
+  it('degrades to a bare-string reading instead of throwing on bad JSON', () => {
+    expect(parseModelSelection('{not json at all', 'fallback-model')).toEqual({
+      source: 'provider',
+      modelId: '{not json at all',
+    })
+  })
+
+  it('rejects JSON that is not a valid selection', () => {
+    const raw = JSON.stringify({ source: 'gateway', modelId: 'x' })
+    const unknownGateway = JSON.stringify({
+      source: 'gateway',
+      gatewayId: 'not-a-gateway',
+      modelId: 'x',
+    })
+
+    expect(parseModelSelection(raw, 'fallback-model').source).toBe('provider')
+    expect(parseModelSelection(unknownGateway, 'fallback-model').source)
+      .toBe('provider')
+  })
+})
+
+describe('serializeModelSelection', () => {
+  it('writes a provider selection as the bare model id', () => {
+    expect(serializeModelSelection({
+      source: 'provider',
+      modelId: 'gemini-2.5-flash',
+    })).toBe('gemini-2.5-flash')
+  })
+
+  it('round-trips a gateway selection through JSON', () => {
+    const selection = {
+      source: 'gateway',
+      gatewayId: 'openrouter',
+      modelId: openRouterModelId,
+    } as const
+    const raw = serializeModelSelection(selection)
+
+    expect(raw.startsWith('{')).toBe(true)
+    expect(parseModelSelection(raw, 'fallback-model')).toEqual(selection)
+  })
+})
+
+describe('useUserModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('loads a pre-gateway stored value with no migration', () => {
+    localStorage.setItem('model', 'gpt-5.4')
+
+    const { selection, userModel } = useUserModel()
+
+    expect(selection.value).toEqual({
+      source: 'provider',
+      modelId: 'gpt-5.4',
+    })
+    expect(userModel.value).toBe('gpt-5.4')
+  })
+
+  it('falls back to the build-time default model', () => {
+    const { selection, userModel } = useUserModel()
+
+    expect(selection.value).toEqual({
+      source: 'provider',
+      modelId: defaultModel,
+    })
+    expect(userModel.value).toBe(defaultModel)
+  })
+
+  it('keeps writing provider selections as a bare string', () => {
+    const { selection } = useUserModel()
+
+    selection.value = { source: 'provider', modelId: 'gpt-5.4' }
+
+    expect(localStorage.getItem('model')).toBe('gpt-5.4')
+  })
+
+  it('stores a gateway selection as JSON and reads it back', () => {
+    const { selection, userModel } = useUserModel()
+
+    selection.value = {
+      source: 'gateway',
+      gatewayId: 'openrouter',
+      modelId: openRouterModelId,
+    }
+
+    expect(JSON.parse(localStorage.getItem('model') as string)).toEqual({
+      source: 'gateway',
+      gatewayId: 'openrouter',
+      modelId: openRouterModelId,
+    })
+    expect(selection.value).toEqual({
+      source: 'gateway',
+      gatewayId: 'openrouter',
+      modelId: openRouterModelId,
+    })
+    expect(userModel.value).toBe(openRouterModelId)
+  })
+
+  it('writes a provider selection when the legacy string ref is set', () => {
+    const { selection, userModel } = useUserModel()
+
+    selection.value = {
+      source: 'gateway',
+      gatewayId: 'vercel',
+      modelId: 'openai/gpt-4o',
+    }
+    userModel.value = 'gpt-5.4'
+
+    expect(localStorage.getItem('model')).toBe('gpt-5.4')
+    expect(selection.value).toEqual({
+      source: 'provider',
+      modelId: 'gpt-5.4',
+    })
+  })
+
+  it('survives a corrupt stored value', () => {
+    localStorage.setItem('model', '{"source":"gateway"')
+
+    const { selection } = useUserModel()
+
+    expect(selection.value.source).toBe('provider')
+  })
+})

--- a/tests/unit/composables/selected-model-info.spec.ts
+++ b/tests/unit/composables/selected-model-info.spec.ts
@@ -1,0 +1,99 @@
+import type { ModelSelection } from '#shared/types/model-selection.d'
+import type { GatewayModel } from '#shared/types/gateways.d'
+import { shallowRef } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { useSelectedModelInfo } from '../../../app/composables/selected-model-info'
+
+const mocks = vi.hoisted(() => ({
+  useUserModel: vi.fn(),
+  useGatewayCatalogCache: vi.fn(),
+  getModel: vi.fn(),
+  getModelName: vi.fn(),
+}))
+
+mockNuxtImport('useUserModel', () => mocks.useUserModel)
+mockNuxtImport('useGatewayCatalogCache', () => mocks.useGatewayCatalogCache)
+mockNuxtImport('getModel', () => mocks.getModel)
+mockNuxtImport('getModelName', () => mocks.getModelName)
+
+const gatewayModel: GatewayModel = {
+  id: 'anthropic/claude-opus-5',
+  name: 'Claude Opus 5',
+  description: 'Frontier reasoning model',
+}
+
+function selectionOf(selection: ModelSelection) {
+  mocks.useUserModel.mockReturnValue({
+    selection: shallowRef<ModelSelection>(selection),
+  })
+}
+
+describe('useSelectedModelInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useGatewayCatalogCache.mockReturnValue(shallowRef({}))
+    mocks.getModel.mockReturnValue({
+      model: { description: 'Curated model' },
+      provider: { id: 'google' },
+    })
+    mocks.getModelName.mockReturnValue('Gemini 2.5 Flash')
+  })
+
+  it('resolves a provider selection from the curated catalog', () => {
+    selectionOf({ source: 'provider', modelId: 'gemini-2.5-flash' })
+
+    const { name, description, iconProviderId } = useSelectedModelInfo()
+
+    expect(name.value).toBe('Gemini 2.5 Flash')
+    expect(description.value).toBe('Curated model')
+    expect(iconProviderId.value).toBe('google')
+  })
+
+  it('resolves a gateway selection from the cached catalog', () => {
+    mocks.useGatewayCatalogCache.mockReturnValue(
+      shallowRef({ vercel: [gatewayModel] }),
+    )
+    selectionOf({
+      source: 'gateway',
+      gatewayId: 'vercel',
+      modelId: 'anthropic/claude-opus-5',
+    })
+
+    const { name, description, iconProviderId } = useSelectedModelInfo()
+
+    expect(name.value).toBe('Claude Opus 5')
+    expect(description.value).toBe('Frontier reasoning model')
+    expect(iconProviderId.value).toBe('vercel')
+  })
+
+  it('falls back to the raw id when the catalog is not cached yet', () => {
+    selectionOf({
+      source: 'gateway',
+      gatewayId: 'openrouter',
+      modelId: 'anthropic/claude-opus-5:free',
+    })
+
+    const { name, description, iconProviderId } = useSelectedModelInfo()
+
+    expect(name.value).toBe('anthropic/claude-opus-5:free')
+    expect(description.value).toBeUndefined()
+    expect(iconProviderId.value).toBe('openrouter')
+    expect(mocks.getModelName).not.toHaveBeenCalled()
+  })
+
+  it('does not confuse catalogs from different gateways', () => {
+    mocks.useGatewayCatalogCache.mockReturnValue(
+      shallowRef({ vercel: [gatewayModel] }),
+    )
+    selectionOf({
+      source: 'gateway',
+      gatewayId: 'openrouter',
+      modelId: 'anthropic/claude-opus-5',
+    })
+
+    const { name } = useSelectedModelInfo()
+
+    expect(name.value).toBe('anthropic/claude-opus-5')
+  })
+})

--- a/tests/unit/composables/user-setting.spec.ts
+++ b/tests/unit/composables/user-setting.spec.ts
@@ -812,4 +812,189 @@ describe('useUserSetting', () => {
       expect(favoriteModels.value).toEqual(['gpt-5.4', 'gemini-2.5-flash'])
     },
   )
+
+  it('uses the local storage fallback for gateway favorites before sync', () => {
+    localStorage.setItem(
+      'settings_favorite_gateway_models',
+      JSON.stringify({ vercel: ['openai/gpt-4o'] }),
+    )
+
+    const { getFavoriteGatewayModels } = useUserSetting()
+
+    expect(getFavoriteGatewayModels('vercel')).toEqual(['openai/gpt-4o'])
+    expect(getFavoriteGatewayModels('openrouter')).toEqual([])
+  })
+
+  it('falls back to an empty map when stored gateway favorites are corrupt', () => {
+    localStorage.setItem('settings_favorite_gateway_models', '{not json')
+
+    const { favoriteGatewayModels } = useUserSetting()
+
+    expect(favoriteGatewayModels.value).toEqual({})
+  })
+
+  it('syncs gateway favorites from the server response', async () => {
+    fetchMock.mockResolvedValue({
+      reasoningExpanded: false,
+      reasoningAutoHide: true,
+      favoriteGatewayModels: {
+        vercel: ['openai/gpt-4o'],
+        openrouter: ['anthropic/claude-opus-5:free'],
+      },
+    })
+
+    const { syncForUser, getFavoriteGatewayModels } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    expect(getFavoriteGatewayModels('vercel')).toEqual(['openai/gpt-4o'])
+    expect(getFavoriteGatewayModels('openrouter'))
+      .toEqual(['anthropic/claude-opus-5:free'])
+  })
+
+  it('keeps the same model id favorited per gateway independently', async () => {
+    fetchMock.mockReset().mockResolvedValueOnce({
+      reasoningExpanded: false,
+      reasoningAutoHide: true,
+      favoriteModels: ['gpt-5.4'],
+      favoriteGatewayModels: { vercel: ['openai/gpt-4o'] },
+    })
+
+    const {
+      syncForUser,
+      favoriteModels,
+      getFavoriteGatewayModels,
+    } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    expect(getFavoriteGatewayModels('vercel')).toEqual(['openai/gpt-4o'])
+    expect(getFavoriteGatewayModels('openrouter')).toEqual([])
+    expect(favoriteModels.value).toEqual(['gpt-5.4'])
+    expect(favoriteModels.value).not.toContain('openai/gpt-4o')
+  })
+
+  it('toggles a gateway favorite without touching other gateways', async () => {
+    fetchMock.mockReset().mockResolvedValueOnce({
+      reasoningExpanded: false,
+      reasoningAutoHide: true,
+      favoriteGatewayModels: {
+        vercel: ['openai/gpt-4o'],
+        openrouter: ['anthropic/claude-opus-5:free'],
+      },
+    })
+
+    const {
+      syncForUser,
+      toggleFavoriteGatewayModel,
+      getFavoriteGatewayModels,
+    } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    fetchMock.mockResolvedValueOnce({})
+
+    await toggleFavoriteGatewayModel('openrouter', 'meta/llama-4')
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/v1/profiles/settings',
+      {
+        method: 'PATCH',
+        body: {
+          favoriteGatewayModels: {
+            vercel: ['openai/gpt-4o'],
+            openrouter: ['anthropic/claude-opus-5:free', 'meta/llama-4'],
+          },
+        },
+      },
+    )
+    expect(getFavoriteGatewayModels('vercel')).toEqual(['openai/gpt-4o'])
+  })
+
+  it('rolls back an optimistic gateway favorite when the save fails', async () => {
+    fetchMock.mockReset().mockResolvedValueOnce({
+      reasoningExpanded: false,
+      reasoningAutoHide: true,
+      favoriteGatewayModels: { vercel: ['openai/gpt-4o'] },
+    })
+
+    const {
+      syncForUser,
+      toggleFavoriteGatewayModel,
+      getFavoriteGatewayModels,
+      settingsError,
+    } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    fetchMock.mockRejectedValueOnce(new Error('nope'))
+
+    await toggleFavoriteGatewayModel('vercel', 'meta/llama-4')
+
+    expect(getFavoriteGatewayModels('vercel')).toEqual(['openai/gpt-4o'])
+    expect(settingsError.value).toBeTruthy()
+  })
+
+  it(
+    'never filters gateway favorites against a catalog, so an unloaded '
+    + 'catalog cannot wipe them',
+    async () => {
+      getProvidersMock.mockReturnValue({ providers: [] })
+      fetchMock.mockReset().mockResolvedValueOnce({
+        reasoningExpanded: false,
+        reasoningAutoHide: true,
+        favoriteGatewayModels: { vercel: ['openai/gpt-4o', 'meta/llama-4'] },
+      })
+
+      const {
+        syncForUser,
+        getFavoriteGatewayModels,
+        toggleFavoriteGatewayModel,
+      } = useUserSetting()
+
+      await syncForUser('user-1')
+
+      expect(getFavoriteGatewayModels('vercel'))
+        .toEqual(['openai/gpt-4o', 'meta/llama-4'])
+
+      fetchMock.mockResolvedValueOnce({})
+
+      await toggleFavoriteGatewayModel('vercel', 'google/gemini-3')
+
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        '/api/v1/profiles/settings',
+        {
+          method: 'PATCH',
+          body: {
+            favoriteGatewayModels: {
+              vercel: ['openai/gpt-4o', 'meta/llama-4', 'google/gemini-3'],
+            },
+          },
+        },
+      )
+    },
+  )
+
+  it('clears gateway favorites when the user context is cleared', async () => {
+    fetchMock.mockResolvedValue({
+      reasoningExpanded: false,
+      reasoningAutoHide: true,
+      favoriteGatewayModels: { vercel: ['openai/gpt-4o'] },
+    })
+
+    const {
+      syncForUser,
+      clearUserContext,
+      getFavoriteGatewayModels,
+    } = useUserSetting()
+
+    await syncForUser('user-1')
+
+    expect(getFavoriteGatewayModels('vercel')).toEqual(['openai/gpt-4o'])
+
+    clearUserContext()
+    localStorage.clear()
+
+    expect(getFavoriteGatewayModels('vercel')).toEqual([])
+  })
 })

--- a/tests/unit/utils/models-picker.spec.ts
+++ b/tests/unit/utils/models-picker.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import type { Model, ModelPriceTier } from '#shared/types/providers.d'
 import {
+  formatGatewayPrice,
+  formatGatewayPriceDetail,
   formatModelTokenLimit,
   formatReleaseDate,
   getModelCategory,
@@ -236,5 +238,40 @@ describe('modelCategoryOptions', () => {
     for (const category of categories) {
       expect(optionValues).toContain(category)
     }
+  })
+})
+
+describe('gateway pricing', () => {
+  it('scales per-token gateway prices up to a per-million figure', () => {
+    expect(formatGatewayPrice({ input: '0.0000025', output: '0.00001' }))
+      .toBe('$2.50/$10.00 per 1M')
+  })
+
+  it('absorbs the float error the scale-up introduces', () => {
+    expect(Number('0.0000029') * 1_000_000).toBe(2.9000000000000004)
+    expect(formatGatewayPrice({ input: '0.0000029', output: '0.0000029' }))
+      .toBe('$2.90/$2.90 per 1M')
+  })
+
+  it('keeps sub-dollar prices readable', () => {
+    expect(formatGatewayPrice({ input: '0.00000005', output: '0.0000002' }))
+      .toBe('$0.050/$0.200 per 1M')
+  })
+
+  it('labels a zero-cost model as free', () => {
+    expect(formatGatewayPrice({ input: '0', output: '0' })).toBe('Free')
+    expect(formatGatewayPriceDetail({ input: '0', output: '0' })).toBe('Free')
+  })
+
+  it('spells out the unit in the detail form', () => {
+    expect(formatGatewayPriceDetail({ input: '0.0000025', output: '0.00001' }))
+      .toBe('$2.50 in / $10.00 out per 1M tokens')
+  })
+
+  it('returns nothing when pricing is missing or unparseable', () => {
+    expect(formatGatewayPrice(undefined)).toBeUndefined()
+    expect(formatGatewayPrice({ input: 'n/a', output: '0.001' }))
+      .toBeUndefined()
+    expect(formatGatewayPriceDetail(undefined)).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- New `ModelSelection` union type (`{source:'provider', modelId}` | `{source:'gateway', gatewayId, modelId}`) replacing the bare model-id-string persistence, with full backward compatibility for existing stored values.
- Per-gateway favorites (new additive `user_settings.favorite_gateway_models` column) — a favorite pinned under one gateway never appears under another or under the direct-provider list.
- Picker redesign: a bottom gateway-button row (pill shape + solid active fill + an accent mode banner + the provider rail disappearing) gives gateway mode a deliberately unambiguous "you switched modes" signal, per the product ask.
- Gateway-mode model rows/detail panel are new dedicated components (not shoehorned into the curated-catalog components), showing real gateway metadata (tool/image-input support, per-token pricing converted to a clearly-labeled per-million display) instead of implying curated-catalog capability badges that don't apply.

Part 4 of a 7-PR stacked initiative — the design-heavy centerpiece (Opus-implemented per the design-work delegation rule). Depends on PR1+PR3 (already merged). Selecting a gateway model is not yet sendable — that's PR5, which this PR's review flagged as a required checklist item for PR5's own DoD.

## Test plan
- [x] `pnpm run format` / `pnpm run typecheck` clean
- [x] 2093 tests passing; new/extended specs registered in `scripts/test-affected-check.mjs`
- [x] `pnpm run build` succeeds
- [x] D1 migration verified: single `ALTER TABLE ADD COLUMN`, no rebuild, no cascade risk
- [x] Code-reviewed; 0 critical/blocking findings, 3 disclosed/reasoned deviations documented in `docs/_wip-plan-providers-gateways.md`
- [ ] CI green on this PR
- [ ] Visual/UX pass in a real browser — this is a design-judgment PR and the mode-switch treatment has not been eyeballed live yet (not required by this PR's own DoD, but worth doing before final sign-off)