### PR TITLE
feat: disable models with no saved API key, guide to the keys page

### DIFF
--- a/app/components/ChatInput.client.vue
+++ b/app/components/ChatInput.client.vue
@@ -260,19 +260,18 @@
                 mode="accent"
                 soft
                 circle
-                title="Regenerate"
+                :title="regenerateButtonTitle"
                 icon-name="lucide:refresh-ccw"
                 icon-only
                 tooltip-position="left"
-                @click="regenerate"
+                @click="onRegenerate"
               />
               <UiButton
                 v-show="!displayStop && !canShowRegenerate"
                 data-testid="send-message"
                 mode="accent"
                 circle
-                :disabled="!hasMessage || isClarifying || researchJobActive
-                  || isSelectedModelKeyless"
+                :disabled="!hasMessage || isClarifying || researchJobActive"
                 :title="sendButtonTitle"
                 icon-name="lucide:arrow-up"
                 icon-only
@@ -380,6 +379,34 @@ const isReasoningActive = computed<boolean>(() => {
 const missingKeyWarning = computed<string>(() => {
   return `Add your ${selectedModelKeyOwnerLabel.value} API key to send this message`
 })
+
+const regenerateButtonTitle = computed<string>(() => {
+  if (isSelectedModelKeyless.value) {
+    return missingKeyWarning.value
+  }
+
+  return 'Regenerate'
+})
+
+/**
+ * Kept clickable rather than disabled: a dead button explains nothing on
+ * touch, where the title never surfaces, and this is a state the user has to
+ * leave deliberately by adding a key.
+ */
+function warnAboutMissingKey() {
+  useWarningMessage(
+    `${missingKeyWarning.value}.`,
+    'Open Profile → API Keys to add it, or pick a model you have a key for.',
+  )
+}
+
+function onRegenerate() {
+  if (isSelectedModelKeyless.value) {
+    return warnAboutMissingKey()
+  }
+
+  props.regenerate()
+}
 
 const sendButtonTitle = computed<string>(() => {
   if (isSelectedModelKeyless.value) {
@@ -719,10 +746,7 @@ function sendMessage() {
   }
 
   if (isSelectedModelKeyless.value) {
-    return useWarningMessage(
-      `${missingKeyWarning.value}.`,
-      'Open Profile → API Keys to add it, or pick a model you have a key for.',
-    )
+    return warnAboutMissingKey()
   }
 
   if (props.isClarifying) {

--- a/app/components/ChatInput.client.vue
+++ b/app/components/ChatInput.client.vue
@@ -271,7 +271,8 @@
                 data-testid="send-message"
                 mode="accent"
                 circle
-                :disabled="!hasMessage || isClarifying || researchJobActive"
+                :disabled="!hasMessage || isClarifying || researchJobActive
+                  || isSelectedModelKeyless"
                 :title="sendButtonTitle"
                 icon-name="lucide:arrow-up"
                 icon-only
@@ -349,6 +350,8 @@ const {
   reasoningMode,
   isDeepResearchModel,
   researchConfig,
+  isSelectedModelKeyless,
+  selectedModelKeyOwnerLabel,
 } = useChatInput()
 const { hasSafeAreaBottom } = useDeviceSafeArea()
 const { visible } = useAnimateAppear()
@@ -374,7 +377,15 @@ const isReasoningActive = computed<boolean>(() => {
   return isReasoningEnabled(reasoning.value)
 })
 
+const missingKeyWarning = computed<string>(() => {
+  return `Add your ${selectedModelKeyOwnerLabel.value} API key to send this message`
+})
+
 const sendButtonTitle = computed<string>(() => {
+  if (isSelectedModelKeyless.value) {
+    return missingKeyWarning.value
+  }
+
   if (props.researchJobActive) {
     return 'Research in progress — please wait'
   }
@@ -705,6 +716,13 @@ function handleEnter(event: KeyboardEvent) {
 function sendMessage() {
   if (!message.value?.trim()) {
     return useWarningMessage('Please enter a message before sending.')
+  }
+
+  if (isSelectedModelKeyless.value) {
+    return useWarningMessage(
+      `${missingKeyWarning.value}.`,
+      'Open Profile → API Keys to add it, or pick a model you have a key for.',
+    )
   }
 
   if (props.isClarifying) {

--- a/app/components/ChatInput/ModelsTrigger.vue
+++ b/app/components/ChatInput/ModelsTrigger.vue
@@ -45,6 +45,14 @@
           <div
             class="bubble-without-background flex flex-col max-h-[60dvh] bg-base-100 border border-base-content/10 shadow-xl"
           >
+            <ChatInputModelsTriggerKeyPrompt
+              v-if="!hasAnyKey && !isActiveGatewayKeyless"
+              compact
+              title="No API keys yet"
+              description="Besidka runs on your own keys. Add one to start."
+              action-label="Add a key"
+              @navigate="close"
+            />
             <div
               v-if="activeGateway"
               data-testid="models-picker-gateway-banner"
@@ -96,6 +104,7 @@
                 :active-provider-id="activeProviderId"
                 :is-favorites-only="isFavoritesOnly"
                 :has-favorites="hasFavorites"
+                :keyless-provider-ids="keylessProviderIds"
                 @toggle-provider="toggleProvider"
                 @toggle-favorites="toggleFavoritesOnly"
               />
@@ -104,8 +113,15 @@
                 class="flex-1 min-h-[14rem] overflow-y-auto p-1.5"
                 :class="{ 'pb-9': !activeGateway && filteredModels.length }"
               >
+                <ChatInputModelsTriggerKeyPrompt
+                  v-if="isActiveGatewayKeyless"
+                  :title="activeGatewayPrompt.title"
+                  :description="activeGatewayPrompt.description"
+                  :action-label="activeGatewayPrompt.actionLabel"
+                  @navigate="close"
+                />
                 <ChatInputModelsTriggerGatewayModelList
-                  v-if="activeGateway"
+                  v-else-if="activeGateway"
                   ref="gatewayList"
                   :key="activeGateway.id"
                   :gateway-id="activeGateway.id"
@@ -155,6 +171,10 @@
                           <ChatInputModelsTriggerModelItem
                             :model="entry.model"
                             :provider-id="entry.providerId"
+                            :provider-name="entry.providerName"
+                            :is-key-missing="
+                              isModelKeyMissing(entry.providerId)
+                            "
                             :is-selected="
                               selectedProviderModelId === entry.model.id
                             "
@@ -179,6 +199,9 @@
                             <ChatInputModelsTriggerModelDetail
                               :model="entry.model"
                               :provider-name="entry.providerName"
+                              :is-key-missing="
+                                isModelKeyMissing(entry.providerId)
+                              "
                               @close="closeDetail"
                             />
                           </li>
@@ -319,6 +342,7 @@ const {
   name: selectedModelName,
   iconProviderId: selectedIconProviderId,
 } = useSelectedModelInfo()
+const { hasKeyForProvider, hasAnyKey } = useUserKeys()
 
 const pickerMode = shallowRef<PickerMode>({ source: 'provider' })
 const gatewayHighlightedOptionId = shallowRef<string | null>(null)
@@ -340,13 +364,29 @@ const listboxId = useId()
 const legacyListId = useId()
 const legacyLabelId = useId()
 
+/**
+ * `hasKeyForProvider` maps the `GatewayId` through `providerMeta` to the
+ * `keys.provider` enum value it is stored under — `vercel` lives in the table
+ * as `vercel-gateway`, so the bare id must never reach a key lookup.
+ */
 const gatewayRailItems = computed(() => {
   return enabledGateways.map((gatewayId) => {
     return {
       id: gatewayId,
       label: providerMeta[gatewayId]?.label ?? gatewayId,
+      hasKey: hasKeyForProvider(gatewayId),
     }
   })
+})
+
+const keylessProviderIds = computed<string[]>(() => {
+  return providers
+    .filter((provider) => {
+      return !hasKeyForProvider(provider.id)
+    })
+    .map((provider) => {
+      return provider.id
+    })
 })
 
 /**
@@ -364,6 +404,20 @@ const activeGateway = computed(() => {
   return gatewayRailItems.value.find((item) => {
     return item.id === mode.gatewayId
   }) ?? null
+})
+
+const isActiveGatewayKeyless = computed<boolean>(() => {
+  return activeGateway.value?.hasKey === false
+})
+
+const activeGatewayPrompt = computed(() => {
+  const label = activeGateway.value?.label ?? 'This gateway'
+
+  return {
+    title: `${label} needs an API key`,
+    description: `Add your ${label} key to browse its models here.`,
+    actionLabel: `Add ${label} key`,
+  }
 })
 
 const activeGatewayFavorites = computed<string[]>(() => {
@@ -488,6 +542,29 @@ const filteredModels = computed<PickerModel[]>(() => {
 const legacyModels = computed<PickerModel[]>(() => {
   return matchingModels.value.filter(({ model }) => {
     return model.status === 'deprecated'
+  })
+})
+
+function isModelKeyMissing(providerId: string): boolean {
+  return keylessProviderIds.value.includes(providerId)
+}
+
+/**
+ * Keyboard navigation and Enter-to-choose run over this list, not over
+ * `filteredModels`: a keyless row is rendered but not selectable, so letting
+ * the highlight land on one would hand the user an Enter key that silently
+ * does nothing. Empty in gateway mode, which keeps the curated catalog out of
+ * reach of the arrow keys while a gateway owns the panel — including when a
+ * keyless gateway replaces the model list entirely and there is no gateway
+ * list handle to delegate to.
+ */
+const selectableModels = computed<PickerModel[]>(() => {
+  if (activeGateway.value) {
+    return []
+  }
+
+  return filteredModels.value.filter(({ providerId }) => {
+    return !isModelKeyMissing(providerId)
   })
 })
 
@@ -627,7 +704,7 @@ function toggleGateway(gatewayId: GatewayId) {
  */
 function getInitialHighlight(): string | null {
   const selectedId = selectedProviderModelId.value
-  const isSelectable = filteredModels.value.some(({ model }) => {
+  const isSelectable = selectableModels.value.some(({ model }) => {
     return model.id === selectedId
   })
 
@@ -635,7 +712,7 @@ function getInitialHighlight(): string | null {
     return selectedId
   }
 
-  return filteredModels.value[0]?.model.id ?? null
+  return selectableModels.value[0]?.model.id ?? null
 }
 
 function toggleProvider(providerId: string) {
@@ -666,6 +743,14 @@ function toggleDetail(modelId: string) {
 }
 
 function selectModel(modelId: string) {
+  const entry = allModels.value.find(({ model }) => {
+    return model.id === modelId
+  })
+
+  if (entry && isModelKeyMissing(entry.providerId)) {
+    return
+  }
+
   selection.value = { source: 'provider', modelId }
   closeAndRestoreFocus()
 }
@@ -673,7 +758,7 @@ function selectModel(modelId: string) {
 function selectGatewayModel(modelId: string) {
   const gateway = activeGateway.value
 
-  if (!gateway) {
+  if (!gateway || gateway.hasKey === false) {
     return
   }
 
@@ -724,17 +809,17 @@ function setHighlight(modelId: string | null) {
 }
 
 function highlightFirst() {
-  setHighlight(filteredModels.value[0]?.model.id ?? null)
+  setHighlight(selectableModels.value[0]?.model.id ?? null)
 }
 
 function highlightLast() {
-  const models = filteredModels.value
+  const models = selectableModels.value
 
   setHighlight(models[models.length - 1]?.model.id ?? null)
 }
 
 function moveHighlight(step: number) {
-  const models = filteredModels.value
+  const models = selectableModels.value
 
   if (!models.length) {
     return
@@ -857,7 +942,7 @@ watch([searchTerm, activeCategory, activeProviderId, isFavoritesOnly], () => {
     return
   }
 
-  highlightedModelId.value = filteredModels.value[0]?.model.id ?? null
+  highlightedModelId.value = selectableModels.value[0]?.model.id ?? null
 })
 
 onClickOutside(root, () => {

--- a/app/components/ChatInput/ModelsTrigger/GatewayRail.vue
+++ b/app/components/ChatInput/ModelsTrigger/GatewayRail.vue
@@ -15,12 +15,15 @@
         type="button"
         :data-testid="`models-picker-gateway-${gateway.id}`"
         class="btn btn-xs shrink-0 gap-1.5 rounded-full"
-        :class="activeGatewayId === gateway.id ? 'btn-accent' : 'btn-ghost'"
+        :class="[
+          activeGatewayId === gateway.id ? 'btn-accent' : 'btn-ghost',
+          {
+            'opacity-60': gateway.hasKey === false
+              && activeGatewayId !== gateway.id
+          }
+        ]"
         :aria-pressed="activeGatewayId === gateway.id"
-        :aria-label="activeGatewayId === gateway.id
-          ? `Leave ${gateway.label} and show provider models`
-          : `Browse ${gateway.label} models`
-        "
+        :aria-label="getGatewayLabel(gateway)"
         @click="emit('toggleGateway', gateway.id)"
       >
         <ProviderIcon
@@ -31,6 +34,17 @@
         <span class="truncate">
           {{ gateway.label }}
         </span>
+        <Icon
+          v-if="gateway.hasKey === false"
+          :data-testid="`models-picker-gateway-${gateway.id}-keyless`"
+          name="lucide:key-round"
+          size="11"
+          class="shrink-0"
+          :class="activeGatewayId === gateway.id
+            ? 'text-current'
+            : 'text-warning'
+          "
+        />
         <span
           v-if="isPending && activeGatewayId === gateway.id"
           data-testid="models-picker-gateway-pending"
@@ -44,8 +58,14 @@
 <script setup lang="ts">
 import type { GatewayId } from '#shared/types/gateways.d'
 
-defineProps<{
-  gateways: Array<{ id: GatewayId, label: string }>
+interface GatewayRailItem {
+  id: GatewayId
+  label: string
+  hasKey?: boolean
+}
+
+const props = defineProps<{
+  gateways: GatewayRailItem[]
   activeGatewayId: GatewayId | null
   isPending: boolean
 }>()
@@ -53,4 +73,16 @@ defineProps<{
 const emit = defineEmits<{
   toggleGateway: [gatewayId: GatewayId]
 }>()
+
+function getGatewayLabel(gateway: GatewayRailItem): string {
+  if (gateway.hasKey === false) {
+    return `Browse ${gateway.label} models — API key required`
+  }
+
+  if (props.activeGatewayId === gateway.id) {
+    return `Leave ${gateway.label} and show provider models`
+  }
+
+  return `Browse ${gateway.label} models`
+}
 </script>

--- a/app/components/ChatInput/ModelsTrigger/KeyPrompt.vue
+++ b/app/components/ChatInput/ModelsTrigger/KeyPrompt.vue
@@ -1,0 +1,76 @@
+<template>
+  <div
+    v-if="compact"
+    data-testid="models-picker-key-banner"
+    class="shrink-0 flex items-center gap-2 px-2.5 py-2 border-b border-warning/30 bg-warning/10"
+  >
+    <Icon
+      name="lucide:key-round"
+      size="14"
+      class="shrink-0 text-warning"
+    />
+    <span class="grow min-w-0 text-xs">
+      <span class="block truncate font-semibold text-warning">
+        {{ title }}
+      </span>
+      <span class="block truncate opacity-70">
+        {{ description }}
+      </span>
+    </span>
+    <NuxtLink
+      to="/profile/keys"
+      data-testid="models-picker-key-banner-link"
+      class="btn btn-warning btn-xs shrink-0 gap-1 rounded-full"
+      @click="emit('navigate')"
+    >
+      {{ actionLabel }}
+    </NuxtLink>
+  </div>
+  <div
+    v-else
+    data-testid="models-picker-key-prompt"
+    class="min-h-full flex flex-col items-center justify-center gap-2 px-4 py-10 text-center"
+  >
+    <Icon
+      name="lucide:key-round"
+      size="24"
+      class="text-warning"
+    />
+    <p class="text-sm font-semibold">
+      {{ title }}
+    </p>
+    <p class="max-w-xs text-xs opacity-60">
+      {{ description }}
+    </p>
+    <NuxtLink
+      to="/profile/keys"
+      data-testid="models-picker-key-prompt-link"
+      class="btn btn-warning btn-xs mt-1 gap-1 rounded-full"
+      @click="emit('navigate')"
+    >
+      <Icon
+        name="lucide:plus"
+        size="12"
+      />
+      {{ actionLabel }}
+    </NuxtLink>
+  </div>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    title: string
+    description: string
+    actionLabel?: string
+    compact?: boolean
+  }>(),
+  {
+    actionLabel: 'Add a key',
+  },
+)
+
+const emit = defineEmits<{
+  navigate: []
+}>()
+</script>

--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -51,6 +51,29 @@
       </span>
     </p>
     <p
+      v-if="isKeyMissing"
+      data-testid="model-detail-key-notice"
+      class="mt-2 flex items-start gap-1.5 p-2 rounded-xl text-xs text-warning capability-chip"
+    >
+      <Icon
+        name="lucide:key-round"
+        size="13"
+        class="shrink-0 mt-px"
+      />
+      <span>
+        {{ providerName }} models need your own API key before they can be
+        selected.
+        <NuxtLink
+          to="/profile/keys"
+          data-testid="model-detail-key-link"
+          class="link font-semibold"
+        >
+          Add your {{ providerName }} key
+        </NuxtLink>
+        to enable them.
+      </span>
+    </p>
+    <p
       v-if="model.description"
       class="mt-1.5 text-xs opacity-70"
     >
@@ -110,6 +133,7 @@ interface SpecRow {
 const props = defineProps<{
   model: Model
   providerName: string
+  isKeyMissing?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/app/components/ChatInput/ModelsTrigger/ModelItem.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelItem.vue
@@ -2,23 +2,23 @@
   <li
     :id="optionId"
     role="option"
-    :aria-selected="isLegacy ? false : isSelected"
-    :aria-disabled="isLegacy ? true : undefined"
+    :aria-selected="isDisabled ? false : isSelected"
+    :aria-disabled="isDisabled ? true : undefined"
   >
     <div
       class="flex items-center gap-1 rounded-xl pl-2 pr-1 py-1 transition-colors"
       :class="{
-        'bg-accent/15': isSelected && !isLegacy,
-        'bg-base-content/10': isHighlighted && !isSelected && !isLegacy,
-        'hover:bg-base-content/5': !isSelected && !isHighlighted && !isLegacy
+        'bg-accent/15': isSelected && !isDisabled,
+        'bg-base-content/10': isHighlighted && !isSelected && !isDisabled,
+        'hover:bg-base-content/5': !isSelected && !isHighlighted && !isDisabled
       }"
     >
       <component
-        :is="isLegacy ? 'div' : 'button'"
-        :type="isLegacy ? undefined : 'button'"
-        :aria-label="isLegacy ? undefined : selectLabel"
+        :is="isDisabled ? 'div' : 'button'"
+        :type="isDisabled ? undefined : 'button'"
+        :aria-label="isDisabled ? undefined : selectLabel"
         class="grow min-w-0 flex flex-wrap xs:flex-nowrap items-center gap-x-2 gap-y-1 py-1 text-left"
-        :class="isLegacy ? 'opacity-50' : 'cursor-pointer'"
+        :class="isDisabled ? 'opacity-50' : 'cursor-pointer'"
         @click="onSelect"
       >
         <span
@@ -26,6 +26,12 @@
           class="sr-only"
         >
           Deprecated, no longer selectable.
+        </span>
+        <span
+          v-else-if="isKeyMissing"
+          class="sr-only"
+        >
+          {{ keyMissingLabel }}
         </span>
         <span
           class="w-full xs:w-auto min-w-0 flex items-center gap-1.5"
@@ -40,6 +46,17 @@
           >
             {{ model.name }}
           </span>
+        </span>
+        <span
+          v-if="isKeyMissing"
+          data-testid="model-key-required"
+          class="badge badge-xs badge-soft badge-warning shrink-0 gap-1 font-semibold max-xs:ml-5"
+        >
+          <Icon
+            name="lucide:key-round"
+            size="10"
+          />
+          Key required
         </span>
         <span
           v-if="model.priceTier"
@@ -160,6 +177,8 @@ const props = defineProps<{
   isFavorite: boolean
   isDetailOpen: boolean
   isLegacy?: boolean
+  isKeyMissing?: boolean
+  providerName?: string
 }>()
 
 const emit = defineEmits<{
@@ -172,6 +191,16 @@ const { isDesktop } = useDevice()
 
 const priceTip = computed<string | undefined>(() => {
   return getModelPriceTip(props.model)
+})
+
+const isDisabled = computed<boolean>(() => {
+  return !!props.isLegacy || !!props.isKeyMissing
+})
+
+const keyMissingLabel = computed<string>(() => {
+  const owner = props.providerName || 'this provider'
+
+  return `Add your ${owner} API key to use this model.`
 })
 
 const hasTooltip = computed<boolean>(() => {
@@ -200,7 +229,7 @@ const detailId = computed<string>(() => {
 })
 
 function onSelect() {
-  if (props.isLegacy) {
+  if (isDisabled.value) {
     return
   }
 

--- a/app/components/ChatInput/ModelsTrigger/ProviderRail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ProviderRail.vue
@@ -31,13 +31,13 @@
       :key="provider.id"
       type="button"
       :data-testid="`models-picker-rail-${provider.id}`"
-      class="btn btn-ghost btn-sm btn-circle"
+      class="btn btn-ghost btn-sm btn-circle relative"
       :class="{
         'btn-active text-accent': activeProviderId === provider.id,
         'tooltip tooltip-soft tooltip-right': $device.isDesktop
       }"
-      :data-tip="provider.name"
-      :aria-label="`Show ${provider.name} models only`"
+      :data-tip="getProviderTip(provider)"
+      :aria-label="getProviderLabel(provider)"
       :aria-pressed="activeProviderId === provider.id"
       @click="emit('toggleProvider', provider.id)"
     >
@@ -45,23 +45,55 @@
         :provider-id="provider.id"
         :label="provider.name"
         class="w-4 fill-current"
+        :class="{ 'opacity-40': isKeyless(provider.id) }"
+      />
+      <span
+        v-if="isKeyless(provider.id)"
+        :data-testid="`models-picker-rail-${provider.id}-keyless`"
+        class="absolute top-0.5 right-0.5 size-2 rounded-full bg-warning"
       />
     </button>
   </div>
 </template>
 
 <script setup lang="ts">
-import type { Providers } from '#shared/types/providers.d'
+import type { Provider, Providers } from '#shared/types/providers.d'
 
-defineProps<{
-  providers: Providers
-  activeProviderId: string | null
-  isFavoritesOnly: boolean
-  hasFavorites: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    providers: Providers
+    activeProviderId: string | null
+    isFavoritesOnly: boolean
+    hasFavorites: boolean
+    keylessProviderIds?: string[]
+  }>(),
+  {
+    keylessProviderIds: () => [],
+  },
+)
 
 const emit = defineEmits<{
   toggleProvider: [providerId: string]
   toggleFavorites: []
 }>()
+
+function isKeyless(providerId: string): boolean {
+  return props.keylessProviderIds.includes(providerId)
+}
+
+function getProviderTip(provider: Provider): string {
+  if (isKeyless(provider.id)) {
+    return `${provider.name} — API key required`
+  }
+
+  return provider.name
+}
+
+function getProviderLabel(provider: Provider): string {
+  if (isKeyless(provider.id)) {
+    return `Show ${provider.name} models only — API key required`
+  }
+
+  return `Show ${provider.name} models only`
+}
 </script>

--- a/app/components/Profile/Keys/Anthropic.vue
+++ b/app/components/Profile/Keys/Anthropic.vue
@@ -94,6 +94,7 @@ const apiKeyInput = ref<InstanceType<typeof UiFormInput> | null>()
 
 const { Validation } = useValidation()
 const { paste } = useClipboardWithPaste()
+const { refresh: refreshUserKeys } = useUserKeys()
 
 const apiKey = shallowRef<string>(fetchedApiKey.value || '')
 
@@ -116,6 +117,7 @@ async function updateKeys() {
       },
     })
     await refresh()
+    await refreshUserKeys()
     form.value?.resetValidation()
     useSuccessMessage('Anthropic API key updated successfully')
   } catch (exception) {
@@ -140,6 +142,7 @@ async function deleteKeys() {
       method: 'delete',
     })
     await refresh()
+    await refreshUserKeys()
     useSuccessMessage('Anthropic keys deleted successfully')
     apiKey.value = ''
     await nextTick()

--- a/app/components/Profile/Keys/Google.vue
+++ b/app/components/Profile/Keys/Google.vue
@@ -94,6 +94,7 @@ const apiKeyInput = ref<InstanceType<typeof UiFormInput> | null>()
 
 const { Validation } = useValidation()
 const { paste } = useClipboardWithPaste()
+const { refresh: refreshUserKeys } = useUserKeys()
 
 const apiKey = shallowRef<string>(fetchedApiKey.value || '')
 
@@ -116,6 +117,7 @@ async function updateKey() {
       },
     })
     await refresh()
+    await refreshUserKeys()
     useSuccessMessage('Google AI Studio key updated successfully')
   } catch (exception) {
     useErrorMessage('Failed to update Google AI Studio key')
@@ -137,6 +139,7 @@ async function deleteKey() {
       method: 'delete',
     })
     await refresh()
+    await refreshUserKeys()
     useSuccessMessage('Google AI Studio key deleted successfully')
     apiKey.value = ''
     await nextTick()

--- a/app/components/Profile/Keys/OpenAi.vue
+++ b/app/components/Profile/Keys/OpenAi.vue
@@ -94,6 +94,7 @@ const apiKeyInput = ref<InstanceType<typeof UiFormInput> | null>()
 
 const { Validation } = useValidation()
 const { paste } = useClipboardWithPaste()
+const { refresh: refreshUserKeys } = useUserKeys()
 
 const apiKey = shallowRef<string>(fetchedApiKey.value || '')
 
@@ -116,6 +117,7 @@ async function updateKeys() {
       },
     })
     await refresh()
+    await refreshUserKeys()
     form.value?.resetValidation()
     useSuccessMessage('OpenAI API key updated successfully')
   } catch (exception) {
@@ -140,6 +142,7 @@ async function deleteKeys() {
       method: 'delete',
     })
     await refresh()
+    await refreshUserKeys()
     useSuccessMessage('OpenAI keys deleted successfully')
     apiKey.value = ''
     await nextTick()

--- a/app/components/Profile/Keys/ProviderKeyCard.vue
+++ b/app/components/Profile/Keys/ProviderKeyCard.vue
@@ -123,6 +123,7 @@ const apiKeyInput = ref<InstanceType<typeof UiFormInput> | null>()
 
 const { Validation } = useValidation()
 const { paste } = useClipboardWithPaste()
+const { refresh: refreshUserKeys } = useUserKeys()
 
 const apiKey = shallowRef<string>(fetchedApiKey.value || '')
 
@@ -145,6 +146,7 @@ async function updateKey() {
       },
     })
     await refresh()
+    await refreshUserKeys()
     useSuccessMessage(`${meta.value.label} API key updated successfully`)
   } catch (exception) {
     const parsedException = parseError(exception)
@@ -167,6 +169,7 @@ async function deleteKey() {
       method: 'delete',
     })
     await refresh()
+    await refreshUserKeys()
     useSuccessMessage(`${meta.value.label} API key deleted successfully`)
     apiKey.value = ''
     await nextTick()

--- a/app/composables/chat-input.ts
+++ b/app/composables/chat-input.ts
@@ -1,5 +1,8 @@
+import { providerMeta } from '#shared/utils/provider-meta'
+
 export function useChatInput() {
-  const { userModel } = useUserModel()
+  const { selection, userModel } = useUserModel()
+  const { hasKeyForProvider } = useUserKeys()
 
   const selectedModel = computed(() => {
     const currentModel = toValue(userModel)
@@ -54,6 +57,41 @@ export function useChatInput() {
     return getReasoningDropdownLevels(reasoningCapability.value)
   })
 
+  /**
+   * The `providerMeta` id whose key unlocks the current selection — a gateway
+   * id in gateway mode, the owning provider id otherwise. `useUserKeys` maps
+   * it to the `keys.provider` enum value, so no caller builds that string.
+   */
+  const selectedModelKeyOwnerId = computed<string | null>(() => {
+    const current = selection.value
+
+    if (current.source === 'gateway') {
+      return current.gatewayId
+    }
+
+    return getModel(current.modelId).provider?.id ?? null
+  })
+
+  const selectedModelKeyOwnerLabel = computed<string>(() => {
+    const ownerId = selectedModelKeyOwnerId.value
+
+    if (!ownerId) {
+      return 'this provider'
+    }
+
+    return providerMeta[ownerId]?.label ?? ownerId
+  })
+
+  const isSelectedModelKeyless = computed<boolean>(() => {
+    const ownerId = selectedModelKeyOwnerId.value
+
+    if (!ownerId) {
+      return false
+    }
+
+    return !hasKeyForProvider(ownerId)
+  })
+
   return {
     isWebSearchSupported,
     isImageGenerationSupported,
@@ -64,5 +102,7 @@ export function useChatInput() {
     isReasoningSupported,
     researchConfig,
     isDeepResearchModel,
+    isSelectedModelKeyless,
+    selectedModelKeyOwnerLabel,
   }
 }

--- a/app/composables/user-keys.ts
+++ b/app/composables/user-keys.ts
@@ -1,0 +1,78 @@
+import { providerMeta } from '#shared/utils/provider-meta'
+
+interface UserKeysResponse {
+  keys: Array<{ provider: string, hasKey: boolean }>
+}
+
+/**
+ * Key presence for every provider and gateway, fetched once into shared state.
+ *
+ * Every lookup fails OPEN — an id the summary does not mention, a request still
+ * in flight, and a request that failed all report "has a key". Gating is UI
+ * guidance layered on top of the server's 401, so the worst case of failing
+ * open is the pre-existing behaviour, while failing closed would disable a
+ * working account's entire model list on a slow or broken response.
+ */
+export function useUserKeys() {
+  const {
+    data,
+    pending: isFetching,
+    error,
+    refresh,
+  } = useLazyFetch<UserKeysResponse>('/api/v1/profiles/keys', {
+    key: 'user-keys',
+  })
+
+  const pending = computed<boolean>(() => {
+    return isFetching.value && !data.value
+  })
+
+  /**
+   * Takes the `keys.provider` enum value, which is NOT interchangeable with a
+   * gateway's `GatewayId` — `vercel` is stored as `vercel-gateway`. Resolve
+   * gateway and provider ids through `hasKeyForProvider` instead of building
+   * that string at a call site.
+   */
+  function hasKey(keyProviderId: string): boolean {
+    const entry = data.value?.keys.find((row) => {
+      return row.provider === keyProviderId
+    })
+
+    if (!entry) {
+      return true
+    }
+
+    return entry.hasKey
+  }
+
+  function hasKeyForProvider(providerOrGatewayId: string): boolean {
+    const keyProviderId = providerMeta[providerOrGatewayId]?.keyProviderId
+
+    if (!keyProviderId) {
+      return true
+    }
+
+    return hasKey(keyProviderId)
+  }
+
+  const hasAnyKey = computed<boolean>(() => {
+    const rows = data.value?.keys
+
+    if (!rows) {
+      return true
+    }
+
+    return rows.some((row) => {
+      return row.hasKey
+    })
+  })
+
+  return {
+    pending,
+    error,
+    hasKey,
+    hasKeyForProvider,
+    hasAnyKey,
+    refresh,
+  }
+}

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -93,6 +93,7 @@ export function getAffectedTests(changedFiles) {
   const modelsTriggerTests = [
     'tests/unit/components/ChatInput/ModelsTrigger.spec.ts',
     'tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts',
+    'tests/unit/components/ChatInput/ModelsTrigger.keys.spec.ts',
     'tests/unit/components/ChatInput/ModelsTrigger/Search.spec.ts',
     'tests/unit/components/ChatInput/ModelsTrigger/ProviderRail.spec.ts',
     'tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts',
@@ -100,6 +101,12 @@ export function getAffectedTests(changedFiles) {
     'tests/unit/components/ChatInput/ModelsTrigger/FilterDropdown.spec.ts',
     'tests/unit/components/ChatInput/ModelsTrigger/GatewayRail.spec.ts',
     'tests/unit/utils/models-picker.spec.ts',
+  ]
+  const userKeysTests = [
+    'tests/unit/composables/user-keys.spec.ts',
+    'tests/unit/components/ChatInput.spec.ts',
+    'tests/unit/composables/chat-input.spec.ts',
+    ...modelsTriggerTests,
   ]
   const modelSelectionTests = [
     'tests/unit/composables/model.spec.ts',
@@ -392,7 +399,7 @@ export function getAffectedTests(changedFiles) {
         /^(app\/components\/ProviderIcon\.vue|shared\/utils\/provider-meta\.ts)$/,
       tests: [
         'tests/unit/components/ProviderIcon.spec.ts',
-        ...modelsTriggerTests,
+        ...userKeysTests,
       ],
     },
     {
@@ -428,9 +435,13 @@ export function getAffectedTests(changedFiles) {
       tests: [...profileSettingsTests, ...modelsTriggerTests],
     },
     {
+      pattern: /^app\/composables\/user-keys\.ts$/,
+      tests: userKeysTests,
+    },
+    {
       pattern:
         /^(server\/api\/v1\/profiles\/keys(\/.*)?\.ts|server\/utils\/keys-rate-limit\.ts|server\/db\/schemas\/keys\.ts|app\/pages\/profile\/keys\.vue|app\/components\/Profile\/Keys\/.*\.vue)$/,
-      tests: keysApiTests,
+      tests: [...keysApiTests, ...userKeysTests],
     },
     {
       pattern: /^(server\/utils\/email-template\.ts|app\/emails\/.*)$/,

--- a/tests/unit/components/ChatInput.spec.ts
+++ b/tests/unit/components/ChatInput.spec.ts
@@ -10,11 +10,13 @@ const mocks = vi.hoisted(() => ({
   useChatFiles: vi.fn(),
   useDevice: vi.fn(),
   uploadFiles: vi.fn(),
+  useWarningMessage: vi.fn(),
 }))
 
 mockNuxtImport('useChatInput', () => mocks.useChatInput)
 mockNuxtImport('useChatFiles', () => mocks.useChatFiles)
 mockNuxtImport('useDevice', () => mocks.useDevice)
+mockNuxtImport('useWarningMessage', () => mocks.useWarningMessage)
 
 const mockRoute = reactive<{ path: string }>({ path: '/chats/abc123' })
 
@@ -30,6 +32,17 @@ const filesModalStub = defineComponent({
     open: filesModalOpenMock,
   },
   template: '<div />',
+})
+
+const uiButtonStub = defineComponent({
+  name: 'UiButtonStub',
+  props: {
+    disabled: { type: Boolean, default: false },
+    title: { type: String, default: '' },
+  },
+  emits: ['click'],
+  template: '<button :disabled="disabled" :title="title" '
+    + '@click="$emit(\'click\')"><slot /></button>',
 })
 
 enableAutoUnmount(afterEach)
@@ -54,8 +67,10 @@ function mountChatInput() {
         LazyChatInputReasoningTrigger: true,
         LazyChatInputDeepResearchTrigger: true,
         LazyChatInputToolbarMore: true,
-        UiBubble: true,
-        UiButton: true,
+        UiBubble: {
+          template: '<div><slot /></div>',
+        },
+        UiButton: uiButtonStub,
       },
     },
   })
@@ -101,6 +116,8 @@ describe('ChatInput.client', () => {
       reasoningMode: shallowRef('none'),
       isDeepResearchModel: shallowRef(false),
       researchConfig: shallowRef(null),
+      isSelectedModelKeyless: shallowRef(false),
+      selectedModelKeyOwnerLabel: shallowRef('OpenAI'),
     })
 
     mocks.useChatFiles.mockReturnValue({
@@ -122,6 +139,7 @@ describe('ChatInput.client', () => {
 
     filesModalOpenMock.mockReset()
     mocks.uploadFiles.mockReset()
+    mocks.useWarningMessage.mockReset()
 
     useFilesModalHandoff().clearPendingOpen()
   })
@@ -217,6 +235,68 @@ describe('ChatInput.client', () => {
       document.dispatchEvent(createPasteEvent([file]))
 
       expect(mocks.uploadFiles).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('missing-key send guidance', () => {
+    function useKeylessSelection() {
+      mocks.useChatInput.mockReturnValue({
+        isWebSearchSupported: shallowRef(false),
+        isImageGenerationSupported: shallowRef(false),
+        isImageGenerationRequired: shallowRef(false),
+        isReasoningSupported: shallowRef(false),
+        reasoningCapability: shallowRef(null),
+        reasoningMode: shallowRef('none'),
+        isDeepResearchModel: shallowRef(false),
+        researchConfig: shallowRef(null),
+        isSelectedModelKeyless: shallowRef(true),
+        selectedModelKeyOwnerLabel: shallowRef('Anthropic'),
+      })
+    }
+
+    it('disables send and names the key the selection now depends on', async () => {
+      useKeylessSelection()
+
+      const wrapper = await mountChatInput()
+
+      await wrapper.get('textarea').setValue('hello')
+
+      const sendButton = wrapper.get('[data-testid="send-message"]')
+
+      expect(sendButton.attributes('disabled')).toBeDefined()
+      expect(sendButton.attributes('title'))
+        .toBe('Add your Anthropic API key to send this message')
+    })
+
+    it('warns with the keys-page guidance when Enter bypasses the button', async () => {
+      useKeylessSelection()
+
+      const wrapper = await mountChatInput()
+      const textarea = wrapper.get('textarea')
+
+      await textarea.setValue('hello')
+      await textarea.trigger('keydown.enter')
+
+      expect(mocks.useWarningMessage).toHaveBeenCalledWith(
+        'Add your Anthropic API key to send this message.',
+        'Open Profile → API Keys to add it, or pick a model you have a key for.',
+      )
+      expect(wrapper.emitted('submit')).toBeUndefined()
+    })
+
+    it('sends normally once a key is present', async () => {
+      const wrapper = await mountChatInput()
+      const textarea = wrapper.get('textarea')
+
+      await textarea.setValue('hello')
+
+      expect(wrapper.get('[data-testid="send-message"]')
+        .attributes('disabled')).toBeUndefined()
+
+      await textarea.trigger('keydown.enter')
+
+      expect(mocks.useWarningMessage).not.toHaveBeenCalled()
+      expect(wrapper.emitted('submit')).toHaveLength(1)
     })
   })
 })

--- a/tests/unit/components/ChatInput.spec.ts
+++ b/tests/unit/components/ChatInput.spec.ts
@@ -254,7 +254,7 @@ describe('ChatInput.client', () => {
       })
     }
 
-    it('disables send and names the key the selection now depends on', async () => {
+    it('names the key the selection depends on without deadening the button', async () => {
       useKeylessSelection()
 
       const wrapper = await mountChatInput()
@@ -263,9 +263,70 @@ describe('ChatInput.client', () => {
 
       const sendButton = wrapper.get('[data-testid="send-message"]')
 
-      expect(sendButton.attributes('disabled')).toBeDefined()
       expect(sendButton.attributes('title'))
         .toBe('Add your Anthropic API key to send this message')
+      expect(sendButton.attributes('disabled')).toBeUndefined()
+    })
+
+    it('warns instead of sending when the send button is pressed', async () => {
+      useKeylessSelection()
+
+      const wrapper = await mountChatInput()
+
+      await wrapper.get('textarea').setValue('hello')
+      await wrapper.get('[data-testid="send-message"]').trigger('click')
+
+      expect(mocks.useWarningMessage).toHaveBeenCalledWith(
+        'Add your Anthropic API key to send this message.',
+        'Open Profile → API Keys to add it, or pick a model you have a key for.',
+      )
+      expect(wrapper.emitted('submit')).toBeUndefined()
+    })
+
+    it('warns instead of regenerating against the same missing key', async () => {
+      useKeylessSelection()
+
+      const regenerate = vi.fn()
+      const wrapper = await mountSuspended(ChatInput, {
+        props: {
+          messagesLength: 2,
+          stop: vi.fn(),
+          regenerate,
+          displayRegenerate: true,
+        },
+        attachTo: document.body,
+        global: {
+          stubs: {
+            ChatInputFilesModal: filesModalStub,
+            LazyChatInputFilesModal: filesModalStub,
+            LazyChatInputFilesDropZone: true,
+            LazyChatScroll: true,
+            LazyChatInputFilesAttachedPreview: true,
+            LazyChatInputModelsTrigger: true,
+            LazyChatInputFilesTrigger: true,
+            LazyChatInputReasoningTrigger: true,
+            LazyChatInputDeepResearchTrigger: true,
+            LazyChatInputToolbarMore: true,
+            UiBubble: {
+              template: '<div><slot /></div>',
+            },
+            UiButton: uiButtonStub,
+          },
+        },
+      })
+
+      const regenerateButton = wrapper.get('[data-testid="regenerate"]')
+
+      expect(regenerateButton.attributes('title'))
+        .toBe('Add your Anthropic API key to send this message')
+
+      await regenerateButton.trigger('click')
+
+      expect(regenerate).not.toHaveBeenCalled()
+      expect(mocks.useWarningMessage).toHaveBeenCalledWith(
+        'Add your Anthropic API key to send this message.',
+        'Open Profile → API Keys to add it, or pick a model you have a key for.',
+      )
     })
 
     it('warns with the keys-page guidance when Enter bypasses the button', async () => {
@@ -297,6 +358,39 @@ describe('ChatInput.client', () => {
 
       expect(mocks.useWarningMessage).not.toHaveBeenCalled()
       expect(wrapper.emitted('submit')).toHaveLength(1)
+    })
+
+    it('leaves the regenerate title alone when a key is present', async () => {
+      const wrapper = await mountSuspended(ChatInput, {
+        props: {
+          messagesLength: 2,
+          stop: vi.fn(),
+          regenerate: vi.fn(),
+          displayRegenerate: true,
+        },
+        attachTo: document.body,
+        global: {
+          stubs: {
+            ChatInputFilesModal: filesModalStub,
+            LazyChatInputFilesModal: filesModalStub,
+            LazyChatInputFilesDropZone: true,
+            LazyChatScroll: true,
+            LazyChatInputFilesAttachedPreview: true,
+            LazyChatInputModelsTrigger: true,
+            LazyChatInputFilesTrigger: true,
+            LazyChatInputReasoningTrigger: true,
+            LazyChatInputDeepResearchTrigger: true,
+            LazyChatInputToolbarMore: true,
+            UiBubble: {
+              template: '<div><slot /></div>',
+            },
+            UiButton: uiButtonStub,
+          },
+        },
+      })
+
+      expect(wrapper.get('[data-testid="regenerate"]').attributes('title'))
+        .toBe('Regenerate')
     })
   })
 })

--- a/tests/unit/components/ChatInput/ModelsTrigger.keys.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.keys.spec.ts
@@ -1,0 +1,390 @@
+import type { ModelSelection } from '#shared/types/model-selection.d'
+import { computed, shallowRef } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ModelsTrigger from '../../../../app/components/ChatInput/ModelsTrigger.vue'
+
+const mocks = vi.hoisted(() => ({
+  getModel: vi.fn(),
+  getModelName: vi.fn(),
+  getProviders: vi.fn(),
+  onClickOutside: vi.fn(),
+  useDevice: vi.fn(),
+  useUserModel: vi.fn(),
+  useUserSetting: vi.fn(),
+  useUserKeys: vi.fn(),
+  useGatewayCatalog: vi.fn(),
+  toggleFavoriteModel: vi.fn(),
+  toggleFavoriteGatewayModel: vi.fn(),
+  getFavoriteGatewayModels: vi.fn(),
+  refreshGatewayCatalog: vi.fn(),
+  refreshUserKeys: vi.fn(),
+}))
+
+mockNuxtImport('getModel', () => mocks.getModel)
+mockNuxtImport('getModelName', () => mocks.getModelName)
+mockNuxtImport('getProviders', () => mocks.getProviders)
+mockNuxtImport('onClickOutside', () => mocks.onClickOutside)
+mockNuxtImport('useDevice', () => mocks.useDevice)
+mockNuxtImport('useUserModel', () => mocks.useUserModel)
+mockNuxtImport('useUserSetting', () => mocks.useUserSetting)
+mockNuxtImport('useUserKeys', () => mocks.useUserKeys)
+mockNuxtImport('useGatewayCatalog', () => mocks.useGatewayCatalog)
+
+const keyedProviderIds = shallowRef<string[]>([])
+
+function createSelectionMock(modelId: string) {
+  const selection = shallowRef<ModelSelection>({
+    source: 'provider',
+    modelId,
+  })
+  const userModel = computed<string>({
+    get() {
+      return selection.value.modelId
+    },
+    set(value) {
+      selection.value = { source: 'provider', modelId: value }
+    },
+  })
+
+  return { selection, userModel }
+}
+
+const baseModel = {
+  contextLength: 32_768,
+  maxOutputTokens: 32_768,
+  priceTier: '$$',
+  price: {
+    tokens: 1,
+    input: '$0.30',
+    output: '$30.00',
+  },
+  modalities: {
+    input: ['text'],
+    output: ['text'],
+  },
+  tools: [],
+  reasoning: false,
+}
+
+const openAiModel = {
+  ...baseModel,
+  id: 'openai-model',
+  name: 'OpenAI model',
+  description: 'Needs an OpenAI key',
+}
+
+const googleModel = {
+  ...baseModel,
+  id: 'google-model',
+  name: 'Google model',
+  description: 'Needs a Google key',
+}
+
+function mountPicker() {
+  return mountSuspended(ModelsTrigger, {
+    props: {
+      isWebSearchEnabled: false,
+      isImageGenerationEnabled: false,
+      isReasoningEnabled: false,
+    },
+    global: {
+      stubs: {
+        ClientOnly: {
+          template: '<slot />',
+        },
+        NuxtLink: {
+          props: ['to'],
+          template: '<a :href="to"><slot /></a>',
+        },
+      },
+    },
+  })
+}
+
+async function openPicker() {
+  const wrapper = await mountPicker()
+
+  await wrapper.get('[data-testid="current-model-trigger"]').trigger('click')
+
+  return wrapper
+}
+
+describe('ChatInput/ModelsTrigger no-key gating', () => {
+  beforeEach(() => {
+    keyedProviderIds.value = ['google']
+
+    mocks.getModel.mockReturnValue({ provider: { id: 'google' } })
+    mocks.getModelName.mockReturnValue('Google model')
+    mocks.getProviders.mockReturnValue({
+      providers: [
+        { id: 'openai', name: 'OpenAI', models: [openAiModel] },
+        { id: 'google', name: 'Google AI Studio', models: [googleModel] },
+      ],
+    })
+    mocks.useDevice.mockReturnValue({
+      isIos: false,
+      isAndroid: false,
+      isDesktop: true,
+    })
+    mocks.useUserModel.mockReturnValue(createSelectionMock('google-model'))
+    mocks.getFavoriteGatewayModels.mockReturnValue([])
+    mocks.useUserSetting.mockReturnValue({
+      favoriteModels: shallowRef<string[]>([]),
+      favoriteGatewayModels: shallowRef({}),
+      getFavoriteGatewayModels: mocks.getFavoriteGatewayModels,
+      toggleFavoriteModel: mocks.toggleFavoriteModel,
+      toggleFavoriteGatewayModel: mocks.toggleFavoriteGatewayModel,
+    })
+    mocks.useUserKeys.mockReturnValue({
+      pending: shallowRef(false),
+      error: shallowRef(null),
+      hasKey: vi.fn(),
+      hasKeyForProvider: (providerOrGatewayId: string) => {
+        return keyedProviderIds.value.includes(providerOrGatewayId)
+      },
+      hasAnyKey: computed(() => keyedProviderIds.value.length > 0),
+      refresh: mocks.refreshUserKeys,
+    })
+    mocks.useGatewayCatalog.mockReset()
+    mocks.useGatewayCatalog.mockReturnValue({
+      models: shallowRef([]),
+      pending: shallowRef(false),
+      error: shallowRef(null),
+      refresh: mocks.refreshGatewayCatalog,
+    })
+  })
+
+  describe('provider rows', () => {
+    it('marks a model non-selectable when its provider has no key', async () => {
+      const wrapper = await openPicker()
+      const row = wrapper.get('#model-option-openai-model')
+
+      expect(row.attributes('aria-disabled')).toBe('true')
+      expect(row.find('[data-testid="model-key-required"]').exists()).toBe(true)
+      expect(wrapper.find('button[aria-label="Choose OpenAI model"]').exists())
+        .toBe(false)
+    })
+
+    it('leaves a model selectable when its provider has a key', async () => {
+      const wrapper = await openPicker()
+      const row = wrapper.get('#model-option-google-model')
+
+      expect(row.attributes('aria-disabled')).toBeUndefined()
+      expect(row.find('[data-testid="model-key-required"]').exists())
+        .toBe(false)
+      expect(wrapper.find('button[aria-label="Choose Google model"]').exists())
+        .toBe(true)
+    })
+
+    it('ignores a click on a keyless row instead of selecting it', async () => {
+      const selectionMock = createSelectionMock('google-model')
+
+      mocks.useUserModel.mockReturnValue(selectionMock)
+
+      const wrapper = await openPicker()
+
+      await wrapper.get('#model-option-openai-model div').trigger('click')
+
+      expect(selectionMock.selection.value).toEqual({
+        source: 'provider',
+        modelId: 'google-model',
+      })
+      expect(wrapper.find('[data-testid="models-picker-panel"]').exists())
+        .toBe(true)
+    })
+
+    it('explains the missing key and links to the keys page in the detail card', async () => {
+      const wrapper = await openPicker()
+
+      await wrapper
+        .get('#model-option-openai-model [data-testid="model-info-trigger"]')
+        .trigger('click')
+
+      const notice = wrapper.get('[data-testid="model-detail-key-notice"]')
+
+      expect(notice.text()).toContain('OpenAI')
+      expect(
+        notice.get('[data-testid="model-detail-key-link"]').attributes('href'),
+      ).toBe('/profile/keys')
+    })
+
+    it('enables the rows live once the key lands, without a remount', async () => {
+      keyedProviderIds.value = []
+
+      const wrapper = await openPicker()
+
+      expect(wrapper.get('#model-option-openai-model')
+        .attributes('aria-disabled')).toBe('true')
+
+      keyedProviderIds.value = ['openai']
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.get('#model-option-openai-model')
+        .attributes('aria-disabled')).toBeUndefined()
+      expect(wrapper.find('button[aria-label="Choose OpenAI model"]').exists())
+        .toBe(true)
+    })
+  })
+
+  describe('keyboard navigation', () => {
+    it('opens with the highlight past the keyless rows', async () => {
+      const wrapper = await openPicker()
+
+      expect(
+        wrapper.get('[data-testid="models-picker-search"]')
+          .attributes('aria-activedescendant'),
+      ).toBe('model-option-google-model')
+    })
+
+    it('never lands the highlight on a keyless row while arrowing', async () => {
+      const wrapper = await openPicker()
+      const search = wrapper.get('[data-testid="models-picker-search"]')
+
+      await search.trigger('keydown', { key: 'ArrowDown' })
+      expect(search.attributes('aria-activedescendant'))
+        .toBe('model-option-google-model')
+
+      await search.trigger('keydown', { key: 'ArrowUp' })
+      expect(search.attributes('aria-activedescendant'))
+        .toBe('model-option-google-model')
+
+      await search.trigger('keydown', { key: 'Home' })
+      expect(search.attributes('aria-activedescendant'))
+        .toBe('model-option-google-model')
+    })
+
+    it('chooses the first model that has a key when Enter is pressed', async () => {
+      const selectionMock = createSelectionMock('other-model')
+
+      mocks.useUserModel.mockReturnValue(selectionMock)
+
+      const wrapper = await openPicker()
+
+      await wrapper.get('[data-testid="models-picker-search"]')
+        .trigger('keydown', { key: 'Enter' })
+
+      expect(selectionMock.selection.value).toEqual({
+        source: 'provider',
+        modelId: 'google-model',
+      })
+    })
+  })
+
+  describe('provider rail', () => {
+    it('flags the keyless providers only', async () => {
+      const wrapper = await openPicker()
+
+      expect(
+        wrapper.find('[data-testid="models-picker-rail-openai-keyless"]')
+          .exists(),
+      ).toBe(true)
+      expect(
+        wrapper.find('[data-testid="models-picker-rail-google-keyless"]')
+          .exists(),
+      ).toBe(false)
+      expect(
+        wrapper.get('[data-testid="models-picker-rail-openai"]')
+          .attributes('aria-label'),
+      ).toContain('API key required')
+    })
+  })
+
+  describe('zero-key account', () => {
+    it('calls out that nothing works yet and links to the keys page', async () => {
+      keyedProviderIds.value = []
+
+      const wrapper = await openPicker()
+      const banner = wrapper.get('[data-testid="models-picker-key-banner"]')
+
+      expect(banner.text()).toContain('No API keys yet')
+      expect(
+        banner.get('[data-testid="models-picker-key-banner-link"]')
+          .attributes('href'),
+      ).toBe('/profile/keys')
+    })
+
+    it('stays hidden as soon as any key exists', async () => {
+      const wrapper = await openPicker()
+
+      expect(wrapper.find('[data-testid="models-picker-key-banner"]').exists())
+        .toBe(false)
+    })
+  })
+
+  describe('gateway mode', () => {
+    it('prompts for the gateway key instead of fetching a catalog to disable', async () => {
+      const wrapper = await openPicker()
+
+      await wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+        .trigger('click')
+
+      const prompt = wrapper.get('[data-testid="models-picker-key-prompt"]')
+
+      expect(prompt.text()).toContain('Vercel AI Gateway needs an API key')
+      expect(
+        prompt.get('[data-testid="models-picker-key-prompt-link"]')
+          .attributes('href'),
+      ).toBe('/profile/keys')
+      expect(mocks.useGatewayCatalog).not.toHaveBeenCalled()
+      expect(wrapper.find('[data-testid="gateway-models-loading"]').exists())
+        .toBe(false)
+    })
+
+    it('loads the catalog once the gateway key exists', async () => {
+      keyedProviderIds.value = ['google', 'vercel']
+
+      const wrapper = await openPicker()
+
+      await wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+        .trigger('click')
+
+      expect(wrapper.find('[data-testid="models-picker-key-prompt"]').exists())
+        .toBe(false)
+      expect(mocks.useGatewayCatalog).toHaveBeenCalled()
+    })
+
+    it('flags the keyless gateways on the rail', async () => {
+      keyedProviderIds.value = ['vercel']
+
+      const wrapper = await openPicker()
+
+      expect(
+        wrapper
+          .find('[data-testid="models-picker-gateway-vercel-keyless"]')
+          .exists(),
+      ).toBe(false)
+      expect(
+        wrapper
+          .find('[data-testid="models-picker-gateway-openrouter-keyless"]')
+          .exists(),
+      ).toBe(true)
+      expect(
+        wrapper.get('[data-testid="models-picker-gateway-openrouter"]')
+          .attributes('aria-label'),
+      ).toContain('API key required')
+    })
+  })
+
+  describe('fail-open contract', () => {
+    it('gates nothing while key presence is still unknown', async () => {
+      mocks.useUserKeys.mockReturnValue({
+        pending: shallowRef(true),
+        error: shallowRef(null),
+        hasKey: vi.fn(),
+        hasKeyForProvider: () => true,
+        hasAnyKey: computed(() => true),
+        refresh: mocks.refreshUserKeys,
+      })
+
+      const wrapper = await openPicker()
+
+      expect(wrapper.findAll('[data-testid="model-key-required"]'))
+        .toHaveLength(0)
+      expect(wrapper.find('[data-testid="models-picker-key-banner"]').exists())
+        .toBe(false)
+      expect(wrapper.find('button[aria-label="Choose OpenAI model"]').exists())
+        .toBe(true)
+    })
+  })
+})

--- a/tests/unit/components/ChatInput/ModelsTrigger/GatewayRail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/GatewayRail.spec.ts
@@ -4,14 +4,20 @@ import type { GatewayId } from '#shared/types/gateways.d'
 import GatewayRail
   from '../../../../../app/components/ChatInput/ModelsTrigger/GatewayRail.vue'
 
-const gateways: Array<{ id: GatewayId, label: string }> = [
+interface GatewayRailItem {
+  id: GatewayId
+  label: string
+  hasKey?: boolean
+}
+
+const gateways: GatewayRailItem[] = [
   { id: 'vercel', label: 'Vercel AI Gateway' },
   { id: 'openrouter', label: 'OpenRouter' },
 ]
 
 function mountRail(
   props: Partial<{
-    gateways: Array<{ id: GatewayId, label: string }>
+    gateways: GatewayRailItem[]
     activeGatewayId: GatewayId | null
     isPending: boolean
   }> = {},
@@ -119,5 +125,56 @@ describe('ChatInput/ModelsTrigger/GatewayRail', () => {
       wrapper.get('[data-testid="models-picker-gateway-openrouter"]')
         .find('svg').exists(),
     ).toBe(true)
+  })
+
+  describe('keyless gateways', () => {
+    it('marks only the gateway reported without a key', async () => {
+      const wrapper = await mountRail({
+        gateways: [
+          { id: 'vercel', label: 'Vercel AI Gateway', hasKey: false },
+          { id: 'openrouter', label: 'OpenRouter', hasKey: true },
+        ],
+      })
+
+      expect(
+        wrapper.find('[data-testid="models-picker-gateway-vercel-keyless"]')
+          .exists(),
+      ).toBe(true)
+      expect(
+        wrapper
+          .find('[data-testid="models-picker-gateway-openrouter-keyless"]')
+          .exists(),
+      ).toBe(false)
+      expect(
+        wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+          .attributes('aria-label'),
+      ).toBe('Browse Vercel AI Gateway models — API key required')
+    })
+
+    it('keeps the button usable so it can reach the key prompt', async () => {
+      const wrapper = await mountRail({
+        gateways: [
+          { id: 'vercel', label: 'Vercel AI Gateway', hasKey: false },
+        ],
+      })
+
+      await wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+        .trigger('click')
+
+      expect(wrapper.emitted('toggleGateway')).toEqual([['vercel']])
+    })
+
+    it('marks nothing when presence is unreported, which is the fail-open default', async () => {
+      const wrapper = await mountRail()
+
+      expect(
+        wrapper.find('[data-testid="models-picker-gateway-vercel-keyless"]')
+          .exists(),
+      ).toBe(false)
+      expect(
+        wrapper.get('[data-testid="models-picker-gateway-vercel"]')
+          .attributes('aria-label'),
+      ).toBe('Browse Vercel AI Gateway models')
+    })
   })
 })

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
@@ -30,13 +30,21 @@ function createModel(overrides: Partial<Model> = {}): Model {
 
 function mountDetail(
   model: Model = createModel(),
-  props: Partial<{ providerName: string }> = {},
+  props: Partial<{ providerName: string, isKeyMissing: boolean }> = {},
 ) {
   return mountSuspended(ModelDetail, {
     props: {
       model,
       providerName: 'OpenAI',
       ...props,
+    },
+    global: {
+      stubs: {
+        NuxtLink: {
+          props: ['to'],
+          template: '<a :href="to"><slot /></a>',
+        },
+      },
     },
   })
 }
@@ -259,5 +267,27 @@ describe('ChatInput/ModelsTrigger/ModelDetail', () => {
       .trigger('click')
 
     expect(wrapper.emitted('close')).toEqual([[]])
+  })
+
+  describe('missing provider key', () => {
+    it('names the provider and links to the keys page', async () => {
+      const wrapper = await mountDetail(createModel(), {
+        isKeyMissing: true,
+        providerName: 'Moonshot AI',
+      })
+      const notice = wrapper.get('[data-testid="model-detail-key-notice"]')
+
+      expect(notice.text()).toContain('Moonshot AI models need your own API key')
+      expect(
+        notice.get('[data-testid="model-detail-key-link"]').attributes('href'),
+      ).toBe('/profile/keys')
+    })
+
+    it('shows no notice when the key is present', async () => {
+      const wrapper = await mountDetail()
+
+      expect(wrapper.find('[data-testid="model-detail-key-notice"]').exists())
+        .toBe(false)
+    })
   })
 })

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelItem.spec.ts
@@ -40,6 +40,9 @@ function mountModelItem(
     isHighlighted: boolean
     isFavorite: boolean
     isDetailOpen: boolean
+    isLegacy: boolean
+    isKeyMissing: boolean
+    providerName: string
   }> = {},
 ) {
   return mountSuspended(ModelItem, {
@@ -360,5 +363,73 @@ describe('ChatInput/ModelsTrigger/ModelItem', () => {
 
     expect(row.classes()).toContain('bg-accent/15')
     expect(row.classes()).not.toContain('bg-base-content/10')
+  })
+
+  describe('missing provider key', () => {
+    it('renders the row as non-interactive and says why', async () => {
+      const wrapper = await mountModelItem(createModel(), {
+        isKeyMissing: true,
+        providerName: 'OpenAI',
+      })
+
+      expect(wrapper.get('li').attributes('aria-disabled')).toBe('true')
+      expect(wrapper.find('button[aria-label="Choose GPT-5.4"]').exists())
+        .toBe(false)
+      expect(wrapper.get('[data-testid="model-key-required"]').text())
+        .toContain('Key required')
+      expect(wrapper.get('.sr-only').text())
+        .toBe('Add your OpenAI API key to use this model.')
+    })
+
+    it('does not emit a selection when the row is clicked', async () => {
+      const wrapper = await mountModelItem(createModel(), {
+        isKeyMissing: true,
+        providerName: 'OpenAI',
+      })
+
+      await wrapper.get('li > div > div').trigger('click')
+
+      expect(wrapper.emitted('select')).toBeUndefined()
+    })
+
+    it('drops the selected and highlighted backgrounds', async () => {
+      const wrapper = await mountModelItem(createModel(), {
+        isKeyMissing: true,
+        isSelected: true,
+        isHighlighted: true,
+      })
+      const row = wrapper.get('li > div')
+
+      expect(row.classes()).not.toContain('bg-accent/15')
+      expect(row.classes()).not.toContain('bg-base-content/10')
+      expect(wrapper.get('li').attributes('aria-selected')).toBe('false')
+    })
+
+    it('keeps the info and favorite actions reachable', async () => {
+      const wrapper = await mountModelItem(createModel(), {
+        isKeyMissing: true,
+      })
+
+      await wrapper.get('[data-testid="model-info-trigger"]').trigger('click')
+      await wrapper.get('[data-testid="model-favorite-toggle"]')
+        .trigger('click')
+
+      expect(wrapper.emitted('toggleDetail')).toHaveLength(1)
+      expect(wrapper.emitted('toggleFavorite')).toHaveLength(1)
+    })
+
+    it('stays fully selectable when the key is present', async () => {
+      const wrapper = await mountModelItem(createModel(), {
+        providerName: 'OpenAI',
+      })
+
+      expect(wrapper.get('li').attributes('aria-disabled')).toBeUndefined()
+      expect(wrapper.find('[data-testid="model-key-required"]').exists())
+        .toBe(false)
+
+      await wrapper.get('button[aria-label="Choose GPT-5.4"]').trigger('click')
+
+      expect(wrapper.emitted('select')).toHaveLength(1)
+    })
   })
 })

--- a/tests/unit/components/ChatInput/ModelsTrigger/ProviderRail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ProviderRail.spec.ts
@@ -15,6 +15,7 @@ function mountRail(
     activeProviderId: string | null
     isFavoritesOnly: boolean
     hasFavorites: boolean
+    keylessProviderIds: string[]
   }> = {},
 ) {
   return mountSuspended(ProviderRail, {
@@ -141,5 +142,52 @@ describe('ChatInput/ModelsTrigger/ProviderRail', () => {
     expect(mistral.text()).toBe('Mi')
     expect(mistral.get('span').classes()).toContain('uppercase')
     expect(mistral.find('svg').exists()).toBe(false)
+  })
+
+  describe('keyless providers', () => {
+    it('marks only the providers it is told have no key', async () => {
+      const wrapper = await mountRail({ keylessProviderIds: ['openai'] })
+
+      expect(
+        wrapper.find('[data-testid="models-picker-rail-openai-keyless"]')
+          .exists(),
+      ).toBe(true)
+      expect(
+        wrapper.find('[data-testid="models-picker-rail-google-keyless"]')
+          .exists(),
+      ).toBe(false)
+    })
+
+    it('says why in the tooltip and the accessible name', async () => {
+      const wrapper = await mountRail({ keylessProviderIds: ['openai'] })
+      const openai = wrapper.get('[data-testid="models-picker-rail-openai"]')
+
+      expect(openai.attributes('data-tip'))
+        .toBe('OpenAI — API key required')
+      expect(openai.attributes('aria-label'))
+        .toBe('Show OpenAI models only — API key required')
+    })
+
+    it('keeps the button usable so filtering still explains the state', async () => {
+      const wrapper = await mountRail({ keylessProviderIds: ['openai'] })
+
+      await wrapper.get('[data-testid="models-picker-rail-openai"]')
+        .trigger('click')
+
+      expect(wrapper.emitted('toggleProvider')).toEqual([['openai']])
+    })
+
+    it('marks nothing when the prop is omitted, which is the fail-open default', async () => {
+      const wrapper = await mountRail()
+
+      expect(
+        wrapper.find('[data-testid="models-picker-rail-openai-keyless"]')
+          .exists(),
+      ).toBe(false)
+      expect(
+        wrapper.get('[data-testid="models-picker-rail-openai"]')
+          .attributes('data-tip'),
+      ).toBe('OpenAI')
+    })
   })
 })

--- a/tests/unit/composables/chat-input.spec.ts
+++ b/tests/unit/composables/chat-input.spec.ts
@@ -1,7 +1,15 @@
-import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { describe, expect, it } from 'vitest'
-import { defineComponent, h } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, defineComponent, h, shallowRef } from 'vue'
 import { useChatInput } from '../../../app/composables/chat-input'
+
+const mocks = vi.hoisted(() => ({
+  useUserKeys: vi.fn(),
+}))
+
+mockNuxtImport('useUserKeys', () => mocks.useUserKeys)
+
+const keyedProviderIds = shallowRef<string[]>([])
 
 function createHost() {
   return defineComponent({
@@ -9,6 +17,12 @@ function createHost() {
       const chatInput = useChatInput()
 
       return () => h('div', [
+        h('span', { 'data-testid': 'is-selected-model-keyless' }, [
+          String(chatInput.isSelectedModelKeyless.value),
+        ]),
+        h('span', { 'data-testid': 'selected-model-key-owner-label' }, [
+          chatInput.selectedModelKeyOwnerLabel.value,
+        ]),
         h('span', { 'data-testid': 'is-image-generation-supported' }, [
           String(chatInput.isImageGenerationSupported.value),
         ]),
@@ -28,6 +42,90 @@ function createHost() {
     },
   })
 }
+
+beforeEach(() => {
+  keyedProviderIds.value = ['openai', 'google', 'anthropic', 'vercel']
+
+  mocks.useUserKeys.mockReturnValue({
+    pending: shallowRef(false),
+    error: shallowRef(null),
+    hasKey: vi.fn(),
+    hasKeyForProvider: (providerOrGatewayId: string) => {
+      return keyedProviderIds.value.includes(providerOrGatewayId)
+    },
+    hasAnyKey: computed(() => keyedProviderIds.value.length > 0),
+    refresh: vi.fn(),
+  })
+})
+
+describe('useChatInput missing-key resolution', () => {
+  it('reports a provider model as keyless once its key is gone', async () => {
+    const wrapper = await mountSuspended(createHost())
+
+    const { userModel } = useUserModel()
+
+    userModel.value = 'gpt-5.4'
+    await wrapper.vm.$nextTick()
+
+    expect(
+      wrapper.get('[data-testid="is-selected-model-keyless"]').text(),
+    ).toBe('false')
+
+    keyedProviderIds.value = ['google']
+    await wrapper.vm.$nextTick()
+
+    expect(
+      wrapper.get('[data-testid="is-selected-model-keyless"]').text(),
+    ).toBe('true')
+    expect(
+      wrapper.get('[data-testid="selected-model-key-owner-label"]').text(),
+    ).toBe('OpenAI')
+  })
+
+  it('resolves a gateway selection through its gateway id, not the catalog', async () => {
+    const wrapper = await mountSuspended(createHost())
+
+    const { selection } = useUserModel()
+
+    selection.value = {
+      source: 'gateway',
+      gatewayId: 'vercel',
+      modelId: 'anthropic/claude-sonnet-4',
+    }
+    await wrapper.vm.$nextTick()
+
+    expect(
+      wrapper.get('[data-testid="is-selected-model-keyless"]').text(),
+    ).toBe('false')
+    expect(
+      wrapper.get('[data-testid="selected-model-key-owner-label"]').text(),
+    ).toBe('Vercel AI Gateway')
+
+    keyedProviderIds.value = ['openai']
+    await wrapper.vm.$nextTick()
+
+    expect(
+      wrapper.get('[data-testid="is-selected-model-keyless"]').text(),
+    ).toBe('true')
+  })
+
+  it('leaves an unresolvable model ungated rather than blocking send', async () => {
+    const wrapper = await mountSuspended(createHost())
+
+    const { userModel } = useUserModel()
+
+    userModel.value = 'not-a-real-model'
+    keyedProviderIds.value = []
+    await wrapper.vm.$nextTick()
+
+    expect(
+      wrapper.get('[data-testid="is-selected-model-keyless"]').text(),
+    ).toBe('false')
+    expect(
+      wrapper.get('[data-testid="selected-model-key-owner-label"]').text(),
+    ).toBe('this provider')
+  })
+})
 
 describe('useChatInput image model capability', () => {
   it('requires image generation for a purpose-built image model', async () => {

--- a/tests/unit/composables/user-keys.spec.ts
+++ b/tests/unit/composables/user-keys.spec.ts
@@ -1,0 +1,192 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { shallowRef } from 'vue'
+import { useUserKeys } from '../../../app/composables/user-keys'
+
+interface KeySummaryRow {
+  provider: string
+  hasKey: boolean
+}
+
+const mocks = vi.hoisted(() => ({
+  useLazyFetch: vi.fn(),
+  refresh: vi.fn(),
+}))
+
+mockNuxtImport('useLazyFetch', () => mocks.useLazyFetch)
+
+function createFetchState(
+  rows: KeySummaryRow[] | null,
+  options: { pending?: boolean, error?: unknown } = {},
+) {
+  return {
+    data: shallowRef(rows ? { keys: rows } : null),
+    pending: shallowRef(options.pending ?? false),
+    error: shallowRef(options.error ?? null),
+    refresh: mocks.refresh,
+  }
+}
+
+function useSummary(
+  rows: KeySummaryRow[] | null,
+  options: { pending?: boolean, error?: unknown } = {},
+) {
+  const state = createFetchState(rows, options)
+
+  mocks.useLazyFetch.mockReturnValue(state)
+
+  return state
+}
+
+describe('useUserKeys', () => {
+  beforeEach(() => {
+    mocks.useLazyFetch.mockReset()
+    mocks.refresh.mockReset()
+  })
+
+  it('shares a single keyed request across every caller', () => {
+    useSummary([])
+
+    useUserKeys()
+    useUserKeys()
+
+    const requestedKeys = mocks.useLazyFetch.mock.calls.map((call) => {
+      return call.slice(0, 2)
+    })
+
+    expect(requestedKeys).toEqual([
+      ['/api/v1/profiles/keys', { key: 'user-keys' }],
+      ['/api/v1/profiles/keys', { key: 'user-keys' }],
+    ])
+  })
+
+  it('reports presence per provider from the summary', () => {
+    useSummary([
+      { provider: 'google', hasKey: true },
+      { provider: 'openai', hasKey: false },
+    ])
+
+    const { hasKey } = useUserKeys()
+
+    expect(hasKey('google')).toBe(true)
+    expect(hasKey('openai')).toBe(false)
+  })
+
+  it('resolves a gateway through its keys-table id, not its bare GatewayId', () => {
+    useSummary([
+      { provider: 'vercel-gateway', hasKey: false },
+      { provider: 'openrouter', hasKey: true },
+    ])
+
+    const { hasKeyForProvider } = useUserKeys()
+
+    expect(hasKeyForProvider('vercel')).toBe(false)
+    expect(hasKeyForProvider('openrouter')).toBe(true)
+  })
+
+  it('fails open on the bare GatewayId, which is why the mapping is required', () => {
+    useSummary([{ provider: 'vercel-gateway', hasKey: false }])
+
+    const { hasKey } = useUserKeys()
+
+    expect(hasKey('vercel-gateway')).toBe(false)
+    expect(hasKey('vercel')).toBe(true)
+  })
+
+  it('maps a direct provider onto its identically named key id', () => {
+    useSummary([{ provider: 'moonshotai', hasKey: false }])
+
+    const { hasKeyForProvider } = useUserKeys()
+
+    expect(hasKeyForProvider('moonshotai')).toBe(false)
+  })
+
+  it('reports every provider as available while the first fetch is in flight', () => {
+    useSummary(null, { pending: true })
+
+    const { pending, hasKey, hasKeyForProvider, hasAnyKey } = useUserKeys()
+
+    expect(pending.value).toBe(true)
+    expect(hasKey('google')).toBe(true)
+    expect(hasKeyForProvider('vercel')).toBe(true)
+    expect(hasAnyKey.value).toBe(true)
+  })
+
+  it('reports every provider as available when the summary request failed', () => {
+    useSummary(null, { error: new Error('offline') })
+
+    const { hasKey, hasKeyForProvider, hasAnyKey } = useUserKeys()
+
+    expect(hasKey('google')).toBe(true)
+    expect(hasKeyForProvider('vercel')).toBe(true)
+    expect(hasAnyKey.value).toBe(true)
+  })
+
+  it('stops reporting pending once data is loaded, so a refresh cannot re-open the gate', () => {
+    const state = useSummary([{ provider: 'google', hasKey: false }])
+
+    state.pending.value = true
+
+    const { pending, hasKey } = useUserKeys()
+
+    expect(pending.value).toBe(false)
+    expect(hasKey('google')).toBe(false)
+  })
+
+  it('fails open for an id the summary does not mention', () => {
+    useSummary([{ provider: 'google', hasKey: false }])
+
+    const { hasKey, hasKeyForProvider } = useUserKeys()
+
+    expect(hasKey('cloudflare-gateway')).toBe(true)
+    expect(hasKeyForProvider('not-a-provider')).toBe(true)
+  })
+
+  it('reflects a newly saved key after a refresh', async () => {
+    const state = useSummary([{ provider: 'google', hasKey: false }])
+
+    mocks.refresh.mockImplementation(async () => {
+      state.data.value = { keys: [{ provider: 'google', hasKey: true }] }
+    })
+
+    const { hasKey, refresh } = useUserKeys()
+
+    expect(hasKey('google')).toBe(false)
+
+    await refresh()
+
+    expect(hasKey('google')).toBe(true)
+  })
+
+  it('reflects a deleted key after a refresh', async () => {
+    const state = useSummary([{ provider: 'google', hasKey: true }])
+
+    mocks.refresh.mockImplementation(async () => {
+      state.data.value = { keys: [{ provider: 'google', hasKey: false }] }
+    })
+
+    const { hasKey, refresh } = useUserKeys()
+
+    expect(hasKey('google')).toBe(true)
+
+    await refresh()
+
+    expect(hasKey('google')).toBe(false)
+  })
+
+  it('reports an account with no keys at all only when every entry is empty', () => {
+    useSummary([
+      { provider: 'google', hasKey: false },
+      { provider: 'vercel-gateway', hasKey: false },
+    ])
+
+    expect(useUserKeys().hasAnyKey.value).toBe(false)
+
+    useSummary([
+      { provider: 'google', hasKey: false },
+      { provider: 'vercel-gateway', hasKey: true },
+    ])
+
+    expect(useUserKeys().hasAnyKey.value).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Models under a provider/gateway with no saved key now render clearly disabled (dimmed, `aria-disabled`, keyboard-nav skips them) with a link to `/profile/keys`, uniformly across all 6 direct providers and all 3 gateways (Cloudflare gated for free via the existing `enabledGateways` iteration — no hardcoded gateway list).
- Zero-key gateway mode short-circuits to a key-required prompt instead of fetching and then disabling a full catalog.
- Send and regenerate share one guard (`isSelectedModelKeyless`) that surfaces guidance instead of letting a doomed request hit the server's 401 — chosen over a disabled button because a disabled button's explanatory `title` is invisible on touch devices.
- New `useUserKeys()` composable (fail-open while loading/erroring, refreshed live after any key save/delete across all 9 key cards, including the pre-existing Anthropic/Google/OpenAI ones).

Part 6 of a 7-PR stacked initiative (design work, Opus-implemented per the delegation rule). Depends on PR1, PR2, PR4 — all merged. 100% client-side; the existing server-side 401 remains the real enforcement backstop.

## Test plan
- [x] `pnpm run format` / `pnpm run typecheck` clean
- [x] 162+ new/updated tests passing, registered in `scripts/test-affected-check.mjs`
- [x] `pnpm run build` succeeds
- [x] Code-reviewed; 0 critical/blocking findings — caught and fixed a real illusory-test-coverage bug (a `UiBubble: true` auto-stub had been silently dropping the send button's slot in the pre-existing test suite) and a second, previously-unguarded 401 path through `regenerate()`
- [ ] CI green on this PR

## Known, accepted gap (disclosed, not fixed here)
- `chat.ts`'s auto-recovery `regenerate()` calls (the interrupted-generation-on-mount path from issue #275) bypass this PR's guard and fall back to the existing generic-error UI on a 401, rather than the new keyed guidance — a narrow race window (key deleted while a generation was mid-interruption), out of scope for this PR.