### PR TITLE
feat(models): surface provider retirement dates, add gemini-3.7-flash and gpt-5.6

### DIFF
--- a/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
+++ b/app/components/ChatInput/ModelsTrigger/ModelDetail.vue
@@ -45,10 +45,19 @@
         size="13"
         class="shrink-0 mt-px"
       />
-      <span>
-        The provider has deprecated this model, so it can stop responding at
-        any time and can no longer be selected. Pick a supported model instead.
-      </span>
+      <span>{{ deprecationNotice }}</span>
+    </p>
+    <p
+      v-else-if="model.retiredAt"
+      data-testid="model-detail-retire-notice"
+      class="mt-2 flex items-start gap-1.5 p-2 rounded-xl text-xs text-warning capability-chip"
+    >
+      <Icon
+        name="lucide:calendar-clock"
+        size="13"
+        class="shrink-0 mt-px"
+      />
+      <span>{{ retireNotice }}</span>
     </p>
     <p
       v-if="model.description"
@@ -118,6 +127,62 @@ const emit = defineEmits<{
 
 const detailId = computed<string>(() => {
   return `model-detail-${props.model.id}`
+})
+
+const retirementMonthNames = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+]
+
+function formatRetirementDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-')
+  const monthName = retirementMonthNames[Number(month) - 1]
+
+  if (!year || !monthName || !day) {
+    return isoDate
+  }
+
+  return `${monthName} ${Number(day)}, ${year}`
+}
+
+function localDateToday(): string {
+  const now = new Date()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+
+  return `${now.getFullYear()}-${month}-${day}`
+}
+
+const retireNotice = computed<string>(() => {
+  const { retiredAt } = props.model
+
+  if (!retiredAt) {
+    return ''
+  }
+
+  const formatted = formatRetirementDate(retiredAt)
+
+  return retiredAt > localDateToday()
+    ? `Scheduled to retire on ${formatted}.`
+    : `Retired on ${formatted}.`
+})
+
+const deprecationNotice = computed<string>(() => {
+  const base = 'The provider has deprecated this model, so it can stop '
+    + 'responding at any time and can no longer be selected. Pick a '
+    + 'supported model instead.'
+  const { retiredAt } = props.model
+
+  if (!retiredAt) {
+    return base
+  }
+
+  const today = localDateToday()
+  const formatted = formatRetirementDate(retiredAt)
+
+  return retiredAt > today
+    ? `${base} It is scheduled to shut down on ${formatted}.`
+    : `${base} It was shut down on ${formatted}.`
 })
 
 const priceTip = computed<string | undefined>(() => {

--- a/docs/models-data-fetching.md
+++ b/docs/models-data-fetching.md
@@ -30,7 +30,8 @@ Workers build stays hermetic and offline, reading the committed snapshot.
 | `name` | fetched, unless the model is a research agent or models.dev publishes the bare id as the name |
 | `description` | fetched, unless the model is a research agent |
 | `contextLength`, `maxOutputTokens`, `modalities` | fetched |
-| `status` | fetched, present only when models.dev flags `deprecated`/`beta`/`alpha` |
+| `status` | fetched, unless hand-set in curated (curated wins — the owner can outrank models.dev) |
+| `retiredAt` | curated only — the provider's official shutdown date; models.dev has no retirement dates |
 | `price.input`, `price.output` | fetched, unless the model is a research agent (billed per task) |
 | `price.display` | curated (per-image copy) |
 | `price.tokens` | curated (the structural cost divisor) |
@@ -127,14 +128,21 @@ state:
   `localStorage`/devtools edit could otherwise still send a deprecated
   model id straight to the API).
 
-As of this pass, one currently curated id is flagged deprecated:
+As of this pass, curated ids carry deprecation state from two sources:
 
+- **`gemini-2.5-flash-image`** — models.dev does not flag it, but Google's
+  official deprecations page schedules its shutdown for 2026-10-02. The
+  curated entry hand-sets `status: 'deprecated'` (curated status now
+  outranks the snapshot at merge time) plus `retiredAt: '2026-10-02'`, so
+  it moves to the legacy picker section and the `useChatProvider()` guard
+  blocks sending with it, in new and continued chats alike.
 - **`gemini-3-pro-preview`** — fully retired from models.dev (it previously
   carried `status: 'deprecated'`). Kept in the catalog via `EXEMPT_IDS` and
-  fully curated in `providers/google.ts` with `status: 'deprecated'` and a
-  `releaseDate`, so a user with it persisted still resolves normally while
-  the legacy-section picker UI and `useChatProvider()` guard stop offering
-  it as a new pick. Its successor, `gemini-3.1-pro-preview`, is already
+  fully curated in `providers/google.ts` with `status: 'deprecated'`, a
+  `releaseDate`, and its passed shutdown date `retiredAt: '2026-03-09'`,
+  so a user with it persisted still resolves normally while the
+  legacy-section picker UI and `useChatProvider()` guard stop offering it
+  as a new pick. Its successor, `gemini-3.1-pro-preview`, is already
   curated separately. The next successful `models:fetch` drops the snapshot
   row for this id — that is expected and correct; the curated half is now
   the only source of its metadata.
@@ -153,6 +161,45 @@ already available upstream (often just the same name minus `-preview`, or
 the next point release) before assuming the legacy-section treatment is the
 right fix — swapping the id is strictly better when a real successor
 exists.
+
+## Retirement dates and how we learn about them
+
+models.dev has no retirement data at all — it flags none of our curated
+models deprecated even when the provider officially schedules shutdown
+(proven: the whole gemini-2.5 family). Retirement knowledge therefore
+arrives through two layers:
+
+1. **The models.dev `status` tripwire.** The weekly drift check and every
+   manual `pnpm run models:fetch` print the deprecated-model warning (see
+   "Auditing curated vs. available models" above), and a fetched
+   `status: 'deprecated'` flows into the merge, driving the legacy picker
+   tab and the server guard automatically. This catches OpenAI-style flags,
+   where models.dev does mark a model deprecated.
+2. **Hand-curated `status` + `retiredAt`.** When models.dev stays silent,
+   the authoritative source is the provider's official deprecation page —
+   for Gemini https://ai.google.dev/gemini-api/docs/deprecations , for
+   OpenAI https://platform.openai.com/docs/deprecations . The weekly cadence
+   already forces a human look at the fetch output; these pages are that
+   human's reading list. A hand-set curated `retiredAt`
+   (`yyyy-mm-dd`, shown in the model detail panel) and, when shutdown is
+   near or past, a hand-set curated `status: 'deprecated'` are set in
+   `providers/*.ts`; curated status outranks the snapshot.
+
+Scraping the deprecation pages on a schedule was rejected (fragile HTML
+churn for little gain) and so was API probing (this repo is 100% BYOK and
+holds no provider keys — see "Optional owner-run spot-check" below).
+
+Semantics: `status: 'deprecated'` is the **gate** — legacy tab plus the
+`useChatProvider()` server guard block new chats with the model.
+`retiredAt` alone is **informational** — the model stays selectable but its
+detail panel shows the scheduled retirement date (`gemini-3.1-flash-lite`,
+retiring 2027-05-07, is the working example).
+
+Beware product-scoped dates: Google's Vertex AI and Gemini API (AI Studio)
+deprecate models on different schedules. The Oct 16 2026 shutdown date
+circulating for the gemini-2.5 text models is a Vertex AI date; the AI
+Studio page announces no shutdown date for them, so they stay untouched in
+the catalog.
 
 ## Hard failure on a retired model
 
@@ -294,12 +341,13 @@ deliberately not fixed now — logged here instead of silently dropped:
   server-side.** An id that doesn't match any known model is stored as-is
   and simply never rendered (see "Favorites are DB-persisted" above) —
   inert, not a correctness risk, so not worth rejecting at the API layer.
-- **models.dev has no retirement *date* field**, only `release_date` and
-  `last_updated` — so a "leaving on \<date\>" countdown badge isn't
-  derivable from this data source; that would need a hand-curated
-  retirement date per model. See "Model status" above for the coarse
-  present-tense `status` field this data source does carry instead, and
-  how it now drives the legacy-section UI and server guard.
+- **models.dev still has no retirement *date* field**, only `release_date`
+  and `last_updated` — the coarse present-tense `status` it does carry
+  drives the legacy-section UI and server guard, but any "leaving on
+  \<date\>" countdown needs a hand-curated date. That gap is now filled by
+  curated `retiredAt` (see "Retirement dates and how we learn about them"
+  above); what remains deferred is surfacing it as anything richer than
+  the detail-panel sentence.
 
 ## New models added this pass — confidence on capability flags
 
@@ -316,6 +364,15 @@ per-model capability confirmed against any field models.dev exposes.** If a
 model in this set turns out not to actually support image generation, a user
 picking that tool would only find out at generation time. Worth a spot-check
 before relying on it for a model you haven't tried yet.
+
+A later pass added `gemini-3.7-flash` — the same-family successor of
+`gemini-3.6-flash`, curated with the identical structure and the same
+$0.75/$3.75 pricing, with name/description/limits pulled from the snapshot
+— and bare `gpt-5.6`, whose models.dev specs are byte-identical to
+`gpt-5.6-sol`. Both `gpt-5.6` ids are now curated deliberately: the specs
+are indistinguishable, but users who know the model by the bare id should
+find it under that id too (this supersedes the earlier decision recorded
+under "Ids deliberately not auto-added" below).
 
 ## Ids deliberately not auto-added (owner review needed)
 
@@ -334,13 +391,13 @@ automatic add:
 - **`gpt-5.3-codex`, `gpt-5.3-codex-spark`** — coding-agent-specialized
   variants, a different product positioning than this app's general chat
   models (also: no plain `gpt-5.3` mainline model exists upstream at all).
-- **`gpt-5.6-sol`** — not a distinct model. OpenAI's own docs state
+- **`gpt-5.6-sol`** — not a distinct model: OpenAI's own docs state
   "Model ID: gpt-5.6-sol (aliased as gpt-5.6)", and its models.dev entry is
   byte-identical to bare `gpt-5.6` (same cost, description, release date).
-  Curating both would show two indistinguishable rows for one model; the
-  bare `gpt-5.6` id was curated instead, matching how every other mainline
-  release in this lineage (`gpt-5`, `gpt-5.1`, `gpt-5.2`, `gpt-5.4`) has no
-  separate top-tier alias id.
+  This pass originally curated only the bare `gpt-5.6` id for that reason;
+  a later pass reversed the call and now curates BOTH ids deliberately (see
+  "New models added this pass" above), so users who know either id find the
+  model under it.
 Two ids originally listed here on an earlier pass of this audit were
 subsequently added, not left out — corrected in a follow-up commit:
 

--- a/providers/data/models-dev-snapshot.json
+++ b/providers/data/models-dev-snapshot.json
@@ -147,6 +147,31 @@
       "output": 3.75
     }
   },
