### PR TITLE
fix(models): handle retired models + alert on drift-check failure

### DIFF
--- a/.github/workflows/models-drift-check.yml
+++ b/.github/workflows/models-drift-check.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout
@@ -35,12 +36,34 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Capture the fetch exit code without short-circuiting later steps: a
+      # missing/incomplete curated model is an intentional hard-fail of the
+      # fetch script. Later steps publish the log and open an issue, then the
+      # job is re-failed at the end so the cron stays a loud red X.
       - name: Fetch model metadata
+        id: fetch
         shell: bash
         run: |
+          set +e
           pnpm run models:fetch 2>&1 | tee "$RUNNER_TEMP/models-fetch.log"
+          exit_code=${PIPESTATUS[0]}
+          echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Write fetch log to job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## models:fetch output"
+            echo ""
+            echo '```'
+            cat "$RUNNER_TEMP/models-fetch.log"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check for snapshot changes
+        if: steps.fetch.outputs.exit_code == '0'
         id: diff
         run: |
           if [ -n "$(git status --porcelain providers/data/models-dev-snapshot.json)" ]; then
@@ -50,7 +73,7 @@ jobs:
           fi
 
       - name: Build pull request body
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.fetch.outputs.exit_code == '0' && steps.diff.outputs.changed == 'true'
         run: |
           {
             echo "Automated weekly refresh of"
@@ -66,7 +89,7 @@ jobs:
           } > "$RUNNER_TEMP/pr-body.md"
 
       - name: Open pull request
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.fetch.outputs.exit_code == '0' && steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore(models): refresh models.dev metadata snapshot"
@@ -75,3 +98,72 @@ jobs:
           branch: chore/models-metadata-drift
           add-paths: providers/data/models-dev-snapshot.json
           labels: dependencies
