### PR TITLE
fix: keep public pages bfcache-eligible with no-cache instead of no-store

### DIFF
--- a/docs/pwa-safari-dock-app-launch.md
+++ b/docs/pwa-safari-dock-app-launch.md
@@ -167,3 +167,51 @@ and `sessionStorage.getItem('nuxt:reload')`.
    unchanged SWR `cache-control`.
 4. `curl -s /_nuxt/builds/latest.json` reflects the new id; requesting
    `/_nuxt/builds/meta/<new>.json` succeeds.
+
+### Public pages get `no-cache`, not `no-store`
+WebKit refuses bfcache for any HTTPS main document served
+`Cache-Control: no-store`, so Safari back/forward on these pages re-fetches
+instead of restoring instantly. `/privacy-policy`, `/terms-of-use`,
+`/cookie-policy` and `/shared/<publicId>` are not the app shell and carry no
+per-user state, so the stale-restore concern above doesn't apply to them —
+`server/plugins/ssr-html-no-store.ts` gives them `no-cache` instead (stored,
+revalidated on normal navigation, same effective network behaviour since
+they carry no validators, but bfcache-eligible). The build-freshness plugin
+(Bug 2 fix, above) still runs unconditionally on every route including
+these, so a stale bfcache restore still gets caught and reloaded. `/` is
+unaffected either way — it already has its own SWR `cache-control` from
+`nuxt.config.ts`'s `routeRules`, so this plugin's early-return on an
+existing header skips it entirely. Under `no-cache`, a revoked share on
+`/shared/**` may still be restored once from that device's bfcache until
+the next reload — identical to pre-#372 behaviour and to bfcache anywhere,
+and accepted deliberately.
+
+## Deliberately not done: caching through the service worker
+
+Investigated and rejected. Re-litigate with new evidence, not by assuming it
+was overlooked.
+
+- **A `fetch` listener for caching, at all.** The worker stays push-only on
+  purpose (Bug 1, above). Do not add one without re-reading this section.
+- **Why it's all-or-nothing.** Once any `fetch` listener exists, every
+  in-scope request dispatches to the worker and pays worker start-up on the
+  critical path — the exact property PR #373 removed. There is no
+  "cache only `/api/v1/chats`" variant.
+- **File downloads.** `server/routes/files/[key].get.ts` serves
+  `private, no-store, max-age=0` on purpose — share revocation must stop
+  retrieval, and a CacheStorage copy would outlive revocation on-device.
+  Anti-recommended, not just unnecessary.
+- **Chat history / model list instant paint.** That's a client-cache
+  problem, not a worker one: `useFetch` + `getCachedData` (already used for
+  the landing GitHub-stars badge) or a last-known list in IndexedDB rendered
+  optimistically then revalidated. Same perceived speed, no worker in the
+  path, testable in the existing harness, sign-out cleanup is ordinary app
+  code. A worker cache of an authenticated API response also creates a
+  logout-purge obligation that's easy to forget.
+- **WebKit risk is unquantified for this path.** The first-load defect (Bug
+  1) is proven for stylesheets via `respondWith` in a fresh Web App process
+  and untested for `fetch()` JSON through the same code path. Any future
+  worker-caching proposal carries that unknown and must go through the
+  preview-Dock-app protocol (Web Inspector checklist, above) before merge.
+- **What would change this.** Offline reading of past chats as a product
+  goal, or richer push/background behaviour that needs the worker anyway.

--- a/server/plugins/ssr-html-no-store.ts
+++ b/server/plugins/ssr-html-no-store.ts
@@ -4,13 +4,24 @@ interface CacheAwareContext {
   cache?: unknown
 }
 
+const BFCACHE_ELIGIBLE_EXACT_PATHS = new Set([
+  '/privacy-policy',
+  '/privacy-policy/',
+  '/terms-of-use',
+  '/terms-of-use/',
+  '/cookie-policy',
+  '/cookie-policy/',
+])
+
+const BFCACHE_ELIGIBLE_PREFIX = '/shared/'
+
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('render:response', (response, context) => {
-    applyNoStoreHeader(response, context)
+    applyDocumentCacheControl(response, context)
   })
 })
 