+  "gemini-3.7-flash": {
+    "name": "Gemini 3.7 Flash",
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
+    "releaseDate": "2026-08-13",
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 0.75,
+      "output": 3.75
+    }
+  },
   "gemini-3.5-flash": {
     "name": "Gemini 3.5 Flash",
     "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
@@ -512,6 +537,30 @@
     "cost": {
       "input": 0.2,
       "output": 1.2
+    },
+    "tieredPricing": true
+  },
+  "gpt-5.6": {
+    "name": "GPT-5.6",
+    "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+    "releaseDate": "2026-07-09",
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 30
     },
     "tieredPricing": true
   },

--- a/providers/google.ts
+++ b/providers/google.ts
@@ -50,6 +50,17 @@ export default {
       },
     },
     {
+      id: 'gemini-3.7-flash',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search', 'image_generation'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
       id: 'gemini-3.5-flash',
       price: {
         tokens: 1_000_000,
@@ -92,6 +103,7 @@ export default {
         mode: 'levels',
         levels: ['low', 'medium', 'high'],
       },
+      retiredAt: '2027-05-07',
       forProjectMemory: true,
     },
     {
@@ -103,6 +115,7 @@ export default {
       maxOutputTokens: 65_536,
       releaseDate: '2025-11-18',
       status: 'deprecated',
+      retiredAt: '2026-03-09',
       price: {
         tokens: 1_000_000,
         input: 'from $2.00',
@@ -198,6 +211,8 @@ export default {
     },
     {
       id: 'gemini-2.5-flash-image',
+      status: 'deprecated',
+      retiredAt: '2026-10-02',
       price: {
         tokens: 1,
         display: '$0.039 / 1K image, plus input',

--- a/providers/merge.ts
+++ b/providers/merge.ts
@@ -23,6 +23,7 @@ export interface CuratedModel {
   maxOutputTokens?: number
   releaseDate?: string
   status?: 'deprecated' | 'beta' | 'alpha'
+  retiredAt?: string
   price: CuratedModelPrice
   modalities?: Model['modalities']
   tools: ModelTool[]
@@ -228,6 +229,7 @@ function toFullyCuratedModel(curated: CuratedModel): Model {
     maxOutputTokens,
     ...(curated.releaseDate ? { releaseDate: curated.releaseDate } : {}),
     ...(curated.status ? { status: curated.status } : {}),
+    ...(curated.retiredAt ? { retiredAt: curated.retiredAt } : {}),
     price: mergedPrice(
       curated.price,
       curated.price.input ?? '',
@@ -246,8 +248,11 @@ function toFullyCuratedModel(curated: CuratedModel): Model {
  * Curated wins for product decisions (capabilities, tools, defaults, the
  * structural `price.tokens` divisor, the per-image `price.display` copy) and
  * for research-agent models, whose name, description and price deliberately
- * encode per-task billing that no per-token figure can express. Everything
- * objective — specs, modalities, release date, status, per-token cost —
+ * encode per-task billing that no per-token figure can express. Retirement
+ * knowledge is also curated-only: a hand-set `status` outranks the fetched
+ * one and `retiredAt` exists only in curated files, because models.dev has
+ * no retirement dates. Everything else objective — specs, modalities,
+ * release date, remaining status values, per-token cost —
  * comes from the snapshot, unless a curated `name` is explicitly set, which
  * always wins: it means models.dev's name is worse than the curated one
  * (a placeholder equal to the bare id, a stale alias suffix like
@@ -274,7 +279,10 @@ export function mergeModelMetadata(
     contextLength: snapshot.limit.context,
     maxOutputTokens: snapshot.limit.output,
     ...(snapshot.releaseDate ? { releaseDate: snapshot.releaseDate } : {}),
-    ...(snapshot.status ? { status: snapshot.status } : {}),
+    ...(curated.status
+      ? { status: curated.status }
+      : snapshot.status ? { status: snapshot.status } : {}),
+    ...(curated.retiredAt ? { retiredAt: curated.retiredAt } : {}),
     price: mergedPrice(
       curated.price,
       keepCuratedPrice

--- a/providers/openai.ts
+++ b/providers/openai.ts
@@ -86,6 +86,17 @@ export default {
       },
     },
     {
+      id: 'gpt-5.6',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search', 'image_generation'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
       id: 'gpt-5.5',
       price: {
         tokens: 1_000_000,

--- a/shared/types/providers.d.ts
+++ b/shared/types/providers.d.ts
@@ -19,6 +19,7 @@ export interface Model {
   maxOutputTokens: number
   releaseDate?: string
   status?: 'deprecated' | 'beta' | 'alpha'
+  retiredAt?: string
   price: {
     tokens: number
     input: string

--- a/tests/e2e/chat/scroll-spacer.spec.ts
+++ b/tests/e2e/chat/scroll-spacer.spec.ts
@@ -526,7 +526,7 @@ async function expectStableImageTurnPin(
   await openCase(page, url)
 
   await page.locator('[data-testid="current-model-trigger"]').click()
-  await page.getByRole('button', { name: 'Choose Nano Banana', exact: true })
+  await page.getByRole('button', { name: 'Choose Nano Banana 2', exact: true })
     .click()
   await page.locator('textarea').fill('A scottish fold cat by a fireplace')
   await page.getByRole('button', { name: 'Send Message' }).click()

--- a/tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger.research.spec.ts
@@ -86,11 +86,11 @@ describe('ChatInput/ModelsTrigger', () => {
       .trigger('click')
 
     expect(findModelButton(wrapper, 'GPT-5.4')).toBeTruthy()
-    expect(findModelButton(wrapper, 'Nano Banana')).toBeUndefined()
+    expect(findModelButton(wrapper, 'Gemini 2.5 Flash')).toBeUndefined()
 
     await wrapper.get('[data-testid="models-picker-rail-openai"]')
       .trigger('click')
 
-    expect(findModelButton(wrapper, 'Nano Banana')).toBeTruthy()
+    expect(findModelButton(wrapper, 'Gemini 2.5 Flash')).toBeTruthy()
   })
 })

--- a/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
+++ b/tests/unit/components/ChatInput/ModelsTrigger/ModelDetail.spec.ts
@@ -97,6 +97,58 @@ describe('ChatInput/ModelsTrigger/ModelDetail', () => {
     ).toBe(false)
   })
 
+  it('appends the scheduled shutdown date to the deprecation notice', async () => {
+    const wrapper = await mountDetail(createModel({
+      status: 'deprecated',
+      retiredAt: '2099-10-02',
+    }))
+    const notice = wrapper.get('[data-testid="model-detail-deprecated-notice"]')
+
+    expect(notice.text()).toContain(
+      'It is scheduled to shut down on October 2, 2099.',
+    )
+  })
+
+  it('uses past tense once the shutdown date has passed', async () => {
+    const wrapper = await mountDetail(createModel({
+      status: 'deprecated',
+      retiredAt: '2000-03-09',
+    }))
+    const notice = wrapper.get('[data-testid="model-detail-deprecated-notice"]')
+
+    expect(notice.text()).toContain('It was shut down on March 9, 2000.')
+    expect(notice.text()).not.toContain('scheduled to shut down')
+  })
+
+  it('shows an informational retire notice for a selectable model', async () => {
+    const wrapper = await mountDetail(createModel({
+      retiredAt: '2099-05-07',
+    }))
+
+    expect(
+      wrapper.find('[data-testid="model-detail-deprecated-notice"]').exists(),
+    ).toBe(false)
+    expect(wrapper.get('[data-testid="model-detail-retire-notice"]').text())
+      .toContain('Scheduled to retire on May 7, 2099.')
+  })
+
+  it('uses past tense in the retire notice once the date has passed', async () => {
+    const wrapper = await mountDetail(createModel({
+      retiredAt: '2000-05-07',
+    }))
+
+    expect(wrapper.get('[data-testid="model-detail-retire-notice"]').text())
+      .toContain('Retired on May 7, 2000.')
+  })
+
+  it('omits the retire notice when the model has no retirement date', async () => {
+    const wrapper = await mountDetail()
+
+    expect(
+      wrapper.find('[data-testid="model-detail-retire-notice"]').exists(),
+    ).toBe(false)
+  })
+
   it('flows inline instead of overlaying the model list', async () => {
     const wrapper = await mountDetail()
     const panel = wrapper.get('[data-testid="model-detail-panel"]')

--- a/tests/unit/providers/merge.spec.ts
+++ b/tests/unit/providers/merge.spec.ts
@@ -251,6 +251,64 @@ describe('mergeModelMetadata', () => {
     expect('status' in withoutStatus).toBe(false)
   })
 
+  it('passes curated retiredAt through both merge paths', () => {
+    const snapshotBacked = mergeModelMetadata(
+      {
+        ...chatModel,
+        retiredAt: '2027-05-07',
+      },
+      snapshotEntry,
+    )
+
+    expect(snapshotBacked.retiredAt).toBe('2027-05-07')
+
+    const fullyCurated = mergeModelMetadata(
+      {
+        ...chatModel,
+        name: 'Retired Legacy',
+        description: 'Curated after retirement',
+        contextLength: 200_000,
+        maxOutputTokens: 100_000,
+        status: 'deprecated',
+        retiredAt: '2026-03-09',
+        modalities: {
+          input: ['text'],
+          output: ['text'],
+        },
+      },
+      undefined,
+    )
+
+    expect(fullyCurated.retiredAt).toBe('2026-03-09')
+  })
+
+  it('omits retiredAt when curated sets none', () => {
+    const model = mergeModelMetadata(chatModel, snapshotEntry)
+
+    expect('retiredAt' in model).toBe(false)
+  })
+
+  it('lets a hand-set curated status outrank the fetched one', () => {
+    const model = mergeModelMetadata(
+      {
+        ...chatModel,
+        status: 'deprecated',
+      },
+      { ...snapshotEntry, status: 'beta' },
+    )
+
+    expect(model.status).toBe('deprecated')
+  })
+
+  it('still takes status from the snapshot when curated sets none', () => {
+    const model = mergeModelMetadata(
+      chatModel,
+      { ...snapshotEntry, status: 'alpha' },
+    )
+
+    expect(model.status).toBe('alpha')
+  })
+
   it('throws when a model has neither a snapshot entry nor full curation', () => {
     expect(() => mergeModelMetadata(chatModel, undefined))
       .toThrowError(/test-chat-model/)


### PR DESCRIPTION
## Summary

- **`retiredAt` — a curated-only retirement date** (hand-set from the provider's official deprecation page), merged through to `Model` and rendered in the model detail panel. models.dev carries no retirement data at all — it flags none of our curated models deprecated even when the provider officially schedules shutdown — so the curated half of the two-half catalog is where this knowledge lives.
- **Curated `status` now outranks the snapshot's** at merge time. Previously status came from the fetched snapshot only, which meant the owner could never outrank models.dev. The gemini-2.5 gap proved why that's wrong (see below).
- **New models:** `gemini-3.7-flash` (same-family successor of curated 3.6-flash, identical pricing $0.75/$3.75) and plain `gpt-5.6` (specs byte-identical to curated `gpt-5.6-sol`; kept for users who know the bare id).
- **Docs:** new "Retirement dates and how we learn about them" section in `docs/models-data-fetching.md` — the layered design, the semantics, and the Vertex-vs-AI-Studio case study.

## Semantics

- `status: 'deprecated'` = gate: legacy picker section + `useChatProvider()` server guard blocks sending with it (new and continued chats alike).
- `retiredAt` alone = informational countdown: the model stays selectable and the detail panel shows when it retires.

## Curated dates (from Google's official deprecations page, updated 2026-08-13)

| Model | Treatment | Date |
|---|---|---|
| `gemini-2.5-flash-image` (Nano Banana) | deprecated → legacy tab | shuts down **2026-10-02** |
| `gemini-3.1-flash-lite` | informational only, stays selectable | retires **2027-05-07** |
| `gemini-3-pro-preview` (already exempt-deprecated) | gains its passed shutdown date | shut down **2026-03-09** |

`gemini-2.5-pro`/`-flash`/`-flash-lite` are deliberately untouched: the **Gemini API (AI Studio) deprecations page announces no shutdown date for them** — the "Oct 16, 2026" date circulating is **Vertex AI**, a different product with different keys. Flipping them later is a one-line edit each.

## How we learn about retirements (the layered design)

1. **models.dev `status` tripwire** — automated, already wired: the weekly audit warns `⚠ DEPRECATED`, the snapshot refresh moves the model to the legacy tab. Catches OpenAI-style flags.
2. **Hand-curated `status` + `retiredAt`** — from the official provider deprecation pages (Gemini deprecations / OpenAI deprecations). The weekly cadence already forces a human look; those pages are the reading list. Curated status now wins at merge time, so the owner outranks models.dev.
3. **Rejected:** scheduled scraping of provider pages (fragile HTML churn) and API probing (the repo is 100% BYOK and holds no provider keys — documented stance).

## UI

- Deprecated notice gains the date with tense handling: *"It is scheduled to shut down on October 2, 2026."* / *"It was shut down on March 9, 2026."* (local-date comparison, deterministic month-name formatter — no locale drift).
- Non-deprecated models with a retire date get a neutral informational notice: *"Scheduled to retire on May 7, 2027."* (testid `model-detail-retire-notice`).

## Verification

- `pnpm run models:fetch` — 33 models, additions only (the two new entries), no other drift.
- Vitest: merge.spec (39), ModelDetail.spec (23), ModelsTrigger.spec, anthropic.spec — all pass; pre-push affected suites: 32 unit files (446 tests) + 10 integration files (105 tests) pass. One spec fixture updated: the picker rail test asserted "Nano Banana" is selectable after clearing the provider filter — invalidated by its deliberate move to the legacy section; now uses `Gemini 2.5 Flash`.
- `pnpm run format` (0 errors) + `pnpm run typecheck` (pass).
- Independent reviewer pass: merge precedence pinned by tests (curated-wins, snapshot-fallback, absence), dates verified against the deprecations page, new models resolve fully from the snapshot, no scope creep. One SHOULD-FIX (accidentally deleted merge-policy table row in docs) + three NITs — all fixed.

## Out of scope (by decision)

Never-curated deprecated models (gpt-4, gpt-4o, o1, o3-mini, …) stay out of the catalog; no EXEMPT_IDS changes (`gemini-2.5-flash-image` remains snapshot-backed while models.dev still lists it); no scraping automation; `claude-fable-5` not added (premium tier, 2× Opus 5 pricing — same call as gpt-5-pro).