+
+      # Failure path: a curated model id is missing or incomplete on
+      # models.dev. Open a single tracking issue (or comment on the existing
+      # open one) instead of leaving a silent red X. The hard-fail stays —
+      # the job is re-failed below.
+      - name: Open or update drift-check failure issue
+        if: steps.fetch.outputs.exit_code != '0'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MARKER='<!-- models-drift-check -->'
+          TITLE='models.dev drift check failed: curated model missing or incomplete'
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          BODY_FILE="$RUNNER_TEMP/drift-issue-body.md"
+          {
+            echo "$MARKER"
+            echo ""
+            echo "Automated weekly \`models:fetch\` failed."
+            echo ""
+            echo "A curated model id is missing or incomplete on models.dev."
+            echo "This is an intentional hard-fail of the fetch script — do not"
+            echo "soften it. Make a deliberate catalog edit:"
+            echo ""
+            echo "- Remove or replace the id in \`providers/*.ts\`, **or**"
+            echo "- Add it to \`EXEMPT_IDS\` in \`scripts/fetch-models-metadata.mjs\`"
+            echo "  and fully curate its metadata (including \`status: 'deprecated'\`"
+            echo "  for retired-but-kept legacy models) in \`providers/*.ts\`."
+            echo ""
+            echo "See \`docs/models-data-fetching.md\`."
+            echo ""
+            echo "Workflow run: $RUN_URL"
+            echo ""
+            echo '```'
+            cat "$RUNNER_TEMP/models-fetch.log"
+            echo '```'
+          } > "$BODY_FILE"
+
+          EXISTING=$(gh issue list \
+            --state open \
+            --search "models.dev drift check failed in:title" \
+            --json number,body \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .number" \
+            | head -n1)
+
+          if [ -n "$EXISTING" ]; then
+            {
+              echo "Another failing run: $RUN_URL"
+              echo ""
+              echo '```'
+              cat "$RUNNER_TEMP/models-fetch.log"
+              echo '```'
+            } | gh issue comment "$EXISTING" --body-file -
+          else
+            # Create the bug label idempotently in case it is missing;
+            # a missing label would otherwise fail issue creation.
+            gh label create bug --color D73A4A 2>/dev/null || true
+            gh issue create \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE" \
+              --label "bug"
+          fi
+
+      - name: Fail job when models:fetch failed
+        if: steps.fetch.outputs.exit_code != '0'
+        run: |
+          echo "models:fetch exited ${{ steps.fetch.outputs.exit_code }}"
+          exit 1

--- a/docs/models-data-fetching.md
+++ b/docs/models-data-fetching.md
@@ -129,11 +129,15 @@ state:
 
 As of this pass, one currently curated id is flagged deprecated:
 
-- **`gemini-3-pro-preview`** — a standalone curated chat model whose
-  successor, `gemini-3.1-pro-preview`, is already curated separately. Left
-  in the catalog (not deleted — a user with it persisted would otherwise
-  see `getModel()` silently resolve to nothing) and handled entirely by the
-  legacy-section UI and server guard above.
+- **`gemini-3-pro-preview`** — fully retired from models.dev (it previously
+  carried `status: 'deprecated'`). Kept in the catalog via `EXEMPT_IDS` and
+  fully curated in `providers/google.ts` with `status: 'deprecated'` and a
+  `releaseDate`, so a user with it persisted still resolves normally while
+  the legacy-section picker UI and `useChatProvider()` guard stop offering
+  it as a new pick. Its successor, `gemini-3.1-pro-preview`, is already
+  curated separately. The next successful `models:fetch` drops the snapshot
+  row for this id — that is expected and correct; the curated half is now
+  the only source of its metadata.
 
 **`gemini-3.1-flash-lite-preview`** was ALSO flagged deprecated on an
 earlier pass of this audit, but that was a genuine bug, not a "leave it in
@@ -158,11 +162,21 @@ point of fetching: a retired or renamed model becomes a loud, deliberate
 edit instead of silently stale hardcoded values.
 
 `EXEMPT_IDS` in `scripts/fetch-models-metadata.mjs` lists the ids that are
-knowingly absent upstream — currently `o3-deep-research` and
-`o4-mini-deep-research`, whose Deep Research snapshots OpenAI bills
-separately but models.dev does not track. Exempt models carry their full
-metadata in the curated file, and the merge throws at import time if any of
-it is missing.
+knowingly absent upstream — two kinds:
+
+- Deep Research snapshots OpenAI bills separately but models.dev does not
+  track (`o3-deep-research`, `o4-mini-deep-research`).
+- Retired-but-kept legacy ids models.dev no longer publishes at all
+  (`gemini-3-pro-preview`; see "Model status" below).
+
+Exempt models carry their **full metadata in the curated file**
+(`providers/*.ts`), not in the snapshot — `models:fetch` rebuilds the
+snapshot from `{}` every run and skips exempt ids, so a hand-edited
+snapshot row would be wiped on the next successful run. For a retired-but-
+kept model, set curated `status: 'deprecated'` (and optionally
+`releaseDate`) so the legacy picker section and `useChatProvider()` guard
+keep working after the snapshot row disappears. The merge throws at import
+time if any required curated field is missing.
 
 ## Optional owner-run spot-check
 
@@ -182,13 +196,24 @@ curl -s "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API
   | jq '.models[].name'
 ```
 
-## No scheduled refresh workflow
+## Scheduled drift check
 
-There is no cron workflow opening a refresh PR. The repo has no
-`create-pull-request` precedent in `.github/workflows/`, and a bot PR that
-renames user-visible models needs a human reading the diff anyway. Run
-`pnpm run models:fetch` when adding a model or when provider pricing
-changes.
+A weekly cron (`.github/workflows/models-drift-check.yml`, `0 9 * * 1`,
+also `workflow_dispatch`) runs `pnpm run models:fetch` so a stale
+snapshot never silently ships.
+
+- **Success:** if the snapshot changed, the workflow opens a refresh PR for
+  `providers/data/models-dev-snapshot.json` only (label `dependencies`).
+  A human still reads the diff — a refreshed snapshot can rename a model
+  users already picked.
+- **Failure:** if a curated id is missing or incomplete on models.dev, the
+  fetch script hard-fails (see below). The workflow captures the exit code,
+  writes the full fetch log to the job summary, and opens or comments on a
+  single tracking GitHub issue (deduped by a `<!-- models-drift-check -->`
+  body marker) instead of leaving a silent red X. The job is then re-failed
+  so the cron stays loud. The script's hard-fail is **not** softened — the
+  human-visible issue and the failed job are the signal; the deliberate
+  catalog edit is still made by hand.
 
 ## Favorites are DB-persisted, not localStorage
 

--- a/providers/data/models-dev-snapshot.json
+++ b/providers/data/models-dev-snapshot.json
@@ -248,33 +248,6 @@
       "output": 1.5
     }
   },
-  "gemini-3-pro-preview": {
-    "name": "Gemini 3 Pro Preview",
-    "description": "Preview Gemini flagship for complex reasoning, coding, and rich multimodal prompts",
-    "releaseDate": "2025-11-18",
-    "status": "deprecated",
-    "limit": {
-      "context": 1048576,
-      "output": 65536
-    },
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video",
-        "audio",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "cost": {
-      "input": 2,
-      "output": 12
-    },
-    "tieredPricing": true
-  },
   "gemini-3-flash-preview": {
     "name": "Gemini 3 Flash Preview",
     "description": "New Gemini flash lane bringing frontier-style multimodal reasoning to cheaper runs",

--- a/providers/google.ts
+++ b/providers/google.ts
@@ -96,8 +96,21 @@ export default {
     },
     {
       id: 'gemini-3-pro-preview',
+      name: 'Gemini 3 Pro Preview',
+      description:
+        'Preview Gemini flagship for complex reasoning, coding, and rich multimodal prompts',
+      contextLength: 1_048_576,
+      maxOutputTokens: 65_536,
+      releaseDate: '2025-11-18',
+      status: 'deprecated',
       price: {
         tokens: 1_000_000,
+        input: 'from $2.00',
+        output: 'from $12.00',
+      },
+      modalities: {
+        input: ['text', 'image', 'video', 'audio', 'pdf'],
+        output: ['text'],
       },
       tools: ['web_search', 'image_generation'],
       reasoning: {

--- a/providers/merge.ts
+++ b/providers/merge.ts
@@ -21,6 +21,8 @@ export interface CuratedModel {
   description?: string
   contextLength?: number
   maxOutputTokens?: number
+  releaseDate?: string
+  status?: 'deprecated' | 'beta' | 'alpha'
   price: CuratedModelPrice
   modalities?: Model['modalities']
   tools: ModelTool[]
@@ -224,6 +226,8 @@ function toFullyCuratedModel(curated: CuratedModel): Model {
     description,
     contextLength,
     maxOutputTokens,
+    ...(curated.releaseDate ? { releaseDate: curated.releaseDate } : {}),
+    ...(curated.status ? { status: curated.status } : {}),
     price: mergedPrice(
       curated.price,
       curated.price.input ?? '',

--- a/scripts/fetch-models-metadata.mjs
+++ b/scripts/fetch-models-metadata.mjs
@@ -45,10 +45,18 @@ const SNAPSHOT_PATH = fileURLToPath(
   new URL('../providers/data/models-dev-snapshot.json', import.meta.url),
 )
 
-// OpenAI bills Deep Research as its own model snapshots, which models.dev
-// does not track separately (it lists only the bare o3 / o4-mini). These two
-// stay fully curated in providers/openai.ts.
-const EXEMPT_IDS = ['o3-deep-research', 'o4-mini-deep-research']
+// Ids that are knowingly absent from models.dev. Two kinds:
+//  - Deep Research snapshots OpenAI bills separately but models.dev does not
+//    track (it lists only the bare o3 / o4-mini). Fully curated in
+//    providers/openai.ts.
+//  - Retired-but-kept legacy ids models.dev no longer publishes at all.
+//    Fully curated in providers/*.ts with `status: 'deprecated'` so the
+//    legacy picker section and useChatProvider() guard keep working.
+const EXEMPT_IDS = [
+  'o3-deep-research',
+  'o4-mini-deep-research',
+  'gemini-3-pro-preview',
+]
 
 const KNOWN_MODEL_STATUSES = ['deprecated', 'beta', 'alpha']
 

--- a/tests/unit/providers/merge.spec.ts
+++ b/tests/unit/providers/merge.spec.ts
@@ -189,6 +189,8 @@ describe('mergeModelMetadata', () => {
         description: 'Not tracked by models.dev',
         contextLength: 200_000,
         maxOutputTokens: 100_000,
+        releaseDate: '2025-11-18',
+        status: 'deprecated',
         price: {
           tokens: 1_000_000,
           input: '$10.00',
@@ -205,7 +207,48 @@ describe('mergeModelMetadata', () => {
     expect(model.name).toBe('Curated Only')
     expect(model.contextLength).toBe(200_000)
     expect(model.price.input).toBe('$10.00')
-    expect('releaseDate' in model).toBe(false)
+    expect(model.releaseDate).toBe('2025-11-18')
+    expect(model.status).toBe('deprecated')
+  })
+
+  it('passes curated status and releaseDate through when there is no snapshot', () => {
+    const withStatus = mergeModelMetadata(
+      {
+        ...chatModel,
+        name: 'Retired Legacy',
+        description: 'Curated after retirement',
+        contextLength: 200_000,
+        maxOutputTokens: 100_000,
+        releaseDate: '2025-11-18',
+        status: 'deprecated',
+        modalities: {
+          input: ['text'],
+          output: ['text'],
+        },
+      },
+      undefined,
+    )
+
+    expect(withStatus.releaseDate).toBe('2025-11-18')
+    expect(withStatus.status).toBe('deprecated')
+
+    const withoutStatus = mergeModelMetadata(
+      {
+        ...chatModel,
+        name: 'Exempt No Status',
+        description: 'Curated, no status or date',
+        contextLength: 200_000,
+        maxOutputTokens: 100_000,
+        modalities: {
+          input: ['text'],
+          output: ['text'],
+        },
+      },
+      undefined,
+    )
+
+    expect('releaseDate' in withoutStatus).toBe(false)
+    expect('status' in withoutStatus).toBe(false)
   })
 
   it('throws when a model has neither a snapshot entry nor full curation', () => {
@@ -368,13 +411,18 @@ describe('merged catalog', () => {
     }
   })
 
-  it('carries a release date exactly for snapshot-backed models', () => {
+  it('carries a release date for snapshot-backed and curated-only models', () => {
     for (const provider of providers) {
       for (const model of provider.models) {
         const entry = snapshot[model.id as keyof typeof snapshot]
 
         if (!entry) {
-          expect('releaseDate' in model).toBe(false)
+          // Fully curated exempt models (e.g. deep-research ids, retired
+          // legacy ids) may carry a curated releaseDate; if present it
+          // must still be a valid date.
+          if ('releaseDate' in model) {
+            expect(model.releaseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+          }
 
           continue
         }


### PR DESCRIPTION
## Summary

Fixes the failing weekly `models:fetch` drift-check run ([run #32015270918](https://github.com/besidka/besidka/actions/runs/32015270918/job/95343293332)) and hardens the workflow so this class of failure (a curated model retiring from models.dev) is loud and human-visible instead of a silent red ✗.

## Root cause

models.dev fully retired `google/gemini-3-pro-preview`. The fetch script (`scripts/fetch-models-metadata.mjs`) intentionally hard-exits 1 when a curated id is no longer listed upstream — by design, a retired model should be a loud, deliberate edit. But the weekly `models-drift-check.yml` cron had no failure-handling step: the fetch exited 1 before writing the snapshot, the "Open pull request" step (gated on a snapshot diff) never ran, and no issue was opened. The workflow just failed silently — the opposite of "loud."

## Architectural fix

**1. Keep the retired model via EXEMPT + full curation (not a snapshot hand-edit).**
A critical finding from the architecture review: `EXEMPT_IDS` models are fully curated in `providers/*.ts` (the `o3-deep-research` pattern), **not** hand-edited into the snapshot — `models:fetch` rebuilds the snapshot from `{}` every run and skips exempt ids, so a snapshot-only hand-edit would be wiped on the next successful run. Additionally, `toFullyCuratedModel` previously dropped `status`/`releaseDate`, so EXEMPT alone would have re-surfaced the retired model as a normal selectable model and silently broken the legacy picker UI + `useChatProvider()` server guard.

- `providers/google.ts` — `gemini-3-pro-preview` is now fully curated (name, description, context/output limits, modalities, `from $2.00`/`from $12.00` tiered prices) with `status: 'deprecated'` and `releaseDate: '2025-11-18'` (last known good snapshot values). Not deleted, so persisted user picks still resolve.
- `providers/merge.ts` — `CuratedModel` gains optional `releaseDate?` / `status?`; `toFullyCuratedModel` passes them through the same way the snapshot branch does.
- `scripts/fetch-models-metadata.mjs` — `gemini-3-pro-preview` added to `EXEMPT_IDS` (comment documents both exempt kinds: never-tracked deep-research ids and retired-but-kept legacy ids).
- `providers/data/models-dev-snapshot.json` — live `models:fetch` now succeeds (exit 0) and drops the retired key (31 models, no unrelated drift).
- `tests/unit/providers/merge.spec.ts` — full-curation `status`/`releaseDate` pass-through coverage; fixed the catalog releaseDate invariant for no-snapshot (curated-only) models.

**2. Make the workflow loud on hard-fail (without softening the script).**
`.github/workflows/models-drift-check.yml` now:
- captures the fetch exit code (`id: fetch`, `set +e` + `PIPESTATUS[0]` + `exit 0` so later steps still run);
- always writes the fetch log to `$GITHUB_STEP_SUMMARY` (success and failure);
- on failure, opens or comments on a single tracking GitHub issue (deduped by a `<!-- models-drift-check -->` body marker) with the full log + remediation instructions, via `gh` + `GH_TOKEN: ${{ github.token }}` (no new third-party action);
- re-fails the job at the end so the cron stays a loud red ✗;
- gates the success path (diff → build body → open refresh PR) on `exit_code == '0'`, unchanged otherwise;
- adds `issues: write` to permissions.

The hard-fail semantics of the fetch script are deliberately **not** weakened — the issue + failed job are the signal; the deliberate catalog edit is still made by hand.

**3. Fix stale docs.**
`docs/models-data-fetching.md` — replaced the now-false "No scheduled refresh workflow" section with an accurate "Scheduled drift check" description (success/failure paths, hard-fail semantics); expanded the `EXEMPT_IDS` section to cover both kinds and explicitly state that exempt metadata lives in `providers/*.ts` (not the snapshot); updated the `gemini-3-pro-preview` Model-status bullet to document the full retirement + exempt-deprecated handling.

## Verification

- `pnpm run format` — 0 errors (26 pre-existing `no-console` warnings in `scripts/generate-vapid-keys.mjs`, none in changed files)
- `pnpm run typecheck` — passed
- `pnpm vitest run tests/unit/providers/merge.spec.ts tests/unit/scripts/audit-curated-models.spec.ts` — 2 files, 45/45 tests passed
- `pnpm run models:fetch` — exit 0; no missing id; 31 models written; `gemini-3-pro-preview` correctly listed as exempt and dropped from the snapshot
- Pre-commit hook (lint-staged + typecheck) ran on all three commits — clean

## Reviewer

An independent `reviewer` subagent pass against the approved plan + AGENTS.md returned **"No issues found"** (attested), with only two pre-acknowledged non-blocking residuals:
- the `bug` label may not exist (now handled: the issue step creates it idempotently);
- `gh issue list --search` can lag (the marker filter still selects correctly when results return).

## Out of scope (by design)

- Did **not** soften the fetch script's hard-fail into a warning that writes a partial snapshot (would revive silent staleness).
- Did **not** delete `gemini-3-pro-preview` from `providers/google.ts` (would break the persisted-user contract; `getModel()` would silently resolve to nothing).
- Did **not** preemptively exempt `gemini-3-flash-preview` or touch any other model.
- Did **not** add maintainer provider API keys or change picker/server-guard logic (the existing `status === 'deprecated'` legacy UI + `useChatProvider()` guard now just work for this model via the curated half).
