### PR TITLE
ci: bypass husky in drift-check and report non-fetch failures

### DIFF
--- a/.github/workflows/models-drift-check.yml
+++ b/.github/workflows/models-drift-check.yml
@@ -18,6 +18,9 @@ jobs:
       pull-requests: write
       issues: write
 
+    env:
+      HUSKY: 0
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -155,6 +158,59 @@ jobs:
           else
             # Create the bug label idempotently in case it is missing;
             # a missing label would otherwise fail issue creation.
+            gh label create bug --color D73A4A 2>/dev/null || true
+            gh issue create \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE" \
+              --label "bug"
+          fi
+
+      # Catch-all: fetch exited 0 but a later step failed (pull request
+      # creation, diff). Opens-or-comments a distinctly marked
+      # tracking issue instead of leaving a silent red X. Disjoint from the
+      # fetch-failure path above, which gates on exit_code != '0'.
+      - name: Open or update workflow failure issue
+        if: failure() && steps.fetch.outputs.exit_code == '0'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MARKER='<!-- models-drift-check-workflow-failure -->'
+          TITLE='models.dev drift check workflow failed'
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          BODY_FILE="$RUNNER_TEMP/drift-workflow-issue-body.md"
+          {
+            echo "$MARKER"
+            echo ""
+            echo "A \`models-metadata-drift\` workflow step failed **after**"
+            echo "\`models:fetch\` exited successfully (exit code 0) — likely"
+            echo "the refresh-pull-request step. Check the run logs:"
+            echo ""
+            echo "Workflow run: $RUN_URL"
+            echo ""
+            echo "Fetch log from this run (informational):"
+            echo '```'
+            cat "$RUNNER_TEMP/models-fetch.log"
+            echo '```'
+          } > "$BODY_FILE"
+
+          EXISTING=$(gh issue list \
+            --state open \
+            --search "drift check workflow failed in:title" \
+            --json number,body \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .number" \
+            | head -n1)
+
+          if [ -n "$EXISTING" ]; then
+            {
+              echo "Another failing run: $RUN_URL"
+              echo ""
+              echo '```'
+              cat "$RUNNER_TEMP/models-fetch.log"
+              echo '```'
+            } | gh issue comment "$EXISTING" --body-file -
+          else
             gh label create bug --color D73A4A 2>/dev/null || true
             gh issue create \
               --title "$TITLE" \

--- a/docs/models-data-fetching.md
+++ b/docs/models-data-fetching.md
@@ -206,14 +206,20 @@ snapshot never silently ships.
   `providers/data/models-dev-snapshot.json` only (label `dependencies`).
   A human still reads the diff — a refreshed snapshot can rename a model
   users already picked.
-- **Failure:** if a curated id is missing or incomplete on models.dev, the
-  fetch script hard-fails (see below). The workflow captures the exit code,
-  writes the full fetch log to the job summary, and opens or comments on a
-  single tracking GitHub issue (deduped by a `<!-- models-drift-check -->`
-  body marker) instead of leaving a silent red X. The job is then re-failed
-  so the cron stays loud. The script's hard-fail is **not** softened — the
-  human-visible issue and the failed job are the signal; the deliberate
-  catalog edit is still made by hand.
+- **Failure:** the job stays a loud red X and a human-visible tracking issue
+  is opened (or commented on, deduplicated). Two disjoint paths:
+  - If a curated id is missing or incomplete on models.dev, the fetch script
+    hard-fails (see below). The workflow captures the exit code, writes the
+    full fetch log to the job summary, and opens or comments on a single
+    tracking issue (deduped by a `<!-- models-drift-check -->` body marker).
+    The script's hard-fail is **not** softened — the deliberate catalog edit
+    is still made by hand.
+  - If `models:fetch` exits 0 but any later step fails (typically the
+    refresh-pull-request commit), a separate catch-all step opens or comments
+    on its own tracking issue (marker
+    `<!-- models-drift-check-workflow-failure -->`). Bot commits in this
+    workflow skip husky hooks via a job-level `HUSKY: 0`, so they never run
+    dev-machine pre-commit tooling.
 
 ## Favorites are DB-persisted, not localStorage
 


### PR DESCRIPTION
## Summary

Two changes to the weekly Models Metadata Drift Check workflow, fixing the first-ever failed run and closing the coverage gap it exposed:

1. **Job-level `HUSKY: 0`** on the `check-drift` job — bot commits made by `create-pull-request` no longer run dev-machine pre-commit tooling.
2. **Catch-all failure reporter** — a new step gated on `failure() && steps.fetch.outputs.exit_code == '0'` opens or comments on a distinctly-marked tracking issue when any post-fetch step fails, instead of leaving a silent red ✗.

## Root cause

[Failed run 32712190038](https://github.com/besidka/besidka/actions/runs/32712190038) crashed at the "Open pull request" step (the fetch itself exited 0 and detected real snapshot drift):

`create-pull-request@v8`'s internal `git commit` triggered the husky `.husky/pre-commit` hook → line 2 runs an unconditional `pnpm run typecheck` → typecheck needs Cloudflare ambient types (`AnalyticsEngineDataset`, `SendEmail`) that live only in `worker-configuration.d.ts`, which is gitignored and generated by `pnpm run cf-typegen` — a step this workflow never runs → three TS2304 errors, exit 2 → commit aborted → step failed.

This was **latent since the workflow's creation**, not introduced by #363: every prior run (Aug 3, Aug 10, Aug 20) had zero snapshot drift, so the PR step had *never executed before*. Aug 24 was the first real drift. #363's failure handling only covers `models:fetch` exiting non-zero; a PR-step crash skipped the tracking-issue steps entirely — a bare red ✗ nobody is subscribed to.

## Why `HUSKY: 0`, not the alternatives

- **`cf-typegen` in the workflow** — wrong layer: with hooks off, typecheck never runs here at all. It treats the symptom ("typecheck lacks types") instead of the cause ("a bot commit ran human tooling").
- **Weakening `.husky/pre-commit`** — the hook is a deliberate dev-machine guardrail; the correct fix is not running it for bot commits, not weakening it for humans.
- **Committing `worker-configuration.d.ts`** — generated, machine-specific; would paper over every future missing-typegen failure.
- **`--ignore-scripts` on install** — kills all postinstall scripts, far broader than husky.

Husky 9 honors `HUSKY=0` at both layers (verified against the installed `husky@9.1.7` source): the `prepare` script skips `core.hooksPath` setup during `pnpm install`, and the hook shim exits 0 if it somehow still runs.

## Catch-all design

- Gate: `failure() && steps.fetch.outputs.exit_code == '0'` — disjoint by construction from the existing fetch-failure steps (`exit_code != '0'`), so the two issue paths can never double-fire.
- Distinct marker `<!-- models-drift-check-workflow-failure -->` and title `models.dev drift check workflow failed` — the marker-based dedup keeps the two issue families mutually invisible.
- The job still ends red: nothing is suppressed, the failing step's status stands.
- Reuses the exact gh/marker/dedup/label pattern of #363's fetch-failure step — no refactoring of the existing step.

## Verification

- `pnpm dlx js-yaml` parse clean; all seven post-change `if:` conditions enumerated and disjointness proven (catch-all is the only step combining `failure()` with `== '0'`).
- Local hook-bypass probe: with `HUSKY=0` exported, a staged commit succeeds in ~1s with no lint-staged/typecheck output; without it, the same commit reproduces the exact TS2304 crash from the failed run.
- `pnpm run format` (0 errors) and `pnpm run typecheck` (passed).
- Reviewer pass: plan fidelity byte-identical, Actions semantics verified, husky semantics verified against installed source, no secrets reach issue bodies (the fetch log is already public in the job summary). One NIT fixed (a comment overclaimed checkout-failure coverage).

## After merge

Dispatch `models-drift-check` manually once — the pending real drift (the snapshot changes that triggered this incident) should now produce a green run and open the refresh PR it was always meant to open.

## Docs

`docs/models-data-fetching.md` — the "Failure" bullet now describes both disjoint failure paths and the `HUSKY: 0` bot-commit behavior.
