### PR TITLE
fix: serve SSR HTML with private, no-store so Safari PWAs can't relaunch onto a stale shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,10 @@ The first bookmark whose timestamp predates the migration is **not necessarily s
   worker behavior, platform quirks (iOS/desktop), delivery troubleshooting
 - `docs/chats/shared-pwa-handoff.md` - Opening shared chats inside the
   installed PWA (push handoff + cold-start tap navigation)
+- `docs/pwa-safari-cache-headers.md` - Why SSR HTML documents get
+  `Cache-Control: private, no-store`: WebKit's cache-first Dock/home-screen
+  PWA launch policy, why `no-store` (not `no-cache`), the `render:response`
+  Nitro plugin vs. `routeRules`/`_headers` trade-off, and the bfcache caveat
 - `docs/deep-research.md` - Deep research: async provider-agent jobs
   (OpenAI Responses background mode, Google Interactions API), job store,
   finalize/cron sweep, UI, live-spike checklist

--- a/docs/pwa-safari-cache-headers.md
+++ b/docs/pwa-safari-cache-headers.md
@@ -1,0 +1,60 @@
+# Safari PWA cache headers on SSR documents
+
+## Symptom
+After a production deploy, the Dock web app (macOS Safari "Add to Dock")
+and iOS home-screen PWAs could relaunch onto a fully unstyled,
+unhydrated page. Chrome PWAs never showed this.
+
+## Root cause
+WebKit launches an installed web app on its start URL with a cache-first
+policy (`ReturnCacheDataElseLoad`): it reuses whatever document is
+already stored, regardless of freshness. Only `no-store` is guaranteed
+never to be stored — `no-cache`/`max-age=0` can still be replayed on
+launch. Chrome revalidates the launch navigation. Our SSR HTML had no
+`Cache-Control` at all; WebKit would store it, and a later deploy
+hard-deletes the previous build's hashed `/_nuxt/entry.<hash>.css|js`.
+Launching onto the stale shell 404s on those assets. The service worker
+isn't involved (`navigateFallback: null`, no `.html` precached).
+
+## Fix
+`server/plugins/ssr-html-no-store.ts`, a Nitro `render:response` hook,
+sets `Cache-Control: private, no-store` on any SSR document response
+without an existing `cache-control` header.
+
+## Why a plugin, not `routeRules`
+`cloudflare_module` writes every `routeRules[*].headers` into
+`.output/public/_headers`, applied by Workers Static Assets outside
+Nitro's specific-rule-wins merge — including to `/_nuxt/*`. A broad
+`/**` rule there risks the immutable long-lived asset headers. A
+`render:response` hook only touches the actual SSR response.
+
+## Why `/` (SWR) is skipped
+`/` is SWR-cached in production (`routeRules['/'].cache`, keyed by
+`buildId`); Nitro's cached-handler wrapper sets `event.context.cache`
+and overwrites `cache-control` itself regardless. The plugin's
+`eventContext.cache` guard isn't load-bearing there, but keeps the skip
+explicit and unit-testable.
+
+## bfcache trade-off
+WebKit refuses bfcache for HTTPS main documents served `no-store`. This
+doesn't affect in-app SPA routing (no new main-document fetch); only a
+full-page back/forward re-fetches instead of restoring.
+
+## Already-poisoned caches
+The header stops WebKit storing a *new* stale shell — it doesn't evict
+one already stored. A device that hit the bug before this fix may still
+need one manual reload, or clearing site data / reinstalling.
+
+## Considered and rejected
+- Rotated `/_nuxt/*` 404s are served `immutable, max-age=1y` too —
+  harmless once stale shells can't exist, only bites on a hash-revert.
+- `Pwa/Refresher.client.vue` dismissing on any wrapper click (lengthens
+  prompt-mode update skew): unrelated, follow-up material.
+- `features.inlineStyles: true`: `entry.css` is ~295 KB raw / ~42 KB
+  brotli per SSR response — too heavy to inline on every document.
+
+## Safari verification checklist
+1. Cold-launch the Dock app (fully quit first).
+2. Web Inspector → Network on the launch load.
+3. The start-URL document response has `cache-control: private, no-store`.
+4. `.css` rows return `200`, not `404`.

