### PR TITLE
feat(models): add legacy Claude generations as selectable models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ stats.html
 !.pi/mcp.json
 .pi-subagents
 .herdr
+omp-session-*.html
 
 # Snyk Security Extension - AI Rules (auto-generated)
 .github/instructions/snyk_rules.instructions.md

--- a/docs/models-data-fetching.md
+++ b/docs/models-data-fetching.md
@@ -202,17 +202,21 @@ circulating for the gemini-2.5 text models is a Vertex AI date; the AI
 Studio page announces no shutdown date for them, so they stay untouched in
 the catalog.
 
-**Anthropic lineage** (checked 2026-08-25): the old Claude lineage
-(opus-4-5/4-6/4-7/4-8, sonnet-4-6, fable-5) stays out of the catalog.
-Anthropic's deprecations table lists all of them Active ("Deprecated:
-N/A"), so none can enter the legacy tab — Anthropic does date-retire
-models (Active → Legacy → Deprecated → Retired, ≥60 days notice), but
-these are not there yet. None is a value tier either: Opus 4.5–4.8 cost
-$5/$25, exactly what curated Opus 5 costs (and 4.7+ use a ~30%-heavier
-tokenizer and reject `temperature`/`top_p`/`top_k` with a 400 on
-non-default values, making them strictly worse picks); Sonnet 4.6 at
-$3/$15 is 50% pricier than curated Sonnet 5; fable-5 ($10/$50) is a
-premium tier already declined. Curated retirement
+**Anthropic lineage** (updated 2026-08-25): the previous Claude
+generations (opus-4-8/4-7/4-6/4-5, sonnet-4-6) are IN the catalog as
+normal selectable models. The catalog is BYOK access, not taste
+curation — the app is not the provider and does not decide what users
+use — and it already keeps old Gemini generations (3.1/3.5/3.6
+alongside 3.7), so the same principle now covers Anthropic too. All
+five are Active ("Deprecated: N/A") in Anthropic's deprecations
+table; when Anthropic actually deprecates any of them, it moves to
+the legacy tab via curated `status` + `retiredAt`, like
+`gemini-2.5-flash-image`. Excluded on purpose: fable-5 ($10/$50
+premium tier above Opus 5, owner declined), the dated-snapshot ids
+(`claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`), and the
+dateless `claude-sonnet-4-5` alias (not on the owner's add-list).
+No old haiku exists upstream — `claude-haiku-4-5` is the only haiku
+generation and is already curated. Curated retirement
 floors ("not sooner than"): opus-5 ≥ 2027-07-24, sonnet-5 ≥ 2027-06-30,
 haiku-4-5 (snapshot claude-haiku-4-5-20251001) ≥ 2026-10-15 — the
 closest watch item.
@@ -415,6 +419,10 @@ automatic add:
   briefly curated too (#367), then removed again as unnecessary
   duplication — the owner prefers the explicit Sol id — so bare
   `gpt-5.6` stays on this deliberately-not-curated list.
+- **`claude-fable-5`** — a premium tier above Opus 5 ($10/$50 vs the
+  $5/$25 Opus pricing); it would add another price tier to the picker,
+  and the owner declined.
+
 Two ids originally listed here on an earlier pass of this audit were
 subsequently added, not left out — corrected in a follow-up commit:
 

--- a/providers/anthropic.ts
+++ b/providers/anthropic.ts
@@ -16,7 +16,63 @@ export default {
       },
     },
     {
+      id: 'claude-opus-4-8',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
+      id: 'claude-opus-4-7',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
+      id: 'claude-opus-4-6',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
+      id: 'claude-opus-4-5',
+      name: 'Claude Opus 4.5',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
       id: 'claude-sonnet-5',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
+      id: 'claude-sonnet-4-6',
       price: {
         tokens: 1_000_000,
       },

--- a/providers/data/models-dev-snapshot.json
+++ b/providers/data/models-dev-snapshot.json
@@ -22,6 +22,98 @@
       "output": 25
     }
   },
