### PR TITLE
fix(ci): promote the newest PR version to preview, not the oldest

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -389,9 +389,11 @@ jobs:
           # A PR pushed more than once uploads multiple versions tagged
           # with the same alias; sort by creation time and take the
           # newest, since a merged PR must promote its latest commit.
+          # A missing created_on sorts first (oldest), never last, so it
+          # can never be mistaken for the newest version.
           VERSION_ID=$(echo "$VERSIONS_JSON" | jq -r --arg alias "pr-${PR_NUMBER}" '
             [ .[] | select(.annotations."workers/alias" == $alias) ]
-            | sort_by(.metadata.created_on)
+            | sort_by(.metadata.created_on // "")
             | last
             | .id // empty
           ')

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -386,11 +386,15 @@ jobs:
             exit 1
           }
 
+          # A PR pushed more than once uploads multiple versions tagged
+          # with the same alias; sort by creation time and take the
+          # newest, since a merged PR must promote its latest commit.
           VERSION_ID=$(echo "$VERSIONS_JSON" | jq -r --arg alias "pr-${PR_NUMBER}" '
-            .[]
-            | select(.annotations."workers/alias" == $alias)
-            | .id
-          ' | head -n 1)
+            [ .[] | select(.annotations."workers/alias" == $alias) ]
+            | sort_by(.metadata.created_on)
+            | last
+            | .id // empty
+          ')
 
           if [ -z "$VERSION_ID" ]; then
             echo "No version found with alias pr-${PR_NUMBER}"


### PR DESCRIPTION
## Summary
- `production.yml`'s "Find version for PR" step matches all Cloudflare worker versions tagged with a PR's `pr-<number>` alias and picks one with `head -n 1`. `wrangler versions list --json` returns results **oldest-first**, so for any PR pushed more than once, this silently promoted the *first* build's version to `besidka-preview` on merge — ignoring every later commit's changes for that promotion step.
- Production itself was unaffected: `build-production` always does a fresh build from the merge commit rather than reusing a versioned artifact.
- Caught live on PR #377: a `NUXT_MESSAGE_SEARCH_SWEEP_BATCH_SIZE` bump added in a later commit never took effect on `besidka-preview` after merge — the promoted version predated it — even though CI was green and production got the right build. Had to manually re-promote the correct version (`wrangler versions deploy --version-id ... --name besidka-preview`) to fix preview after the fact.
- Fix: explicitly sort matching versions by `metadata.created_on` and take the last one, instead of depending on the API's undocumented list order.

## Test plan
- [x] Verified the new `jq` filter against real production `wrangler versions list --json` output (10 versions across 3 PRs, including PR #377's 3 pushes) — correctly returns the newest of 3 same-alias versions, still returns the single match when only one exists, and returns empty for no match
- [x] `actionlint .github/workflows/production.yml` — no new findings introduced (pre-existing shellcheck/runner-label notices elsewhere in the file are unrelated to this change)
- N/A: no application code changed, so no unit/integration tests are affected