--- a/scripts/test-affected-check.mjs
+++ b/scripts/test-affected-check.mjs
@@ -422,6 +422,10 @@ export function getAffectedTests(changedFiles) {
       tests: landingTests,
     },
     {
+      pattern: /^server\/plugins\/ssr-html-no-store\.ts$/,
+      tests: ['tests/integration/server/ssr-html-no-store-plugin.spec.ts'],
+    },
+    {
       pattern: /^server\/middleware\/evlog-auth\.ts$/,
       tests: ['tests/integration/api/stats.spec.ts'],
     },

--- a/server/plugins/ssr-html-no-store.ts
+++ b/server/plugins/ssr-html-no-store.ts
@@ -1,0 +1,33 @@
+import type { RenderContext, RenderResponse } from 'nitropack/types'
+
+interface CacheAwareContext {
+  cache?: unknown
+}
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('render:response', (response, context) => {
+    applyNoStoreHeader(response, context)
+  })
+})
+
+export function applyNoStoreHeader(
+  response: Partial<RenderResponse>,
+  context: RenderContext,
+): void {
+  const eventContext = context.event.context as CacheAwareContext
+
+  if (eventContext.cache) {
+    return
+  }
+
+  const headers = response.headers || {}
+  const hasCacheControl = Object.keys(headers).some((name) => {
+    return name.toLowerCase() === 'cache-control'
+  })
+
+  if (hasCacheControl) {
+    return
+  }
+
+  response.headers = { ...headers, 'cache-control': 'private, no-store' }
+}