+  "claude-opus-4-8": {
+    "name": "Claude Opus 4.8",
+    "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+    "releaseDate": "2026-05-28",
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 25
+    }
+  },
+  "claude-opus-4-7": {
+    "name": "Claude Opus 4.7",
+    "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
+    "releaseDate": "2026-04-14",
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 25
+    }
+  },
+  "claude-opus-4-6": {
+    "name": "Claude Opus 4.6",
+    "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
+    "releaseDate": "2026-02-04",
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 25
+    }
+  },
+  "claude-opus-4-5": {
+    "name": "Claude Opus 4.5 (latest)",
+    "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
+    "releaseDate": "2025-11-24",
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 5,
+      "output": 25
+    }
+  },
   "claude-sonnet-5": {
     "name": "Claude Sonnet 5",
     "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
@@ -43,6 +135,29 @@
     "cost": {
       "input": 2,
       "output": 10
+    }
+  },
+  "claude-sonnet-4-6": {
+    "name": "Claude Sonnet 4.6",
+    "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
+    "releaseDate": "2026-02-17",
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 3,
+      "output": 15
     }
   },
   "claude-haiku-4-5": {

--- a/tests/unit/providers/anthropic.spec.ts
+++ b/tests/unit/providers/anthropic.spec.ts
@@ -4,12 +4,17 @@ import snapshot from '../../../providers/data/models-dev-snapshot.json'
 
 const expectedModelIds = [
   'claude-opus-5',
+  'claude-opus-4-8',
+  'claude-opus-4-7',
+  'claude-opus-4-6',
+  'claude-opus-4-5',
   'claude-sonnet-5',
+  'claude-sonnet-4-6',
   'claude-haiku-4-5',
 ]
 
 describe('curated anthropic provider', () => {
-  it('curates exactly the three expected models', () => {
+  it('curates exactly the eight expected models', () => {
     const ids = anthropic.models.map(model => model.id)
 
     expect(anthropic.models).toHaveLength(expectedModelIds.length)


### PR DESCRIPTION
## Summary

Adds 5 legacy-generation Claude models as **normal selectable** entries: `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5`, `claude-sonnet-4-6`. The Anthropic provider goes from 3 to 8 models.

## Why

The catalog is BYOK access, not taste curation: the app is not the provider and doesn't decide what users should use — it offers what's available. It already keeps old Gemini generations (3.1/3.5/3.6 alongside 3.7); the same principle now covers Anthropic. All 5 models are **Active** per Anthropic's official deprecations table (checked 2026-08-25), so none enters the legacy tab — that stays reserved for deprecated/retiring models (`gemini-2.5-flash-image`, `gemini-3-pro-preview`, both unchanged). When Anthropic actually deprecates one of these, it moves to the legacy tab via curated `status` + `retiredAt` — the established pattern.

## Scope decisions (owner's)

- **Added:** the five non-dated models from the owner's list.
- **Excluded:** `claude-fable-5` (premium tier, declined); dated snapshot ids (`-20251101`/`-20250929`/`-20251001`); `claude-sonnet-4-5` (dateless alias, not on the add-list).
- **Old haiku:** none exists upstream — `haiku-4-5` is the only generation and is already curated (its dated variant is the same model, so adding it would be duplication).

## Details

- `providers/anthropic.ts` — 5 new entries structurally identical to the existing ones (per-Mtok pricing, web search, low/medium/high reasoning); one documented deviation: `claude-opus-4-5` carries a `name: 'Claude Opus 4.5'` override because models.dev's live name is "Claude Opus 4.5 (latest)" and the merge's no-alias-suffix invariant (pinned in merge.spec) requires the override.
- Snapshot refreshed: 32 → **37 models**; diff is exactly the 5 new entries (field-for-field against live models.dev, incl. opus-4-5's 200K context vs 1M on the others).
- `tests/unit/providers/anthropic.spec.ts` — 3 → 8 expected ids.
- `docs/models-data-fetching.md` — lineage paragraph rewritten around the BYOK access principle + Gemini precedent; `claude-fable-5` added to the deliberately-not-curated list; retirement floors kept (haiku-4-5 ≥ 2026-10-15 remains the closest watch item).

## Verification

- All 4 affected suites pass (61 tests: anthropic, merge, cost-map, audit). `pnpm run format` 0 errors, `pnpm run typecheck` pass.
- Independent reviewer pass: **zero findings** across seven areas — snapshot field-for-field vs live models.dev, real merge executed (all 8 resolve, no "(latest)" names, no stray status/retiredAt), legacy semantics untouched, docs truthful, no count-based UI assumptions, no hardcoded claude ids anywhere.
