### PR TITLE
feat(models): add Claude Sonnet 4.5 as a selectable model

### DIFF
--- a/docs/models-data-fetching.md
+++ b/docs/models-data-fetching.md
@@ -202,21 +202,25 @@ circulating for the gemini-2.5 text models is a Vertex AI date; the AI
 Studio page announces no shutdown date for them, so they stay untouched in
 the catalog.
 
-**Anthropic lineage** (updated 2026-08-25): the previous Claude
-generations (opus-4-8/4-7/4-6/4-5, sonnet-4-6) are IN the catalog as
+**Anthropic lineage** (updated 2026-08-26): the previous Claude
+generations (opus-4-8/4-7/4-6/4-5, sonnet-4-6/4-5) are IN the catalog as
 normal selectable models. The catalog is BYOK access, not taste
 curation — the app is not the provider and does not decide what users
 use — and it already keeps old Gemini generations (3.1/3.5/3.6
-alongside 3.7), so the same principle now covers Anthropic too. All
-five are Active ("Deprecated: N/A") in Anthropic's deprecations
-table; when Anthropic actually deprecates any of them, it moves to
-the legacy tab via curated `status` + `retiredAt`, like
-`gemini-2.5-flash-image`. Excluded on purpose: fable-5 ($10/$50
-premium tier above Opus 5, owner declined), the dated-snapshot ids
-(`claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`), and the
-dateless `claude-sonnet-4-5` alias (not on the owner's add-list).
-No old haiku exists upstream — `claude-haiku-4-5` is the only haiku
-generation and is already curated. Curated retirement
+alongside 3.7), so the same principle now covers Anthropic too: every
+active mainline chat generation upstream is offered. All six are
+Active ("Deprecated: N/A") in Anthropic's deprecations table; when
+Anthropic actually deprecates any of them, it moves to the legacy tab
+via curated `status` + `retiredAt`, like `gemini-2.5-flash-image`.
+Excluded on purpose: fable-5 ($10/$50 premium tier above Opus 5 —
+price overkill for a chat-only app, owner declined) and the
+dated-snapshot ids (`claude-opus-4-5-20251101`,
+`claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`), which are
+the same models as their dateless aliases. Older generations (Sonnet
+4, Haiku 4, Opus 4.1) are no longer listed on models.dev at all, so
+there is nothing to add or retire for them. `claude-opus-4-5` and
+`claude-sonnet-4-5` carry a curated `name` override because models.dev
+names those aliases with a "(latest)" suffix. Curated retirement
 floors ("not sooner than"): opus-5 ≥ 2027-07-24, sonnet-5 ≥ 2027-06-30,
 haiku-4-5 (snapshot claude-haiku-4-5-20251001) ≥ 2026-10-15 — the
 closest watch item.

--- a/providers/anthropic.ts
+++ b/providers/anthropic.ts
@@ -83,6 +83,18 @@ export default {
       },
     },
     {
+      id: 'claude-sonnet-4-5',
+      name: 'Claude Sonnet 4.5',
+      price: {
+        tokens: 1_000_000,
+      },
+      tools: ['web_search'],
+      reasoning: {
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+      },
+    },
+    {
       id: 'claude-haiku-4-5',
       name: 'Claude Haiku 4.5',
       price: {

--- a/providers/data/models-dev-snapshot.json
+++ b/providers/data/models-dev-snapshot.json
@@ -160,6 +160,29 @@
       "output": 15
     }
   },
+  "claude-sonnet-4-5": {
+    "name": "Claude Sonnet 4.5 (latest)",
+    "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
+    "releaseDate": "2025-09-29",
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    },
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "cost": {
+      "input": 3,
+      "output": 15
+    }
+  },
   "claude-haiku-4-5": {
     "name": "Claude Haiku 4.5 (latest)",
     "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",

--- a/tests/unit/providers/anthropic.spec.ts
+++ b/tests/unit/providers/anthropic.spec.ts
@@ -10,11 +10,12 @@ const expectedModelIds = [
   'claude-opus-4-5',
   'claude-sonnet-5',
   'claude-sonnet-4-6',
+  'claude-sonnet-4-5',
   'claude-haiku-4-5',
 ]
 
 describe('curated anthropic provider', () => {
-  it('curates exactly the eight expected models', () => {
+  it('curates exactly the nine expected models', () => {
     const ids = anthropic.models.map(model => model.id)
 
     expect(anthropic.models).toHaveLength(expectedModelIds.length)


### PR DESCRIPTION
## Summary

Adds `claude-sonnet-4-5` as a **normal selectable** model. The Anthropic provider goes from 8 to 9 models and the Sonnet lineage is now complete (5 / 4.6 / 4.5), matching how the Opus lineage (5 / 4.8 / 4.7 / 4.6 / 4.5) was completed in #370.

## Why

The catalog offers every active mainline chat generation upstream — the app is not the provider and doesn't decide what users should use. `claude-sonnet-4-5` is Active on Anthropic's deprecations table with no retirement date and priced at the standard Sonnet tier ($3/$15). It was left out of #370 only because it wasn't on the original add-list.

Checked while here: **Sonnet 4, Haiku 4 and Opus 4.1 are no longer listed on models.dev at all**, so there is nothing further to add (or to retire into the legacy tab). `claude-fable-5` stays excluded as a premium price tier.

## Changes

- `providers/anthropic.ts` — new entry after `claude-sonnet-4-6`, structurally identical, plus `name: 'Claude Sonnet 4.5'` (models.dev names the alias "Claude Sonnet 4.5 (latest)"; `merge.spec.ts` forbids that suffix reaching the UI)
- `providers/data/models-dev-snapshot.json` — refreshed via `pnpm run models:fetch` (37 → 38 models; only the new key added)
- `tests/unit/providers/anthropic.spec.ts` — 9 expected ids
- `docs/models-data-fetching.md` — Anthropic-lineage paragraph updated (six models, exclusions, no-older-generations note)

## Verification

- `pnpm run format && pnpm run typecheck` — clean
- `pnpm vitest run` on anthropic / merge / cost-map / audit-curated-models suites — 61/61
- Remaining uncurated Anthropic ids after this: `claude-fable-5` + three dated duplicates (all deliberate)