-export function applyNoStoreHeader(
+export function applyDocumentCacheControl(
   response: Partial<RenderResponse>,
   context: RenderContext,
 ): void {
@@ -29,5 +40,11 @@ export function applyNoStoreHeader(
     return
   }
 
-  response.headers = { ...headers, 'cache-control': 'private, no-store' }
+  const path = context.event.path.split('?')[0]
+  const isBfcacheEligible = BFCACHE_ELIGIBLE_EXACT_PATHS.has(path)
+    || path.startsWith(BFCACHE_ELIGIBLE_PREFIX)
+
+  const cacheControl = isBfcacheEligible ? 'no-cache' : 'private, no-store'
+
+  response.headers = { ...headers, 'cache-control': cacheControl }
 }

--- a/tests/integration/server/ssr-html-no-store-plugin.spec.ts
+++ b/tests/integration/server/ssr-html-no-store-plugin.spec.ts
@@ -7,14 +7,14 @@ beforeAll(() => {
 describe('ssr html no-store plugin', () => {
   it('sets private, no-store when the response has no cache-control',
     async () => {
-      const { applyNoStoreHeader } = await import(
+      const { applyDocumentCacheControl } = await import(
         '../../../server/plugins/ssr-html-no-store'
       )
 
       const response = { headers: { 'content-type': 'text/html' } }
-      const context = { event: { context: {} } }
+      const context = { event: { path: '/signin', context: {} } }
 
-      applyNoStoreHeader(response as never, context as never)
+      applyDocumentCacheControl(response as never, context as never)
 
       expect(response.headers).toEqual({
         'content-type': 'text/html',
@@ -23,41 +23,138 @@ describe('ssr html no-store plugin', () => {
     })
 
   it('leaves an existing cache-control untouched', async () => {
-    const { applyNoStoreHeader } = await import(
+    const { applyDocumentCacheControl } = await import(
       '../../../server/plugins/ssr-html-no-store'
     )
 
     const response = { headers: { 'cache-control': 's-maxage=3600' } }
-    const context = { event: { context: {} } }
+    const context = { event: { path: '/signin', context: {} } }
 
-    applyNoStoreHeader(response as never, context as never)
+    applyDocumentCacheControl(response as never, context as never)
 
     expect(response.headers).toEqual({ 'cache-control': 's-maxage=3600' })
   })
 
   it('treats cache-control case-insensitively', async () => {
-    const { applyNoStoreHeader } = await import(
+    const { applyDocumentCacheControl } = await import(
       '../../../server/plugins/ssr-html-no-store'
     )
 
     const response = { headers: { 'Cache-Control': 's-maxage=3600' } }
-    const context = { event: { context: {} } }
+    const context = { event: { path: '/signin', context: {} } }
 
-    applyNoStoreHeader(response as never, context as never)
+    applyDocumentCacheControl(response as never, context as never)
 
     expect(response.headers).toEqual({ 'Cache-Control': 's-maxage=3600' })
   })
 
   it('skips cached routes', async () => {
-    const { applyNoStoreHeader } = await import(
+    const { applyDocumentCacheControl } = await import(
       '../../../server/plugins/ssr-html-no-store'
     )
 
     const response = { headers: { 'content-type': 'text/html' } }
-    const context = { event: { context: { cache: { options: {} } } } }
+    const context = {
+      event: { path: '/', context: { cache: { options: {} } } },
+    }
 
-    applyNoStoreHeader(response as never, context as never)
+    applyDocumentCacheControl(response as never, context as never)
 
     expect(response.headers['cache-control']).toBeUndefined()
   })
+
+  it('sets no-cache for the privacy policy page', async () => {
+    const { applyDocumentCacheControl } = await import(
+      '../../../server/plugins/ssr-html-no-store'
+    )
+
+    const response = { headers: { 'content-type': 'text/html' } }
+    const context = { event: { path: '/privacy-policy', context: {} } }
+
+    applyDocumentCacheControl(response as never, context as never)
+
+    expect(response.headers['cache-control']).toBe('no-cache')
+  })
+
+  it('sets no-cache for the terms page with a trailing slash',
+    async () => {
+      const { applyDocumentCacheControl } = await import(
+        '../../../server/plugins/ssr-html-no-store'
+      )
+
+      const response = { headers: { 'content-type': 'text/html' } }
+      const context = { event: { path: '/terms-of-use/', context: {} } }
+
+      applyDocumentCacheControl(response as never, context as never)
+
+      expect(response.headers['cache-control']).toBe('no-cache')
+    })
+
+  it('sets no-cache for the cookie policy page with a query string',
+    async () => {
+      const { applyDocumentCacheControl } = await import(
+        '../../../server/plugins/ssr-html-no-store'
+      )
+
+      const response = { headers: { 'content-type': 'text/html' } }
+      const context = { event: { path: '/cookie-policy?x=1', context: {} } }
+
+      applyDocumentCacheControl(response as never, context as never)
+
+      expect(response.headers['cache-control']).toBe('no-cache')
+    })
+
+  it('sets no-cache for a shared chat page', async () => {
+    const { applyDocumentCacheControl } = await import(
+      '../../../server/plugins/ssr-html-no-store'
+    )
+
+    const response = { headers: { 'content-type': 'text/html' } }
+    const context = { event: { path: '/shared/abc123', context: {} } }
+
+    applyDocumentCacheControl(response as never, context as never)
+
+    expect(response.headers['cache-control']).toBe('no-cache')
+  })
+
+  it('sets private, no-store for a path that only looks shared-like',
+    async () => {
+      const { applyDocumentCacheControl } = await import(
+        '../../../server/plugins/ssr-html-no-store'
+      )
+
+      const response = { headers: { 'content-type': 'text/html' } }
+      const context = { event: { path: '/sharedx', context: {} } }
+
+      applyDocumentCacheControl(response as never, context as never)
+
+      expect(response.headers['cache-control']).toBe('private, no-store')
+    })
+
+  it('sets private, no-store for other app routes', async () => {
+    const { applyDocumentCacheControl } = await import(
+      '../../../server/plugins/ssr-html-no-store'
+    )
+
+    const response = { headers: { 'content-type': 'text/html' } }
+    const context = { event: { path: '/chats/new', context: {} } }
+
+    applyDocumentCacheControl(response as never, context as never)
+
+    expect(response.headers['cache-control']).toBe('private, no-store')
+  })
+
+  it('sets private, no-store for /shared with no trailing segment',
+    async () => {
+      const { applyDocumentCacheControl } = await import(
+        '../../../server/plugins/ssr-html-no-store'
+      )
+
+      const response = { headers: { 'content-type': 'text/html' } }
+      const context = { event: { path: '/shared', context: {} } }
+
+      applyDocumentCacheControl(response as never, context as never)
+
+      expect(response.headers['cache-control']).toBe('private, no-store')
+    })
 })


### PR DESCRIPTION
## Why

WebKit refuses the back/forward cache for HTTPS main documents served `Cache-Control: no-store`. Since PR #372 every SSR document carries it, so Safari re-fetched the legal pages and shared chats on back/forward instead of restoring them instantly. This was the only measurable performance cost of the three Dock-app PRs (#372, #373, #374).

## Change

`server/plugins/ssr-html-no-store.ts` now distinguishes:

| Path | `Cache-Control` |
|---|---|
| `/privacy-policy`, `/terms-of-use`, `/cookie-policy` (with or without trailing slash), `/shared/**` | `no-cache` — stored but revalidated on normal navigation (same network behaviour as always; no validators), **bfcache-eligible** |
| every other SSR document | `private, no-store` (unchanged) |
| `/` | SWR header from route rules (unchanged, untouched by the hook) |

These public pages are not the app shell the Dock web app restores and are not personalised, so the stale-restore concern behind `no-store` doesn't apply. The build-freshness plugin (#374) still runs on them.

**Accepted trade-off:** a revoked share on `/shared/**` may be restored once from a device's bfcache until the next reload — identical to pre-#372 behaviour and to bfcache anywhere.

## Docs

`docs/pwa-safari-dock-app-launch.md`:
- the `no-cache` exemption and its rationale;
- a new **"Deliberately not done: caching through the service worker"** section (following `docs/seo.md`'s rejected-options convention): a `fetch` listener is all-or-nothing (reinstates worker start-up on every request — what #373 removed); file downloads are `no-store` on purpose for share revocation; instant history/model-list paint is a client-cache problem (`useFetch` + `getCachedData` / IndexedDB), not a worker one; the WebKit first-load defect is untested for `fetch()` JSON; what would change the answer (offline reading as a product goal).

## Verification

- `pnpm run format && pnpm run typecheck` — clean
- `tests/integration/server/ssr-html-no-store-plugin.spec.ts` — 11/11 (exact legal paths ± slash, query string stripped, `/shared/abc`, negatives `/sharedx`, `/shared`, `/chats/new`, cached-route skip, existing-header skip)
- After deploy: `curl -sI https://besidka.com/privacy-policy | grep -i cache-control` → `no-cache`; `/signin` → `private, no-store`; `/` → SWR unchanged.