--- a/tests/integration/server/ssr-html-no-store-plugin.spec.ts
+++ b/tests/integration/server/ssr-html-no-store-plugin.spec.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+beforeAll(() => {
+  vi.stubGlobal('defineNitroPlugin', (plugin: unknown) => plugin)
+})
+
+describe('ssr html no-store plugin', () => {
+  it('sets private, no-store when the response has no cache-control',
+    async () => {
+      const { applyNoStoreHeader } = await import(
+        '../../../server/plugins/ssr-html-no-store'
+      )
+
+      const response = { headers: { 'content-type': 'text/html' } }
+      const context = { event: { context: {} } }
+
+      applyNoStoreHeader(response as never, context as never)
+
+      expect(response.headers).toEqual({
+        'content-type': 'text/html',
+        'cache-control': 'private, no-store',
+      })
+    })
+
+  it('leaves an existing cache-control untouched', async () => {
+    const { applyNoStoreHeader } = await import(
+      '../../../server/plugins/ssr-html-no-store'
+    )
+
+    const response = { headers: { 'cache-control': 's-maxage=3600' } }
+    const context = { event: { context: {} } }
+
+    applyNoStoreHeader(response as never, context as never)
+
+    expect(response.headers).toEqual({ 'cache-control': 's-maxage=3600' })
+  })
+
+  it('treats cache-control case-insensitively', async () => {
+    const { applyNoStoreHeader } = await import(
+      '../../../server/plugins/ssr-html-no-store'
+    )
+
+    const response = { headers: { 'Cache-Control': 's-maxage=3600' } }
+    const context = { event: { context: {} } }
+
+    applyNoStoreHeader(response as never, context as never)
+
+    expect(response.headers).toEqual({ 'Cache-Control': 's-maxage=3600' })
+  })
+
+  it('skips cached routes', async () => {
+    const { applyNoStoreHeader } = await import(
+      '../../../server/plugins/ssr-html-no-store'
+    )
+
+    const response = { headers: { 'content-type': 'text/html' } }
+    const context = { event: { context: { cache: { options: {} } } } }
+
+    applyNoStoreHeader(response as never, context as never)
+
+    expect(response.headers['cache-control']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

The macOS Safari Dock web app (and iOS home-screen PWAs) rendered a fully unstyled, unhydrated page on cold launch until a manual reload. The Chrome PWA never showed it.

## Root cause

SSR documents were served with **no `Cache-Control` at all** (verified: `/signin` has no `cache-control`/`last-modified`/`etag`; `/` only has the SWR `s-maxage`, which browsers ignore).

WebKit launches installed web apps on their start URL with a cache-first load policy (`ReturnCacheDataElseLoad`) that reuses a stored document **regardless of freshness**. Only `no-store` responses are never stored — `no-cache` entries are still replayed under that policy. Every production deploy hard-deletes the previous build's hashed `/_nuxt/entry.<hash>.css|js` (the 404 is even served `immutable, max-age=1y`), so the replayed shell loads zero CSS and never hydrates. Chrome revalidates the launch navigation, so it never sees the stale shell.

The service worker is not involved: `navigateFallback: null` and zero `.html` entries in the live `sw.js` precache. A "Safari CORS cache-key collision on `<link crossorigin>`" theory was investigated and rejected — every cited WebKit bug concerns cross-origin resources; same-origin CORS-mode requests produce `basic` responses with no CORS check.

## Fix

`server/plugins/ssr-html-no-store.ts` — a Nitro `render:response` hook (fires only inside `defineRenderHandler`, i.e. Nuxt's SSR HTML renderer) sets `Cache-Control: private, no-store` on document responses that carry no `cache-control`, skipping requests where `event.context.cache` is set (Nitro's `defineCachedEventHandler` marks the SWR-cached `/` that way, and its wrapper overwrites `cache-control` afterwards regardless).

### Alternatives rejected

- **`routeRules` headers** — the `cloudflare_module` preset writes every `routeRules[*].headers` into `.output/public/_headers`, which Workers Static Assets apply to `/_nuxt/*` outside Nitro's specific-rule-wins merge. A `/**` rule there risks the immutable asset headers.
- **`features.inlineStyles: true`** — `entry.css` is ~295 KB raw / 42 KB brotli per SSR response.
- **Fixing the `immutable` 404s for rotated assets** — harmless once stale shells can't exist; only bites on a hash-reverting revert.

### Known non-fix (follow-up material)

`Pwa/Refresher.client.vue` dismisses on any click of the wrapper, which lengthens prompt-mode update skew. Out of scope here.

## Trade-offs

- WebKit refuses back/forward cache for HTTPS `no-store` main documents. In-app SPA routing never re-fetches the document, so this only affects full-page back/forward.
- `/shared/**` and legal pages also get `no-store`; crawlers fetch fresh regardless, no indexability impact.
- **`no-store` does not evict an already-stored stale shell.** A device that already hit the bug may need one manual reload (or clearing besidka.com site data / reinstalling the Dock app) after this deploys. The fix prevents recurrence.

## Verification

- `pnpm run format && pnpm run typecheck` — clean
- `pnpm vitest run tests/integration/server/ssr-html-no-store-plugin.spec.ts` — 4/4
- `pnpm run build` — `.output/public/_headers` unchanged (no `no-store`, `/_nuxt/*` still `immutable`); plugin present in the server bundle
- `wrangler dev` against the build (sole process on the port): `/signin` → `private, no-store`; `/` → `s-maxage=3600, stale-while-revalidate` (SWR intact); `/_nuxt/*.css` → `public, max-age=31536000, immutable`

### Manual check after deploy (Safari Dock app)

1. Fully quit and cold-launch the app — it should render styled without a reload (a device that was already poisoned may need one reload first).
2. Web Inspector → Network → the `/chats/new` document response shows `cache-control: private, no-store`; `.css` rows are `200`.

Docs: `docs/pwa-safari-cache-headers.md`.
